### PR TITLE
feat: enable GitHub Actions CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,98 @@
+name: CI
+on:
+  pull_request:
+    branches: [ main ]
+  push:
+    branches: [ main ]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Test Python ${{ matrix.python-version }} on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-15-intel, windows-latest]
+        #os: [ubuntu-latest, macos-latest]
+        # python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10"]
+
+    steps:
+    - uses: actions/checkout@v4
+      name: Checkout code
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@v2
+      with:
+        version: "latest"
+
+    - name: Set up Python ${{ matrix.python-version }}
+      run: uv python install ${{ matrix.python-version }}
+
+    - name: Install dependencies
+      run: uv sync --all-extras --python ${{ matrix.python-version }}
+
+    - name: Run ruff lint
+      run: uv run --python ${{ matrix.python-version }} ruff check src/ 
+
+    - name: Run type checking with mypy
+      run: uv run --python ${{ matrix.python-version }} mypy src/llm4ad/
+
+    - name: Run tests with coverage
+      run: uv run --python ${{ matrix.python-version }} pytest tests/ -m unit --cov=src/llm4ad --cov-report=xml --cov-report=term
+
+    - name: Upload coverage report
+      uses: actions/upload-artifact@v4
+      with:
+        name: coverage-report-${{ matrix.os }}-${{ matrix.python-version }}
+        path: coverage.xml
+      if: success()
+
+  coverage:
+    name: Code Coverage
+    runs-on: ubuntu-latest
+    needs: test
+    if: github.event_name == 'pull_request'
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Download coverage reports
+      uses: actions/download-artifact@v4
+      with:
+        pattern: coverage-report-*
+        merge-multiple: true
+
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v4
+      with:
+        file: ./coverage.xml
+        fail_ci_if_error: false
+        token: ${{ secrets.CODECOV_TOKEN }}
+
+  e2e:
+    name: E2E Tests (Sorting Benchmark)
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+      name: Checkout code
+
+    - name: Install system dependencies
+      run: sudo apt-get update && sudo apt-get install -y g++
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@v2
+      with:
+        version: "latest"
+
+    - name: Set up Python
+      run: uv python install 3.12
+
+    - name: Install dependencies
+      run: uv sync --all-extras --python 3.12
+
+    - name: Run e2e tests
+      run: uv run --python 3.12 pytest tests/e2e/ -m e2e -v

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -220,6 +220,7 @@ markers = [
     "unit: Unit tests",
     "integration: Integration tests",
     "slow: Slow tests",
+    "e2e: End-to-end tests",
 ]
 
 [tool.coverage.run]


### PR DESCRIPTION
1. Add .github/workflows/ci.yml with test, coverage, and e2e jobs across Ubuntu, macOS, and Windows
2. Add concurrency group so older CI runs cancel when a PR is repushed
3. Register the e2e pytest marker in pyproject.toml to avoid unknown-marker warnings