### PR TITLE
fix: correct pypi name for python-mip in builder cheat sheet

### DIFF
--- a/src/llm4ad/builder/prompts.py
+++ b/src/llm4ad/builder/prompts.py
@@ -1149,9 +1149,9 @@ spare package (small) is much lower than the cost of a mid-run pip install.
 
 ### Cheat sheet by problem_type
 - `combinatorial_optimization`: numpy, scipy, networkx, ortools, pulp,
-  python-mip, numba
+  mip, numba
 - `sorting`: numpy
-- `scheduling`: numpy, scipy, networkx, ortools, pandas, python-mip
+- `scheduling`: numpy, scipy, networkx, ortools, pandas, mip
 - `ml`: numpy, pandas, scikit-learn, scipy, matplotlib, joblib
 - `rl`: numpy, scipy, gymnasium, torch, matplotlib, stable-baselines3
 - `regression`: numpy, pandas, scikit-learn, scipy, statsmodels, matplotlib


### PR DESCRIPTION
1. python-mip publishes to pypi under the name `mip`; `pip install python-mip` does not resolve to the coin-or package
2. update the combinatorial_optimization and scheduling cheat sheet entries in builder prompts to use `mip`