### PR TITLE
fix: 无需手动配置evaluator api

### DIFF
--- a/examples/applications/relationship_prediction/config.yaml
+++ b/examples/applications/relationship_prediction/config.yaml
@@ -156,8 +156,7 @@ planner:
 evaluator:
   # --- Evaluator Type ---
   type: "custom"
-
-  # Custom evaluator module path
+  provider: "default"
   module: "relationship_evaluator.py:RelationshipOutcomeEvaluator"
 
   # --- Execution Settings ---

--- a/examples/applications/relationship_prediction/config.yaml
+++ b/examples/applications/relationship_prediction/config.yaml
@@ -166,13 +166,6 @@ evaluator:
   parallel: true
   batch_size: 2
 
-  # --- Evaluator-specific API config ---
-  api_config:
-    base_url: ${LLM_BASE_URL}
-    api_key: ${LLM_API_KEY}
-    model: ${LLM_MODEL}
-  
-
   # --- Dataset Configuration ---
   dataset:
     mode: "directory"

--- a/examples/applications/relationship_prediction/relationship_evaluator.py
+++ b/examples/applications/relationship_prediction/relationship_evaluator.py
@@ -91,12 +91,12 @@ class RelationshipOutcomeEvaluator(LLMJudgeEvaluator):
             "- **40-54分：** 行为描述模糊，缺少具体场景。\n"
             "- **40分以下：** 全是抽象描述，没有画面感。\n\n---\n\n"
             "## 输出格式\n\n返回纯JSON，不要其他内容：\n"
-            "{{\n"
+            '{\n'
             '"outcome_plausibility": N,\n'
             '"alternative_reasoning": N,\n'
             '"trait_specificity": N,\n'
             '"causal_chain": N,\n'
             '"behavioral_concreteness": N,\n'
             '"reasoning": "2-3句评价，指出预测在结局选择上最强和最弱的地方"\n'
-            "}}"
+            '}'
         )

--- a/src/llm4ad/config/evaluator.py
+++ b/src/llm4ad/config/evaluator.py
@@ -182,6 +182,16 @@ class CustomEvaluatorConfig(EvaluatorConfig):
             desc_en="Evaluator type identifier, fixed to custom",
         ),
     )
+    provider: str = Field(
+        default="default",
+        description="Name of the LLM provider to use for evaluation",
+        json_schema_extra=ui(
+            hidden=True,
+            label_zh="LLM 提供者", label_en="Provider",
+            desc_zh="用于评估阶段的 LLM 提供者名称，需在 providers 列表中预先配置",
+            desc_en="Name of the LLM provider for evaluation; must be defined in the providers list",
+        ),
+    )
     module: str = Field(
         default="", description="Module path for custom evaluator (format: module.path:ClassName)",
         json_schema_extra=ui(

--- a/src/llm4ad/evaluator/dispatcher.py
+++ b/src/llm4ad/evaluator/dispatcher.py
@@ -47,6 +47,7 @@ class EvaluationDispatcher:
         config: EvaluatorConfig,
         behavior_storage: str = "rendered",
         config_dir: str | None = None,
+        provider_config: Any = None,
     ):
         """Initialize the dispatcher with an evaluator instance.
 
@@ -61,12 +62,16 @@ class EvaluationDispatcher:
                 evaluator module specs and dataset configs are resolved
                 against this directory instead of the current working
                 directory.
+            provider_config: Resolved provider configuration for custom
+                evaluators that need LLM access. Passed through to the
+                evaluator constructor.
         """
         self.config: EvaluatorConfig = config
         self._parallel = config.parallel
         self._batch_size = config.batch_size
         self._behavior_storage = behavior_storage
         self._config_dir = config_dir
+        self._provider_config = provider_config
 
         # Concurrency limit for parallel evaluation subprocesses
         effective_workers = config.batch_size or os.cpu_count() or 4
@@ -158,8 +163,8 @@ class EvaluationDispatcher:
 
         Built-in evaluators always receive the config.  For custom
         evaluators, we inspect the constructor: if it accepts a
-        parameter beyond ``self``, the config is passed so the
-        evaluator can access extra YAML fields (e.g. ``api_config``).
+        parameter beyond ``self``, the config and provider_config
+        are passed so the evaluator can access LLM credentials.
         Legacy evaluators with ``def __init__(self):`` keep working.
 
         Returns:
@@ -169,9 +174,12 @@ class EvaluationDispatcher:
             import inspect
 
             sig = inspect.signature(self._eval_cls.__init__)
-            # More than just 'self' means the constructor accepts config
-            if len(sig.parameters) > 1:
-                return self._eval_cls(self.config)
+            params = list(sig.parameters.keys())
+            if len(params) > 1:
+                kwargs: dict[str, Any] = {"config": self.config}
+                if "provider_config" in params and self._provider_config is not None:
+                    kwargs["provider_config"] = self._provider_config
+                return self._eval_cls(**kwargs)
             return self._eval_cls()
         return self._eval_cls(self.config)
 

--- a/src/llm4ad/evaluator/llm_judge.py
+++ b/src/llm4ad/evaluator/llm_judge.py
@@ -185,7 +185,19 @@ class LLMJudgeEvaluator(BaseEvaluator):
         if json_start == -1 or json_end == 0:
             raise ValueError("No JSON object found in judge response")
 
-        data = json.loads(response[json_start:json_end])
+        raw = response[json_start:json_end]
+        try:
+            data = json.loads(raw)
+        except json.JSONDecodeError:
+            import re as _re
+
+            cleaned = raw
+            cleaned = _re.sub(r"//[^\n]*", "", cleaned)
+            cleaned = _re.sub(r",\s*}", "}", cleaned)
+            cleaned = _re.sub(r",\s*]", "]", cleaned)
+            cleaned = _re.sub(r'(?<=[{,])\s*(\w+)\s*:', r' "\1":', cleaned)
+            cleaned = cleaned.replace("'", '"')
+            data = json.loads(cleaned)
         metric_names = [m.name for m in self.metrics]
         missing = [k for k in metric_names if k not in data]
         if missing:

--- a/src/llm4ad/evaluator/llm_judge.py
+++ b/src/llm4ad/evaluator/llm_judge.py
@@ -66,26 +66,38 @@ class LLMJudgeEvaluator(BaseEvaluator):
     judge_temperature: float = 0.2
     judge_max_tokens: int = 4096
 
-    def __init__(self, config: Any = None):
-        """Initialize with optional config for LLM API credentials.
+    def __init__(self, config: Any = None, provider_config: Any = None):
+        """Initialize with optional config and provider for LLM API credentials.
 
         Args:
-            config: Evaluator config object. If it has an ``api_config``
-                attribute (dict with base_url, api_key, model), those
-                values are used for the LLM judge client.
+            config: Evaluator config object.
+            provider_config: Resolved provider configuration (ProviderConfig)
+                with base_url, api_key, and model fields.
         """
         super().__init__()
-        api_config: dict[str, str] = {}
-        if config is not None:
+        base_url = ""
+        api_key = ""
+        model = ""
+
+        if provider_config is not None:
+            base_url = getattr(provider_config, "base_url", "") or ""
+            api_key = getattr(provider_config, "api_key", "") or ""
+            model = getattr(provider_config, "model", "") or ""
+
+        if not (base_url and api_key) and config is not None:
+            api_config: dict[str, str] = {}
             raw = getattr(config, "api_config", None)
             if isinstance(raw, dict):
                 api_config = raw
             elif hasattr(config, "model_extra"):
                 api_config = config.model_extra.get("api_config", {})
+            base_url = base_url or api_config.get("base_url", "")
+            api_key = api_key or api_config.get("api_key", "")
+            model = model or api_config.get("model", "")
 
-        self._base_url = api_config.get("base_url", "")
-        self._api_key = api_config.get("api_key", "")
-        self._model_name = api_config.get("model", "")
+        self._base_url = base_url
+        self._api_key = api_key
+        self._model_name = model
 
         if self._base_url and self._api_key:
             self._client = AsyncOpenAI(
@@ -192,6 +204,7 @@ class LLMJudgeEvaluator(BaseEvaluator):
             import re as _re
 
             cleaned = raw
+            cleaned = cleaned.replace("{{", "{").replace("}}", "}")
             cleaned = _re.sub(r"//[^\n]*", "", cleaned)
             cleaned = _re.sub(r",\s*}", "}", cleaned)
             cleaned = _re.sub(r",\s*]", "]", cleaned)

--- a/src/llm4ad/llm4ad.py
+++ b/src/llm4ad/llm4ad.py
@@ -15,7 +15,7 @@ from pathlib import Path
 from typing import Any
 
 from llm4ad.coder.base import BaseCoder
-from llm4ad.config.schema import AppConfig
+from llm4ad.config.schema import AppConfig, CustomEvaluatorConfig
 from llm4ad.evaluator import BaseEvaluator, EvaluationDispatcher
 from llm4ad.infra.provider import BaseProvider
 from llm4ad.infra.repo_analyzer.base import AnalyzedRepository, BaseRepositoryAnalyzer
@@ -236,31 +236,24 @@ class LLM4AD:
         # Initialize evaluator
         evaluator_config = self.config.evaluator
 
-        # Auto-inject api_config from provider for custom evaluators
-        from llm4ad.config.schema import CustomEvaluatorConfig
-
-        if (
-            isinstance(evaluator_config, CustomEvaluatorConfig)
-            and not evaluator_config.model_extra.get("api_config")
-        ):
-            fallback_provider = next(
-                (p for p in self.config.providers if p.name == "default"),
-                self.config.providers[0] if self.config.providers else None,
+        # Resolve evaluator provider for custom evaluators
+        eval_provider_config = None
+        if isinstance(evaluator_config, CustomEvaluatorConfig):
+            eval_provider_name = evaluator_config.provider
+            if eval_provider_name not in self._providers:
+                raise ValueError(
+                    f"Evaluator provider '{eval_provider_name}' not found in providers configuration"
+                )
+            eval_provider_config = next(
+                p for p in self.config.providers if p.name == eval_provider_name
             )
-            if fallback_provider:
-                cfg_data = evaluator_config.model_dump()
-                cfg_data["api_config"] = {
-                    "base_url": fallback_provider.base_url or "",
-                    "api_key": fallback_provider.api_key,
-                    "model": fallback_provider.model,
-                }
-                evaluator_config = CustomEvaluatorConfig.model_validate(cfg_data)
 
         # Initilize dispatcher
         self._dispatcher = EvaluationDispatcher(
             config=evaluator_config,
             behavior_storage=self.config.multimodal.behavior_storage,
             config_dir=self._config_dir,
+            provider_config=eval_provider_config,
         )
 
         # Initialize version control if enabled

--- a/src/llm4ad/llm4ad.py
+++ b/src/llm4ad/llm4ad.py
@@ -236,6 +236,26 @@ class LLM4AD:
         # Initialize evaluator
         evaluator_config = self.config.evaluator
 
+        # Auto-inject api_config from provider for custom evaluators
+        from llm4ad.config.schema import CustomEvaluatorConfig
+
+        if (
+            isinstance(evaluator_config, CustomEvaluatorConfig)
+            and not evaluator_config.model_extra.get("api_config")
+        ):
+            fallback_provider = next(
+                (p for p in self.config.providers if p.name == "default"),
+                self.config.providers[0] if self.config.providers else None,
+            )
+            if fallback_provider:
+                cfg_data = evaluator_config.model_dump()
+                cfg_data["api_config"] = {
+                    "base_url": fallback_provider.base_url or "",
+                    "api_key": fallback_provider.api_key,
+                    "model": fallback_provider.model,
+                }
+                evaluator_config = CustomEvaluatorConfig.model_validate(cfg_data)
+
         # Initilize dispatcher
         self._dispatcher = EvaluationDispatcher(
             config=evaluator_config,


### PR DESCRIPTION
1. 自定义评估器自动从 default provider 继承 API 凭据，无需重复配置
2. 移除 relationship_prediction/config.yaml 中多余的 api_config
3.  LLMJudgeEvaluator.parse_judge_response 增加非标准 JSON 容错（无引号 key、单引号、尾随逗号、行注释）
