### PR TITLE
feat: support per-turn zh/en language selection in chat-tune

### DIFF
--- a/src/backend/Dockerfile.task
+++ b/src/backend/Dockerfile.task
@@ -18,11 +18,9 @@ RUN if [ -n "$APT_MIRROR" ]; then \
     build-essential \
     cmake \
     ninja-build \
-    gdb \
-    valgrind \
     pkg-config \
     libeigen3-dev \
-    openjdk-17-jdk \
+    openjdk-17-jdk-headless \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 

--- a/src/backend/app/schemas/chat_tune.py
+++ b/src/backend/app/schemas/chat_tune.py
@@ -2,7 +2,7 @@
 
 import uuid
 from datetime import datetime
-from typing import Any
+from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
@@ -52,6 +52,10 @@ class ChatTuneTurnStartRequest(BaseModel):
             "覆盖后端的默认分发；为 None 时由后端按会话状态自动判断。"
             "仅 start_turn 接受此参数；retry_turn 不受影响。"
         ),
+    )
+    language: Literal["zh", "en"] = Field(
+        default="zh",
+        description="本轮对话使用的语言（zh/en），驱动 LLM 回答语言",
     )
 
     @model_validator(mode="after")

--- a/src/backend/app/services/chat_tune_service.py
+++ b/src/backend/app/services/chat_tune_service.py
@@ -114,6 +114,20 @@ def _safe_error_message(exc: Exception, max_len: int = 2000) -> str:
     return msg[:max_len]
 
 
+def _t(language: str | None, zh: str, en: str) -> str:
+    """按语言挑选面向用户的文案，缺省回退中文。
+
+    Args:
+        language: 语言码（'zh'/'en' 等），通常取自 ``gathering_context['language']``。
+        zh: 中文文案。
+        en: 英文文案。
+
+    Returns:
+        ``language == 'en'`` 时返回英文，否则返回中文。
+    """
+    return en if (language or "zh") == "en" else zh
+
+
 @dataclass
 class TurnStreamContext:
     """stream_turn 路由所需的上下文数据。
@@ -443,6 +457,20 @@ def start_turn(
     set_chat_tune_generation_id(session.id, turn_id, generation_id)
     delete_chat_tune_stream(session.id, turn_id)
 
+    def _ctx_with_language() -> dict[str, Any]:
+        """在上一轮持久化的 gathering_context 上覆写本轮前端传入的 language。
+
+        首轮 session.gathering_context 为空，返回仅含 language 的 dict 即可——
+        容器内 runner 用 ``gctx.get(...)`` 带默认值取字段，不影响首轮判定。
+        """
+        ctx = (
+            copy.deepcopy(session.gathering_context)
+            if session.gathering_context
+            else {}
+        )
+        ctx["language"] = request.language
+        return ctx
+
     try:
         if generation_kind is ChatTuneGenerationKind.REVIEW:
             asyncio.create_task(
@@ -454,9 +482,7 @@ def start_turn(
                     task_id=task.id,
                     provider_config=provider_config,
                     user_content=llm_user_content,
-                    gathering_context=copy.deepcopy(session.gathering_context)
-                    if session.gathering_context
-                    else None,
+                    gathering_context=_ctx_with_language(),
                     input_data_path=task.input_data_path,
                 )
             )
@@ -469,9 +495,7 @@ def start_turn(
                     generation_id=generation_id,
                     task_id=task.id,
                     provider_config=provider_config,
-                    gathering_context=copy.deepcopy(session.gathering_context)
-                    if session.gathering_context
-                    else None,
+                    gathering_context=_ctx_with_language(),
                     input_data_path=task.input_data_path,
                 )
             )
@@ -485,9 +509,7 @@ def start_turn(
                     user_content=llm_user_content,
                     base_config=copy.deepcopy(session.latest_config or {}),
                     generation_id=generation_id,
-                    gathering_context=copy.deepcopy(session.gathering_context)
-                    if session.gathering_context
-                    else None,
+                    gathering_context=_ctx_with_language(),
                     input_data_path=task.input_data_path,
                 )
             )
@@ -857,6 +879,7 @@ async def _run_ai_build(
     """后台协程：在隔离容器中执行 AI 构建，并把事件转发到 Redis。"""
     from app.services import container_service
 
+    language = (gathering_context or {}).get("language") or "zh"
     content_buffer = ""
     blueprint_data: dict[str, Any] | None = None
     cancelled = False
@@ -898,7 +921,10 @@ async def _run_ai_build(
         if not await _wait_chat_tune_ready(
             client, base_url, settings.CHAT_TUNE_CONTAINER_READY_TIMEOUT
         ):
-            raise RuntimeError("构建容器启动超时，请重试")
+            raise RuntimeError(_t(
+                language, "构建容器启动超时，请重试",
+                "Build container timed out while starting. Please retry.",
+            ))
 
         body = {
             "provider_config": provider_config,
@@ -944,7 +970,10 @@ async def _run_ai_build(
                             turn_id=turn_id,
                         )
                     elif etype == "error":
-                        raise RuntimeError(event.get("error") or "构建容器执行失败")
+                        raise RuntimeError(event.get("error") or _t(
+                            language, "构建容器执行失败",
+                            "Build container execution failed",
+                        ))
                     elif etype == "done":
                         stream_done = True
                         break
@@ -1060,6 +1089,7 @@ async def _run_review_generation(
     """后台协程：在隔离容器中执行 review 对话，并把事件转发到 Redis。"""
     from app.services import container_service
 
+    language = (gathering_context or {}).get("language") or "zh"
     content_buffer = ""
     cancelled = False
     container_id: str | None = None
@@ -1101,7 +1131,10 @@ async def _run_review_generation(
         if not await _wait_chat_tune_ready(
             client, base_url, settings.CHAT_TUNE_CONTAINER_READY_TIMEOUT
         ):
-            raise RuntimeError("Review 容器启动超时，请重试")
+            raise RuntimeError(_t(
+                language, "Review 容器启动超时，请重试",
+                "Review container timed out while starting. Please retry.",
+            ))
 
         body = {
             "provider_config": provider_config,
@@ -1148,7 +1181,10 @@ async def _run_review_generation(
                             turn_id=turn_id,
                         )
                     elif etype == "error":
-                        raise RuntimeError(event.get("error") or "Review 容器执行失败")
+                        raise RuntimeError(event.get("error") or _t(
+                            language, "Review 容器执行失败",
+                            "Review container execution failed",
+                        ))
                     elif etype == "done":
                         stream_done = True
                         break
@@ -1260,6 +1296,7 @@ async def _run_chat_tune_generation(
     """
     from app.services import container_service
 
+    language = (gathering_context or {}).get("language") or "zh"
     content_buffer = ""
     payload: dict[str, Any] | None = None
     updated_messages: list[dict[str, Any]] | None = None
@@ -1311,7 +1348,10 @@ async def _run_chat_tune_generation(
         if not await _wait_chat_tune_ready(
             client, base_url, settings.CHAT_TUNE_CONTAINER_READY_TIMEOUT
         ):
-            raise RuntimeError("调参容器启动超时，请重试")
+            raise RuntimeError(_t(
+                language, "调参容器启动超时，请重试",
+                "Chat-tune container timed out while starting. Please retry.",
+            ))
 
         body = {
             "provider_config": provider_config,
@@ -1365,7 +1405,7 @@ async def _run_chat_tune_generation(
                         if event.get("response_type") == "choices":
                             payload = _build_choice_payload(event.get("choices") or [])
                         elif event.get("response_type") == "complete":
-                            payload = _build_confirm_build_payload()
+                            payload = _build_confirm_build_payload(language)
                             needs_profile = event.get("needs_profile")
                             await asyncio.to_thread(
                                 _update_session_stage,
@@ -1375,7 +1415,10 @@ async def _run_chat_tune_generation(
                                 turn_id=turn_id,
                             )
                     elif etype == "error":
-                        raise RuntimeError(event.get("error") or "调参容器执行失败")
+                        raise RuntimeError(event.get("error") or _t(
+                            language, "调参容器执行失败",
+                            "Chat-tune container execution failed",
+                        ))
                     elif etype == "done":
                         stream_done = True
                         break
@@ -1520,24 +1563,36 @@ _CONFIRM_BUILD_VALUE = "confirm_build"
 _DECLINE_BUILD_VALUE = "decline_build"
 
 
-def _build_confirm_build_payload() -> dict[str, Any]:
-    """构造确认是否开始 AI 构建的表单 payload。"""
+def _build_confirm_build_payload(language: str = "zh") -> dict[str, Any]:
+    """构造确认是否开始 AI 构建的表单 payload。
+
+    Args:
+        language: 语言码（'zh'/'en'），决定表单文案语言；缺省中文。
+    """
     return {
         "cardId": f"card-{uuid.uuid4().hex[:8]}",
         "kind": "choice",
         "stage": "confirm_build",
-        "prompt": "需求分析已完成，是否开始 AI 构建？",
+        "prompt": _t(
+            language, "需求分析已完成，是否开始 AI 构建？",
+            "Needs analysis is complete. Start the AI build?",
+        ),
         "hint": "",
         "options": [
             {
                 "value": _CONFIRM_BUILD_VALUE,
-                "label": "确认构建",
-                "description": "开始 AI 自动构建任务配置",
+                "label": _t(language, "确认构建", "Start build"),
+                "description": _t(
+                    language, "开始 AI 自动构建任务配置",
+                    "Let the AI build the task configuration automatically",
+                ),
             },
             {
                 "value": _DECLINE_BUILD_VALUE,
-                "label": "暂不构建",
-                "description": "继续调参对话",
+                "label": _t(language, "暂不构建", "Not now"),
+                "description": _t(
+                    language, "继续调参对话", "Keep chatting to tune the configuration",
+                ),
             },
         ],
     }
@@ -1549,7 +1604,9 @@ def _build_gathering_context(
 ) -> dict[str, Any]:
     """根据本轮更新后的对话历史拼装可持久化的 gathering_context。
 
-    ``user_context`` / ``language`` 在单轮内不变，沿用上一轮快照（首轮缺省）。
+    ``user_context`` 在单轮内不变，沿用上一轮快照（首轮缺省）。
+    ``language`` 取本轮 ``incoming`` 注入值（由 ``start_turn`` 从前端请求写入），
+    使每轮都能按前端选择的语言回答；缺省回退到 ``"zh"``。
     ``user_input`` 为每轮瞬时字段，不持久化。
     """
     incoming = incoming or {}

--- a/src/backend/app/tasks/chat_tune_runner.py
+++ b/src/backend/app/tasks/chat_tune_runner.py
@@ -239,6 +239,20 @@ def _sse(obj: dict[str, Any]) -> str:
     return f"data: {json.dumps(obj, ensure_ascii=False, default=str)}\n\n"
 
 
+def _t(language: str | None, zh: str, en: str) -> str:
+    """按语言挑选进度/状态文案，缺省回退中文。
+
+    Args:
+        language: 语言码（'zh'/'en' 等），来自 ``gathering_context['language']``。
+        zh: 中文文案。
+        en: 英文文案。
+
+    Returns:
+        ``language == 'en'`` 时返回英文，否则返回中文。
+    """
+    return en if (language or "zh") == "en" else zh
+
+
 def _serialize_response(response: Any) -> dict[str, Any]:
     """把 ``NeedsGatheringResponse`` 序列化为可回传的事件 dict。
 
@@ -348,33 +362,55 @@ async def _build_event_stream(req: BuildRequest) -> AsyncIterator[str]:
 
     try:
         ctx = req.gathering_context or {}
+        language = ctx.get("language") or "zh"
         needs_dict = ctx.get("needs_profile")
         if not needs_dict:
-            yield _sse({"type": "error", "error": "缺少 needs_profile，无法构建"})
+            yield _sse({"type": "error", "error": _t(
+                language, "缺少 needs_profile，无法构建",
+                "Missing needs_profile; cannot build",
+            )})
             return
 
-        yield _sse({"type": "chunk", "content": "🔨 **开始 AI 构建**\n\n"})
-        yield _sse({"type": "chunk", "content": "正在初始化构建环境...\n\n"})
+        yield _sse({"type": "chunk", "content": _t(
+            language, "🔨 **开始 AI 构建**\n\n", "🔨 **Starting AI build**\n\n",
+        )})
+        yield _sse({"type": "chunk", "content": _t(
+            language, "正在初始化构建环境...\n\n",
+            "Initializing build environment...\n\n",
+        )})
 
         provider = BaseProvider.create(
             req.provider_config["type"], config=req.provider_config
         )
         needs = NeedsProfile.from_dict(needs_dict)
 
-        yield _sse({"type": "chunk", "content": "正在分析需求并生成代码...\n\n"})
+        yield _sse({"type": "chunk", "content": _t(
+            language, "正在分析需求并生成代码...\n\n",
+            "Analyzing requirements and generating code...\n\n",
+        )})
 
         try:
             builder = BuildOrchestrator(provider, console=None, max_repair_attempts=10)
             blueprint = await builder.build(needs)
         except BuildError as exc:
-            yield _sse({"type": "chunk", "content": f"\n❌ **构建失败**：{exc}\n"})
+            yield _sse({"type": "chunk", "content": _t(
+                language, f"\n❌ **构建失败**：{exc}\n",
+                f"\n❌ **Build failed**: {exc}\n",
+            )})
             yield _sse({"type": "error", "error": str(exc)[:_MAX_ERROR_LEN]})
             return
 
-        yield _sse({"type": "chunk", "content": "正在写入任务文件...\n\n"})
+        yield _sse({"type": "chunk", "content": _t(
+            language, "正在写入任务文件...\n\n", "Writing task files...\n\n",
+        )})
         write_task_directory(blueprint, DATA_DIR)
 
-        yield _sse({"type": "chunk", "content": "\n✅ **构建完成！**你可以继续对话来 review 和调整配置。\n"})
+        yield _sse({"type": "chunk", "content": _t(
+            language,
+            "\n✅ **构建完成！**你可以继续对话来 review 和调整配置。\n",
+            "\n✅ **Build complete!** You can keep chatting to review and "
+            "adjust the configuration.\n",
+        )})
         yield _sse({"type": "build_result", "blueprint_data": asdict(blueprint)})
         yield _sse({"type": "done"})
     except Exception as exc:
@@ -426,10 +462,14 @@ async def _review_event_stream(req: ReviewRequest) -> AsyncIterator[str]:
     stream = None
     try:
         ctx = req.gathering_context or {}
+        language = ctx.get("language") or "zh"
         blueprint_data = ctx.get("blueprint_data")
         needs_dict = ctx.get("needs_profile")
         if not blueprint_data or not needs_dict:
-            yield _sse({"type": "error", "error": "缺少构建产物或需求分析结果"})
+            yield _sse({"type": "error", "error": _t(
+                language, "缺少构建产物或需求分析结果",
+                "Missing build artifact or needs analysis result",
+            )})
             return
 
         provider = BaseProvider.create(
@@ -439,7 +479,6 @@ async def _review_event_stream(req: ReviewRequest) -> AsyncIterator[str]:
         needs = NeedsProfile.from_dict(needs_dict)
 
         review_messages: list[dict[str, str]] = ctx.get("review_messages", [])
-        language = ctx.get("language") or "zh"
 
         is_first_review = len(review_messages) == 0
         initial_message = None
@@ -471,33 +510,54 @@ async def _review_event_stream(req: ReviewRequest) -> AsyncIterator[str]:
                 review_response = item
 
         if review_response is None:
-            yield _sse({"type": "error", "error": "review 流未返回 ReviewResponse"})
+            yield _sse({"type": "error", "error": _t(
+                language, "review 流未返回 ReviewResponse",
+                "Review stream did not return a ReviewResponse",
+            )})
             return
 
         action = review_response.action
 
         if action == ReviewAction.MODIFY_EVALUATOR and review_response.modification_text:
-            yield _sse({"type": "chunk", "content": "\n\n🔧 正在修改评估器...\n"})
+            yield _sse({"type": "chunk", "content": _t(
+                language, "\n\n🔧 正在修改评估器...\n",
+                "\n\n🔧 Modifying evaluator...\n",
+            )})
             try:
                 builder = BuildOrchestrator(provider, console=None)
                 await builder.rebuild_evaluator(
                     blueprint, review_response.modification_text, needs
                 )
-                yield _sse({"type": "chunk", "content": "✅ 评估器已更新。\n"})
+                yield _sse({"type": "chunk", "content": _t(
+                    language, "✅ 评估器已更新。\n", "✅ Evaluator updated.\n",
+                )})
             except BuildError as exc:
-                yield _sse({"type": "chunk", "content": f"⚠️ 修改失败：{exc}\n"})
+                yield _sse({"type": "chunk", "content": _t(
+                    language, f"⚠️ 修改失败：{exc}\n",
+                    f"⚠️ Modification failed: {exc}\n",
+                )})
 
         elif action == ReviewAction.REGENERATE:
-            yield _sse({"type": "chunk", "content": "\n\n🔄 正在重新构建...\n"})
+            yield _sse({"type": "chunk", "content": _t(
+                language, "\n\n🔄 正在重新构建...\n", "\n\n🔄 Rebuilding...\n",
+            )})
             try:
                 builder = BuildOrchestrator(provider, console=None)
                 blueprint = await builder.build(needs)
-                yield _sse({"type": "chunk", "content": "✅ 重新构建完成。\n"})
+                yield _sse({"type": "chunk", "content": _t(
+                    language, "✅ 重新构建完成。\n", "✅ Rebuild complete.\n",
+                )})
             except BuildError as exc:
-                yield _sse({"type": "chunk", "content": f"⚠️ 重新构建失败：{exc}\n"})
+                yield _sse({"type": "chunk", "content": _t(
+                    language, f"⚠️ 重新构建失败：{exc}\n",
+                    f"⚠️ Rebuild failed: {exc}\n",
+                )})
 
         elif action == ReviewAction.CONFIRMED:
-            yield _sse({"type": "chunk", "content": "\n\n✅ **配置已确认。**\n"})
+            yield _sse({"type": "chunk", "content": _t(
+                language, "\n\n✅ **配置已确认。**\n",
+                "\n\n✅ **Configuration confirmed.**\n",
+            )})
             write_task_directory(blueprint, DATA_DIR)
 
         yield _sse(_serialize_review_response(review_response, asdict(blueprint)))

--- a/src/frontend/src/client/schemas.gen.ts
+++ b/src/frontend/src/client/schemas.gen.ts
@@ -631,6 +631,13 @@ export const ChatTuneTurnStartRequestSchema = {
                 }
             ],
             description: '显式指定本轮要执行的阶段（gathering/build/review），用于前端覆盖后端的默认分发；为 None 时由后端按会话状态自动判断。仅 start_turn 接受此参数；retry_turn 不受影响。'
+        },
+        language: {
+            type: 'string',
+            enum: ['zh', 'en'],
+            title: 'Language',
+            description: '本轮对话使用的语言（zh/en），驱动 LLM 回答语言',
+            default: 'zh'
         }
     },
     type: 'object',

--- a/src/frontend/src/client/types.gen.ts
+++ b/src/frontend/src/client/types.gen.ts
@@ -268,6 +268,10 @@ export type ChatTuneTurnStartRequest = {
      * 显式指定本轮要执行的阶段（gathering/build/review），用于前端覆盖后端的默认分发；为 None 时由后端按会话状态自动判断。仅 start_turn 接受此参数；retry_turn 不受影响。
      */
     target_stage?: (ChatTuneActiveStage | null);
+    /**
+     * 本轮对话使用的语言（zh/en），驱动 LLM 回答语言
+     */
+    language?: 'zh' | 'en';
 };
 
 /**

--- a/src/frontend/src/components/Evolution/AIChatFloating.tsx
+++ b/src/frontend/src/components/Evolution/AIChatFloating.tsx
@@ -214,7 +214,7 @@ function FloatingChatImpl({
   taskName: string
   readOnly: boolean
 }) {
-  const { t } = useTranslation()
+  const { t, i18n } = useTranslation()
   const { activeTab } = useEvolution()
   const queryClient = useQueryClient()
   const stream = useChatTuneStream()
@@ -436,6 +436,7 @@ function FloatingChatImpl({
             provider_id: providerId || undefined,
             model_name: modelName || undefined,
             target_stage: targetStage,
+            language: i18n.language?.startsWith("zh") ? "zh" : "en",
           },
         })
 
@@ -498,6 +499,7 @@ function FloatingChatImpl({
       targetStage,
       connectStream,
       refetchSession,
+      i18n.language,
       t,
     ],
   )

--- a/src/frontend/src/components/Evolution/TaskDetail/ChatTuneView.tsx
+++ b/src/frontend/src/components/Evolution/TaskDetail/ChatTuneView.tsx
@@ -224,7 +224,7 @@ export default function ChatTuneView({
   readOnly = false,
   onSwitchToStepper,
 }: ChatTuneViewProps) {
-  const { t } = useTranslation()
+  const { t, i18n } = useTranslation()
   const {
     setIsConfiguring,
     setIsViewingParams,
@@ -623,6 +623,7 @@ export default function ChatTuneView({
             provider_id: providerId || undefined,
             model_name: modelName || undefined,
             target_stage: targetStage,
+            language: i18n.language?.startsWith("zh") ? "zh" : "en",
           },
         })
         // The backend has accepted the turn; if the user has since switched
@@ -683,6 +684,7 @@ export default function ChatTuneView({
       targetStage,
       connectToStream,
       refetchSession,
+      i18n.language,
       t,
     ],
   )

--- a/src/llm4ad/consultant/core.py
+++ b/src/llm4ad/consultant/core.py
@@ -23,6 +23,7 @@ from llm4ad.consultant.context_limiter import (
 from llm4ad.consultant.prompts import (
     _build_language_instruction,
     build_extraction_prompt,
+    build_language_reminder,
     build_needs_gathering_prompt,
 )
 from llm4ad.infra.provider.base import (
@@ -392,6 +393,35 @@ async def process_needs_gathering_turn(
     )
 
 
+def _inject_language_reminder(
+    chat_messages: list[ChatMessage], language: str | None
+) -> None:
+    """Fold a language reminder into the most recent user message, in place.
+
+    The language requirement lives in the system prompt, but models sometimes
+    mirror the language the user just wrote in. Appending the reminder to the
+    latest user turn gives the directive maximum recency right before
+    generation. ``chat_messages`` is the LLM-only list (separate from the
+    persisted ``phase_messages``), so this does not pollute conversation history,
+    and editing the existing user message keeps role alternation valid.
+
+    Args:
+        chat_messages: Messages about to be sent to the provider.
+        language: Target language code, or None to skip.
+    """
+    reminder = build_language_reminder(language)
+    if not reminder:
+        return
+    for i in range(len(chat_messages) - 1, -1, -1):
+        msg = chat_messages[i]
+        if msg.role == "user" and isinstance(msg.content, str):
+            chat_messages[i] = ChatMessage(
+                role="user",
+                content=msg.content + reminder,
+            )
+            return
+
+
 async def process_needs_gathering_turn_stream(
     ctx: NeedsGatheringContext,
     provider: BaseProvider,
@@ -439,6 +469,7 @@ async def process_needs_gathering_turn_stream(
     chat_messages = [ChatMessage(role="system", content=system_prompt)]
     for msg in messages_for_llm:
         chat_messages.append(ChatMessage(role=msg["role"], content=msg["content"]))
+    _inject_language_reminder(chat_messages, ctx.language)
 
     full_text = ""
     for _ in range(max_tool_rounds):
@@ -756,6 +787,7 @@ async def process_review_turn(
     )]
     for msg in messages_for_llm:
         chat_messages.append(ChatMessage(role=msg["role"], content=msg["content"]))
+    _inject_language_reminder(chat_messages, ctx.language)
 
     stream = await provider.chat_stream(chat_messages)
     full_text = ""
@@ -831,6 +863,7 @@ async def process_review_turn_stream(
     )]
     for msg in messages_for_llm:
         chat_messages.append(ChatMessage(role=msg["role"], content=msg["content"]))
+    _inject_language_reminder(chat_messages, ctx.language)
 
     stream = await provider.chat_stream(chat_messages)
     full_text = ""

--- a/src/llm4ad/consultant/prompts.py
+++ b/src/llm4ad/consultant/prompts.py
@@ -60,8 +60,9 @@ If the user chooses to generate a new one, proceed normally without mentioning \
 the existing evaluator again in this session.
 
 ## Language Rule
-Detect the language of the user's FIRST message and use that language \
-consistently for ALL your responses throughout the entire conversation. \
+Unless a "Language Requirement" section appears later in this prompt (which always \
+takes absolute precedence), detect the language of the user's FIRST message and use \
+that language consistently for ALL your responses throughout the entire conversation. \
 If the user writes in Chinese, reply in Chinese. If in English, reply in English. \
 Do NOT switch languages mid-conversation.
 
@@ -246,8 +247,9 @@ output [CONFIRMED] on its own line.
 
 ## Conversation Rules
 - Be concise; avoid lengthy explanations unless asked
-- Match the user's language: if they write in Chinese, reply in Chinese; \
-if in English, reply in English. Stay consistent throughout.
+- Unless a "Language Requirement" section later in this prompt specifies otherwise \
+(which always takes precedence), match the user's language: if they write in Chinese, \
+reply in Chinese; if in English, reply in English. Stay consistent throughout.
 - When explaining code, focus on the evaluation logic, not boilerplate
 """
 
@@ -258,9 +260,10 @@ Explain the following evaluator code to the user. Focus on:
 3. What input/output format is expected
 4. Any important implementation details
 
-Keep the explanation concise (under 10 sentences). Match the language used \
-in the original problem description below — if it is in Chinese, explain in \
-Chinese; if in English, explain in English.
+Keep the explanation concise (under 10 sentences). Unless a "Language Requirement" \
+section appears later in this prompt (which always takes precedence), match the \
+language used in the original problem description below — if it is in Chinese, \
+explain in Chinese; if in English, explain in English.
 
 ## Evaluator Code:
 ```python
@@ -282,10 +285,15 @@ _LANGUAGE_NAMES = {
 
 _LANGUAGE_INSTRUCTION_TEMPLATE = """\
 
-## Language Requirement
-You MUST respond in {language_name}. All your responses, questions, choices, \
-and explanations must be in {language_name}. Do NOT switch to another language \
-under any circumstances."""
+## Language Requirement (HIGHEST PRIORITY — overrides every other language rule above)
+You MUST write EVERY response in {language_name}, and ONLY {language_name}. \
+This applies to all questions, options, explanations, and any other text you produce. \
+This requirement OVERRIDES any earlier instruction about "matching the user's \
+language", "detecting the conversation language", or "not switching languages \
+mid-conversation". Even if earlier messages in this conversation — including the \
+user's own messages and your previous replies — are in a different language, you \
+MUST still respond in {language_name}: switch to {language_name} now and never \
+switch away from it."""
 
 
 def _build_language_instruction(language: str | None) -> str:
@@ -301,6 +309,34 @@ def _build_language_instruction(language: str | None) -> str:
         return ""
     language_name = _LANGUAGE_NAMES.get(language, language)
     return _LANGUAGE_INSTRUCTION_TEMPLATE.format(language_name=language_name)
+
+
+_LANGUAGE_REMINDER_TEMPLATE = (
+    "\n\n[Language reminder: regardless of the language used in the message "
+    "above, you MUST write your ENTIRE reply — including any questions, options, "
+    "and explanations — in {language_name}, and in no other language.]"
+)
+
+
+def build_language_reminder(language: str | None) -> str:
+    """Build a short language reminder to fold into the latest user turn.
+
+    The system prompt's language requirement is sometimes overridden by the
+    model mirroring the language the user just wrote in (especially for
+    substantive requests). Appending this reminder to the most recent user
+    message gives the directive maximum recency right before generation.
+
+    Args:
+        language: Language code ('zh', 'en', etc.) or None.
+
+    Returns:
+        Reminder string (leading with blank lines), or empty string if no
+        language is specified.
+    """
+    if not language:
+        return ""
+    language_name = _LANGUAGE_NAMES.get(language, language)
+    return _LANGUAGE_REMINDER_TEMPLATE.format(language_name=language_name)
 
 
 def build_needs_gathering_prompt(


### PR DESCRIPTION
1. add `language` field to ChatTuneTurnStartRequest, passed from frontend i18n
2. thread language through gathering_context into build/review/tune runners
3. localize container status, error, and confirm-build prompts via `_t` helper
4. add language reminder injected into latest user turn to enforce reply language
5. strengthen Language Requirement prompt to override conversation-language matching
6. slim Dockerfile.task: drop gdb/valgrind, use openjdk-17-jdk-headless