### PR TITLE
feat: make streaming chat cursor blink

### DIFF
--- a/src/frontend/src/components/Evolution/TaskDetail/ChatTuneView.tsx
+++ b/src/frontend/src/components/Evolution/TaskDetail/ChatTuneView.tsx
@@ -3272,7 +3272,8 @@ function ChatMarkdown({
   )
   return (
     <div
-      className="prose prose-sm dark:prose-invert max-w-none [overflow-wrap:anywhere]
+      className={cn(
+        `prose prose-sm dark:prose-invert max-w-none [overflow-wrap:anywhere]
         prose-p:my-1 prose-p:leading-relaxed
         prose-headings:my-2 prose-headings:font-semibold
         prose-ul:my-1 prose-ol:my-1 prose-li:my-0
@@ -3280,14 +3281,16 @@ function ChatMarkdown({
         prose-pre:my-2 prose-pre:rounded-lg prose-pre:text-[13px] prose-pre:leading-relaxed prose-pre:bg-code-block-bg prose-pre:text-foreground prose-pre:border prose-pre:border-border/50
         prose-a:text-primary prose-a:no-underline hover:prose-a:underline
         prose-blockquote:my-2 prose-blockquote:border-primary/30
-        [&>*:first-child]:mt-0 [&>*:last-child]:mb-0"
+        [&>*:first-child]:mt-0 [&>*:last-child]:mb-0`,
+        streaming && "chat-streaming-cursor",
+      )}
     >
       <Markdown
         remarkPlugins={MARKDOWN_REMARK_PLUGINS}
         rehypePlugins={MARKDOWN_REHYPE_PLUGINS}
         components={components}
       >
-        {streaming ? `${content} ▍` : content}
+        {content}
       </Markdown>
     </div>
   )

--- a/src/frontend/src/index.css
+++ b/src/frontend/src/index.css
@@ -492,3 +492,26 @@
   background: transparent;
   padding: 0;
 }
+
+/* Blinking caret appended inline after the last block while streaming. */
+@keyframes chat-cursor-blink {
+  0%,
+  50% {
+    opacity: 1;
+  }
+  50.01%,
+  100% {
+    opacity: 0;
+  }
+}
+.chat-streaming-cursor > :last-child::after {
+  content: "▍";
+  display: inline-block;
+  margin-left: 0.05em;
+  animation: chat-cursor-blink 1s step-end infinite;
+}
+@media (prefers-reduced-motion: reduce) {
+  .chat-streaming-cursor > :last-child::after {
+    animation: none;
+  }
+}


### PR DESCRIPTION
1. Add chat-cursor-blink keyframe and .chat-streaming-cursor caret style in index.css
2. Replace static trailing cursor character with an animated ::after pseudo-element
3. Respect prefers-reduced-motion by disabling the blink animation