### PR TITLE
feat: add interactive demo project + guided walkthrough

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
     <img src="https://img.shields.io/badge/license-BSD--3--Clause-blue" alt="License">
   </a>
   <a href="https://github.com/Optima-CityU/LLM4AD_Next/actions/workflows/ci.yml">
-    <img src="https://img.shields.io/github/actions/workflow/status/Optima-CityU/LLM4AD_Next/ci" alt="CI">
+    <img src="https://img.shields.io/github/actions/workflow/status/Optima-CityU/LLM4AD_Next/ci.yml" alt="CI">
   </a>
 </p>
 

--- a/src/frontend/src/components/Evolution/EvolutionTaskList.tsx
+++ b/src/frontend/src/components/Evolution/EvolutionTaskList.tsx
@@ -83,7 +83,9 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip"
+import { DEMO_TASK, isDemoProjectId } from "@/data/demoFixtures"
 import useCustomToast from "@/hooks/useCustomToast"
+import { getDemoState, setDemoPhase, useDemoState } from "@/hooks/useDemoMode"
 import { useEvolution } from "@/hooks/useEvolution"
 import { formatDateTime } from "@/lib/utils"
 import { handleError } from "@/utils"
@@ -110,14 +112,30 @@ export function getTasksInfiniteQueryKey(projectId: string) {
 }
 
 export function useInfiniteTasks(projectId: string) {
+  const isDemo = isDemoProjectId(projectId)
+  // The demo task only "exists" once the user has clicked New Task. Subscribe
+  // to the demo phase so the list refreshes the moment the simulation starts.
+  // Real projects keep their original query key intact so external callers
+  // (TaskVersionTree, useCopyBeforeRun) can still setQueryData on it.
+  const demoState = useDemoState()
   return useInfiniteQuery({
-    queryKey: getTasksInfiniteQueryKey(projectId),
-    queryFn: ({ pageParam = 0 }) =>
-      Llm4AdTasksService.listTasks({
+    queryKey: isDemo
+      ? [...getTasksInfiniteQueryKey(projectId), demoState.phase]
+      : getTasksInfiniteQueryKey(projectId),
+    queryFn: ({ pageParam = 0 }) => {
+      if (isDemo) {
+        const taskExists = getDemoState().phase !== "uninitialized"
+        return Promise.resolve({
+          items: taskExists && pageParam === 0 ? [DEMO_TASK] : [],
+          total: taskExists ? 1 : 0,
+        })
+      }
+      return Llm4AdTasksService.listTasks({
         projectId,
         skip: pageParam,
         limit: TASKS_PAGE_SIZE,
-      }),
+      })
+    },
     initialPageParam: 0,
     getNextPageParam: (lastPage, allPages) => {
       const loaded = allPages.reduce((acc, p) => acc + p.items.length, 0)
@@ -191,9 +209,14 @@ export function CreateTaskDialog({
   onCreated: (task: TaskResponse) => void
   variant?: "compact" | "large" | "iconOnly"
 }) {
+  const isDemo = isDemoProjectId(projectId)
   const [isOpen, setIsOpen] = useState(false)
   const [confirmNoTemplateOpen, setConfirmNoTemplateOpen] = useState(false)
-  const [buildMode, setBuildMode] = useState<"ai" | "manual">("manual")
+  // In the demo, default the dialog to AI build so the walkthrough lands on
+  // the path it actually simulates. Real projects keep manual as default.
+  const [buildMode, setBuildMode] = useState<"ai" | "manual">(
+    isDemo ? "ai" : "manual",
+  )
   const queryClient = useQueryClient()
   const { showSuccessToast, showErrorToast } = useCustomToast()
   const { t, i18n } = useTranslation()
@@ -210,7 +233,9 @@ export function CreateTaskDialog({
     resolver: zodResolver(nameSchema),
     mode: "onBlur",
     defaultValues: {
-      name: "",
+      // Pre-fill the task name in the demo so the user can land on a single
+      // click; real projects start blank so the user has to think about it.
+      name: isDemo ? "TSP Heuristic" : "",
       template_name: undefined,
       config_name: undefined,
     },
@@ -269,6 +294,18 @@ export function CreateTaskDialog({
   })
 
   const submitTask = (data: NameFormData) => {
+    // Demo mode: skip the real createTask API. Whichever mode the user picked
+    // (AI build / Manual stepper) we land on the simulated AI Build view —
+    // demo only mocks the AI path. Setting demo phase to "configuring"
+    // triggers DemoBuildView via the layout's phase listener.
+    if (isDemo) {
+      setIsOpen(false)
+      form.reset()
+      setBuildMode("ai")
+      setDemoPhase("configuring")
+      onCreated(DEMO_TASK)
+      return
+    }
     const payload: TaskCreate = {
       name: data.name,
       project_id: projectId,
@@ -285,6 +322,13 @@ export function CreateTaskDialog({
   }
 
   const onSubmit = (data: NameFormData) => {
+    // Demo mode: short-circuit every branch so the user always lands on the
+    // simulated build session regardless of which mode they ticked or whether
+    // they picked a template.
+    if (isDemo) {
+      submitTask(data)
+      return
+    }
     if (isAiMode) {
       submitTask(data)
       return
@@ -303,7 +347,7 @@ export function CreateTaskDialog({
         setIsOpen(open)
         if (!open) {
           form.reset()
-          setBuildMode("manual")
+          setBuildMode(isDemo ? "ai" : "manual")
         }
       }}
     >
@@ -345,7 +389,10 @@ export function CreateTaskDialog({
           </button>
         )}
       </DialogTrigger>
-      <DialogContent className="sm:max-w-lg">
+      <DialogContent
+        data-tour="create-task-dialog"
+        className="sm:max-w-lg"
+      >
         <DialogHeader>
           <DialogTitle>{t("evolution.createTaskTitle")}</DialogTitle>
           <DialogDescription>
@@ -652,6 +699,7 @@ export function CreateTaskDialog({
               </DialogClose>
               <LoadingButton
                 type="submit"
+                data-tour="create-task-submit"
                 loading={mutation.isPending}
                 className="bg-primary/20 text-primary border border-primary/40 hover:bg-primary/30"
               >
@@ -939,6 +987,9 @@ export default function EvolutionTaskList() {
             return (
               <div
                 key={task.id}
+                data-tour={
+                  task.id === DEMO_TASK.id ? "demo-task-row" : undefined
+                }
                 className={`group flex flex-col gap-1 px-3 py-2.5 rounded-md cursor-pointer
                   transition-all duration-200 border
                   ${

--- a/src/frontend/src/components/Evolution/TaskDetail/DemoBuildView.tsx
+++ b/src/frontend/src/components/Evolution/TaskDetail/DemoBuildView.tsx
@@ -1,0 +1,713 @@
+import {
+  Bot,
+  Check,
+  ChevronsUpDown,
+  CircleAlert,
+  FileCode,
+  Layers,
+  Loader2,
+  Monitor,
+  Play,
+  Send,
+  Sparkles,
+  X,
+} from "lucide-react"
+import { useEffect, useRef, useState } from "react"
+import { useTranslation } from "react-i18next"
+
+import { DEMO_AI_BUILD_FILES } from "@/data/demoFixtures"
+import { setDemoPhase, useDemoState } from "@/hooks/useDemoMode"
+import { cn } from "@/lib/utils"
+
+/**
+ * One scripted exchange. The user sends `userText`, then `aiText` arrives
+ * after `aiDelayMs`, and the composer auto-prefills `nextUserText` (or empty
+ * if this is the last turn).
+ */
+interface GatherTurn {
+  userText: string
+  aiText: string
+  /** Delay before the AI reply appears, after the user "sends". */
+  aiDelayMs: number
+  /** What the composer should auto-fill after the AI replies. */
+  nextUserText?: string
+}
+
+const GATHER_SCRIPT_ZH: GatherTurn[] = [
+  {
+    userText:
+      "你好，我想设计一个旅行商问题（TSP）的启发式算法，目标是最小化总路径长度。",
+    aiText:
+      "好的，我先确认两点细节：\n\n1. 距离类型：欧氏距离还是其它（如曼哈顿、网络距离）？\n2. 问题规模：大约多少个城市？",
+    aiDelayMs: 700,
+    nextUserText: "1. 欧氏距离\n2. 50-100 个城市",
+  },
+  {
+    userText: "1. 欧氏距离\n2. 50-100 个城市",
+    aiText:
+      "明白。再确认一下评估指标 —— 除了路径长度，是否还需要考虑别的，比如运行时间、可视化输出？",
+    aiDelayMs: 650,
+    nextUserText: "只看路径长度即可",
+  },
+  {
+    userText: "只看路径长度即可",
+    aiText:
+      "好的，我已经收集到了所有信息：\n\n• 问题：旅行商问题（TSP）\n• 距离类型：欧氏距离\n• 问题规模：50-100 个城市\n• 评估指标：路径长度\n• 设计思路：贪心最近邻构造 + 2-opt 局部搜索\n• 预计产物：config.yaml、evaluator.py、task.py\n\n确认无误的话，要现在开始构建吗？",
+    aiDelayMs: 750,
+    nextUserText: "好的，开始构建",
+  },
+  {
+    userText: "好的，开始构建",
+    aiText: "收到，开始生成配置和代码……",
+    aiDelayMs: 400,
+    // No nextUserText — sending this turn flips phase to "building".
+  },
+]
+
+const GATHER_SCRIPT_EN: GatherTurn[] = [
+  {
+    userText:
+      "Hi, I'd like to design a heuristic for the Travelling Salesman Problem (TSP) to minimize the total tour length.",
+    aiText:
+      "Got it. Let me confirm two details first:\n\n1. Distance type: Euclidean, or something else (Manhattan, network distance, ...)?\n2. Problem size: roughly how many cities?",
+    aiDelayMs: 700,
+    nextUserText: "1. Euclidean\n2. 50-100 cities",
+  },
+  {
+    userText: "1. Euclidean\n2. 50-100 cities",
+    aiText:
+      "Understood. One more on evaluation — besides tour length, do you also care about runtime or any visual output?",
+    aiDelayMs: 650,
+    nextUserText: "Tour length is the only metric we care about.",
+  },
+  {
+    userText: "Tour length is the only metric we care about.",
+    aiText:
+      "Great, I've gathered everything I need:\n\n• Problem: Travelling Salesman Problem (TSP)\n• Distance: Euclidean\n• Size: 50-100 cities\n• Metric: tour length\n• Approach: greedy nearest-neighbor construction + 2-opt local search\n• Expected files: config.yaml, evaluator.py, task.py\n\nIf that all looks right, shall we start the build?",
+    aiDelayMs: 750,
+    nextUserText: "Yes, start the build.",
+  },
+  {
+    userText: "Yes, start the build.",
+    aiText: "On it — generating the config and code now...",
+    aiDelayMs: 400,
+    // No nextUserText — sending this turn flips phase to "building".
+  },
+]
+
+function gatherScript(language: string): GatherTurn[] {
+  return language?.startsWith("zh") ? GATHER_SCRIPT_ZH : GATHER_SCRIPT_EN
+}
+
+interface ChatMessage {
+  role: "user" | "ai" | "system"
+  text: string
+}
+
+/**
+ * The welcome message the real backend injects on every AI Build session
+ * (`_WELCOME_TEXT` in `chat_tune_service.py`). Mirroring it here keeps the
+ * demo's first-frame UX consistent with what users will see on real tasks.
+ */
+function welcomeMessage(language: string): ChatMessage {
+  const lang = language?.startsWith("zh") ? "zh" : "en"
+  if (lang === "zh") {
+    return {
+      role: "system",
+      text:
+        "👋 欢迎使用 LLM4AD AI 助手\n\n" +
+        "我将帮助你配置任务参数，让算法设计更加高效。你可以：\n" +
+        "• 直接描述你的需求，我来帮你生成配置\n" +
+        "• 随时对现有配置提出修改建议",
+    }
+  }
+  return {
+    role: "system",
+    text:
+      "👋 Welcome to the LLM4AD AI Assistant\n\n" +
+      "I'll help you configure task parameters for efficient algorithm design. You can:\n" +
+      "• Describe your needs and I'll generate a configuration\n" +
+      "• Ask for modifications to the current config at any time",
+  }
+}
+
+type StageState = "not_started" | "running" | "completed"
+
+interface StageRow {
+  key: "gathering" | "build" | "review"
+  state: StageState
+}
+
+/**
+ * Stand-in for the real ChatTuneView (AI Build panel). Mirrors the real
+ * layout — header (✨ AI title + mode switch + ✕), preview column on the
+ * left (progress + 3-stage checklist + files + Run button), chat column on
+ * the right — and replays a scripted requirements-gathering conversation
+ * driven by the user clicking Send. Once the user sends the final "开始构建"
+ * turn the panel flips into build mode (progress bar + file reveal).
+ */
+export default function DemoBuildView() {
+  const { t, i18n } = useTranslation()
+  const demoState = useDemoState()
+  // Pick the conversation script for the active language. Computed inline
+  // (not state) so a mid-demo language switch updates the next prompt the
+  // user sees. Past chat history stays as-is — re-localizing already-sent
+  // messages would be jarring.
+  const SCRIPT = gatherScript(i18n.language)
+
+  // Scripted gathering turn the user is currently on. 0..SCRIPT.length
+  // — when it equals length the gathering phase is exhausted and the panel
+  // moves into building.
+  const [gatherStep, setGatherStep] = useState(0)
+  // Visible chat history. Seeded with the same welcome system message the
+  // real backend injects on every AI Build session.
+  const [messages, setMessages] = useState<ChatMessage[]>(() => [
+    welcomeMessage(i18n.language),
+  ])
+  // True while the AI's reply is being typed out — disables the Send button
+  // so the user can't double-fire while a reply is in flight.
+  const [chatBusy, setChatBusy] = useState(false)
+  // Scroll anchor for the chat history — a ref to the bottom-most element so
+  // we can pin the view to the latest message as the conversation grows.
+  const messagesEndRef = useRef<HTMLDivElement | null>(null)
+  // What's currently in the composer textarea. Auto-filled with the next
+  // scripted user line; cleared while the AI is busy.
+  const [composer, setComposer] = useState(SCRIPT[0].userText)
+
+  // Build animation timing (only relevant when phase === "building").
+  const [phaseEnteredAt, setPhaseEnteredAt] = useState<number>(() => Date.now())
+  const [, setTick] = useState(0)
+  const timerRef = useRef<number | null>(null)
+
+  // When the demo phase changes, reset the build animation clock and clean
+  // up any pending typing timer.
+  useEffect(() => {
+    setPhaseEnteredAt(Date.now())
+    if (timerRef.current) {
+      window.clearTimeout(timerRef.current)
+      timerRef.current = null
+    }
+    // configuring restart: rewind the gathering script too. building/running/
+    // completed don't need to reset the script — the user has already gone
+    // through it.
+    if (demoState.phase === "configuring") {
+      setGatherStep(0)
+      setMessages([welcomeMessage(i18n.language)])
+      setChatBusy(false)
+      setComposer(SCRIPT[0].userText)
+    }
+  }, [demoState.phase])
+
+  // Drive a 100ms tick during the build animation so progress / file reveal
+  // / chat lines refresh in flight.
+  useEffect(() => {
+    if (demoState.phase !== "building") return
+    const id = window.setInterval(() => setTick((n) => n + 1), 100)
+    return () => window.clearInterval(id)
+  }, [demoState.phase])
+
+  // Auto-pin the chat scroll to the bottom whenever new content arrives —
+  // either a new message lands, the AI starts/stops typing, or the build
+  // phase appends its synthetic status message.
+  useEffect(() => {
+    messagesEndRef.current?.scrollIntoView({ block: "end", behavior: "smooth" })
+  }, [messages.length, chatBusy, demoState.phase])
+
+  // Cleanup any pending typing timer on unmount.
+  useEffect(() => {
+    return () => {
+      if (timerRef.current) window.clearTimeout(timerRef.current)
+    }
+  }, [])
+
+  const elapsed = Date.now() - phaseEnteredAt
+  const isConfiguring = demoState.phase === "configuring"
+  const isBuilding = demoState.phase === "building"
+  const buildDone = isBuilding && elapsed >= 2400
+
+  // Stage rows for the preview panel — mirrors the live BUILD_STEPS state.
+  const stages: StageRow[] = (() => {
+    if (isConfiguring) {
+      // Within configuring, gathering keeps "running" until the script is
+      // exhausted. (We never sit on configuring after the script is done —
+      // sending the last turn flips us into building — but be defensive.)
+      return [
+        {
+          key: "gathering",
+          state: gatherStep >= SCRIPT.length ? "completed" : "running",
+        },
+        { key: "build", state: "not_started" },
+        { key: "review", state: "not_started" },
+      ]
+    }
+    if (!isBuilding) {
+      return [
+        { key: "gathering", state: "completed" },
+        { key: "build", state: "completed" },
+        { key: "review", state: "completed" },
+      ]
+    }
+    if (buildDone) {
+      return [
+        { key: "gathering", state: "completed" },
+        { key: "build", state: "completed" },
+        { key: "review", state: "completed" },
+      ]
+    }
+    if (elapsed < 1200) {
+      return [
+        { key: "gathering", state: "completed" },
+        { key: "build", state: "running" },
+        { key: "review", state: "not_started" },
+      ]
+    }
+    return [
+      { key: "gathering", state: "completed" },
+      { key: "build", state: "completed" },
+      { key: "review", state: "running" },
+    ]
+  })()
+
+  const completedCount = stages.filter((s) => s.state === "completed").length
+  const total = stages.length
+  const progressPct = (completedCount / total) * 100
+  const filesVisible = isBuilding ? Math.min(3, Math.floor(elapsed / 700) + 1) : 0
+
+  // Send the current composer text. Pushes the user message, schedules the
+  // AI reply, and either pre-fills the next scripted user turn or — when the
+  // last turn fires — flips the demo into the building phase.
+  const handleSend = () => {
+    if (!isConfiguring || chatBusy) return
+    if (gatherStep >= SCRIPT.length) return
+    const turn = SCRIPT[gatherStep]
+    const userText = composer.trim() || turn.userText
+    setMessages((m) => [...m, { role: "user", text: userText }])
+    setComposer("")
+    setChatBusy(true)
+    timerRef.current = window.setTimeout(() => {
+      setMessages((m) => [...m, { role: "ai", text: turn.aiText }])
+      setChatBusy(false)
+      const nextStep = gatherStep + 1
+      setGatherStep(nextStep)
+      if (turn.nextUserText) {
+        setComposer(turn.nextUserText)
+      } else {
+        // Last turn — flip into the build animation.
+        setComposer("")
+        setDemoPhase("building")
+      }
+    }, turn.aiDelayMs)
+  }
+
+  const handleRun = () => {
+    if (!buildDone) return
+    setDemoPhase("running")
+  }
+
+  const STAGE_LABELS: Record<StageRow["key"], string> = {
+    gathering: t("evolution.chatTune.buildSteps.gathering", {
+      defaultValue: "需求分析",
+    }),
+    build: t("evolution.chatTune.buildSteps.build", {
+      defaultValue: "开始构建",
+    }),
+    review: t("evolution.chatTune.buildSteps.review", { defaultValue: "审阅" }),
+  }
+
+  // While building, append a synthetic AI bubble so the chat doesn't go
+  // silent during the 2.4s animation.
+  const buildPhaseMessages: ChatMessage[] = isBuilding
+    ? buildDone
+      ? [
+          {
+            role: "ai",
+            text: t("demoBuild.buildDoneMessage", {
+              defaultValue:
+                "构建完成，三个文件已生成。请在左侧审阅后点击「提交运行」启动进化。",
+            }),
+          },
+        ]
+      : [
+          {
+            role: "ai",
+            text: t("demoBuild.buildingMessage", {
+              defaultValue: "正在生成 config.yaml、evaluator.py、task.py……",
+            }),
+          },
+        ]
+    : []
+  const visibleMessages = [...messages, ...buildPhaseMessages]
+
+  return (
+    <div className="h-full flex flex-col">
+      {/* Header — mirrors ChatTuneView header */}
+      <div className="shrink-0 flex items-center justify-between px-1 pb-2 border-b mb-3">
+        <div className="flex items-center gap-2.5 min-w-0">
+          <span
+            className="flex items-center justify-center size-7 rounded-lg shrink-0 shadow-[0_0_12px] shadow-primary/30"
+            style={{
+              background:
+                "linear-gradient(135deg, color-mix(in srgb, var(--primary) 25%, transparent), color-mix(in srgb, #6366f1 25%, transparent))",
+              border:
+                "1px solid color-mix(in srgb, var(--primary) 40%, transparent)",
+            }}
+          >
+            <Sparkles className="size-3.5 text-primary" />
+          </span>
+          <div className="flex flex-col min-w-0">
+            <span className="text-sm font-semibold leading-tight truncate text-foreground">
+              {t("evolution.chatTune.headerTitle", {
+                defaultValue: "AI 构建",
+              })}
+            </span>
+            <span className="text-[11px] text-muted-foreground leading-tight truncate">
+              {t("evolution.chatTune.headerHint", {
+                defaultValue: "用对话方式让 AI 帮你完成需求分析与配置构建",
+              })}
+            </span>
+          </div>
+        </div>
+        <div className="flex items-center gap-2">
+          {/* Mode switch — visual only in demo, AI is selected */}
+          <div
+            role="tablist"
+            className="inline-flex items-center gap-0.5 p-0.5 rounded-md border border-primary/40 bg-primary/5 shadow-sm"
+          >
+            <button
+              type="button"
+              role="tab"
+              aria-selected="true"
+              className="flex items-center gap-1 px-2.5 py-1 rounded text-xs font-medium bg-primary text-primary-foreground shadow-sm"
+            >
+              <Sparkles className="size-3.5" />
+              <span>
+                {t("evolution.chatTune.modeAi", { defaultValue: "AI 构建" })}
+              </span>
+            </button>
+            <button
+              type="button"
+              role="tab"
+              aria-selected="false"
+              disabled
+              className="flex items-center gap-1 px-2.5 py-1 rounded text-xs font-medium text-muted-foreground/60 cursor-not-allowed"
+            >
+              <Layers className="size-3.5" />
+              <span>
+                {t("evolution.chatTune.modeManual", {
+                  defaultValue: "手动配置",
+                })}
+              </span>
+            </button>
+          </div>
+          {/* Close icon — visual only */}
+          <button
+            type="button"
+            disabled
+            className="p-1.5 rounded-md text-muted-foreground/40 cursor-not-allowed"
+          >
+            <X className="size-4" />
+          </button>
+        </div>
+      </div>
+
+      {/* Body: preview (left, 1/3) + chat (right, 2/3) */}
+      <div className="flex-1 min-h-0 grid grid-cols-1 lg:grid-cols-[minmax(0,1fr)_minmax(0,2fr)] gap-4">
+        {/* Preview column */}
+        <div
+          data-tour="ai-preview"
+          className="min-h-0 flex flex-col rounded-xl border border-border/60 bg-card/70 overflow-hidden"
+        >
+          {/* Build status: progress + stages + files. Tour spotlights this
+              block during the building phase so the highlight doesn't bleed
+              into the Run footer below. */}
+          <div
+            data-tour="ai-preview-body"
+            className="flex-1 min-h-0 flex flex-col"
+          >
+          {/* Progress bar */}
+          <div className="shrink-0 px-4 py-3 border-b border-border/50 bg-muted/30">
+            <div className="flex items-center justify-between mb-2">
+              <span className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                {t("evolution.chatTune.preview.progress", {
+                  defaultValue: "配置进度",
+                })}
+              </span>
+              <span className="text-xs font-semibold text-foreground">
+                {completedCount} / {total}
+              </span>
+            </div>
+            <div className="h-1.5 rounded-full bg-muted overflow-hidden">
+              <div
+                className="h-full bg-linear-to-r from-primary to-emerald-400 transition-[width] duration-300"
+                style={{ width: `${progressPct}%` }}
+              />
+            </div>
+          </div>
+
+          {/* Stage checklist */}
+          <div className="shrink-0 px-4 py-3 border-b border-border/50">
+            <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground mb-2">
+              {t("evolution.chatTune.preview.stages", {
+                defaultValue: "阶段",
+              })}
+            </p>
+            <ul className="space-y-1">
+              {stages.map(({ key, state }) => {
+                const isActive = state === "running"
+                return (
+                  <li
+                    key={key}
+                    className={cn(
+                      "flex items-center gap-2 px-2 py-1.5 rounded-md text-sm transition-colors",
+                      isActive
+                        ? "bg-primary/10 text-primary"
+                        : state === "completed"
+                          ? "text-foreground"
+                          : "text-muted-foreground",
+                    )}
+                  >
+                    <span className="shrink-0 size-4 flex items-center justify-center">
+                      {state === "completed" ? (
+                        <Check className="size-3.5 text-emerald-500" />
+                      ) : isActive ? (
+                        <Loader2 className="size-3.5 animate-spin" />
+                      ) : (
+                        <span className="size-2 rounded-full bg-muted-foreground/30" />
+                      )}
+                    </span>
+                    <span className="flex-1 truncate">{STAGE_LABELS[key]}</span>
+                    {isActive && (
+                      <span className="text-[10px] uppercase tracking-wider opacity-70">
+                        {t("evolution.chatTune.buildStepRunning", {
+                          defaultValue: "进行中",
+                        })}
+                      </span>
+                    )}
+                  </li>
+                )
+              })}
+            </ul>
+          </div>
+
+          {/* Files */}
+          <div className="flex-1 min-h-0 overflow-y-auto px-4 py-3">
+            <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground mb-2">
+              {t("evolution.chatTune.preview.files", {
+                defaultValue: "文件列表",
+              })}
+            </p>
+            {filesVisible === 0 ? (
+              <div className="text-xs text-muted-foreground/60 italic">
+                {t("demoBuild.noFilesYet", {
+                  defaultValue: "AI 完成构建后，生成的文件会在这里出现",
+                })}
+              </div>
+            ) : (
+              <div className="space-y-1.5">
+                {DEMO_AI_BUILD_FILES.map((file, idx) => {
+                  const visible = idx < filesVisible
+                  return (
+                    <div
+                      key={file.name}
+                      className={cn(
+                        "flex items-center gap-2 px-2 py-1.5 rounded-md border text-sm transition-all duration-300",
+                        visible
+                          ? "border-primary/30 bg-primary/5 opacity-100 translate-y-0"
+                          : "border-border/30 bg-transparent opacity-0 translate-y-1 pointer-events-none",
+                      )}
+                    >
+                      <FileCode className="size-3.5 text-primary shrink-0" />
+                      <span className="font-mono text-xs truncate flex-1">
+                        {file.name}
+                      </span>
+                      <span className="text-[10px] uppercase tracking-wider text-muted-foreground shrink-0">
+                        {file.language}
+                      </span>
+                    </div>
+                  )
+                })}
+              </div>
+            )}
+          </div>
+          </div>
+
+          {/* Run button — bottom border-t */}
+          <div
+            data-tour="ai-run"
+            className="shrink-0 px-3 py-2.5 border-t border-border/50 space-y-2"
+          >
+            {!buildDone && (
+              <div className="flex items-center gap-1.5 px-2 py-1.5 rounded-md text-[11px] bg-muted/60 border border-border/50 text-muted-foreground">
+                <CircleAlert className="size-3 shrink-0" />
+                <span>
+                  {t("evolution.chatTune.runHintNeedBuild", {
+                    defaultValue: "完成 AI 构建后即可提交运行",
+                  })}
+                </span>
+              </div>
+            )}
+            <button
+              type="button"
+              onClick={handleRun}
+              disabled={!buildDone}
+              className={cn(
+                "w-full inline-flex items-center justify-center gap-1.5 h-9 px-4 rounded-md text-sm font-medium transition-all",
+                buildDone
+                  ? "bg-primary text-primary-foreground shadow-md hover:shadow-lg"
+                  : "bg-primary/30 text-primary-foreground/60 cursor-not-allowed",
+              )}
+            >
+              <Play className="size-3.5" />
+              {t("evolution.confirmStep.submitRun", {
+                defaultValue: "提交运行",
+              })}
+            </button>
+          </div>
+        </div>
+
+        {/* Chat column */}
+        <div
+          data-tour="ai-chat-panel"
+          className="min-h-0 flex flex-col rounded-xl border border-border/60 bg-card/70 overflow-hidden"
+        >
+          {/* Messages */}
+          <div className="flex-1 min-h-0 overflow-y-auto p-4 space-y-3">
+            {visibleMessages.map((msg, idx) => {
+              if (msg.role === "system") {
+                return (
+                  <div
+                    key={idx}
+                    className="flex gap-2 animate-in fade-in slide-in-from-bottom-1 duration-200"
+                  >
+                    <div className="shrink-0 flex items-center justify-center size-7 rounded-lg bg-muted border border-border/50">
+                      <Monitor className="size-3.5 text-muted-foreground" />
+                    </div>
+                    <div className="min-w-0 flex-1">
+                      <div className="rounded-2xl rounded-tl-sm border border-dashed border-muted-foreground/30 bg-muted/40 px-3.5 py-2 text-sm leading-relaxed text-muted-foreground whitespace-pre-wrap">
+                        {msg.text}
+                      </div>
+                    </div>
+                    <div className="shrink-0 size-7 invisible" />
+                  </div>
+                )
+              }
+              const isUser = msg.role === "user"
+              return (
+                <div
+                  key={idx}
+                  className="flex gap-2 animate-in fade-in slide-in-from-bottom-1 duration-200"
+                >
+                  {/* AI avatar (left) — placeholder for user to keep alignment */}
+                  <div
+                    className={cn(
+                      "shrink-0 size-7 rounded-lg",
+                      isUser && "invisible",
+                    )}
+                  >
+                    {!isUser && (
+                      <div className="size-full flex items-center justify-center bg-primary/10 border border-primary/20 rounded-lg">
+                        <Bot className="size-3.5 text-primary" />
+                      </div>
+                    )}
+                  </div>
+                  <div className="min-w-0 flex-1 flex flex-col gap-2">
+                    <div
+                      className={cn(
+                        "rounded-2xl px-3.5 py-2 text-sm leading-relaxed shadow-sm min-w-0 [overflow-wrap:anywhere]",
+                        isUser
+                          ? "bg-primary text-primary-foreground rounded-tr-sm whitespace-pre-wrap self-end max-w-[85%]"
+                          : "bg-gradient-to-br from-muted to-muted/60 border border-border/50 text-foreground rounded-tl-sm whitespace-pre-wrap min-h-[44px] flex flex-col justify-center max-w-[90%]",
+                      )}
+                    >
+                      {msg.text}
+                    </div>
+                  </div>
+                </div>
+              )
+            })}
+            {chatBusy && (
+              <div className="flex gap-2 animate-in fade-in slide-in-from-bottom-1 duration-200">
+                <div className="shrink-0 size-7 rounded-lg flex items-center justify-center bg-primary/10 border border-primary/20">
+                  <Bot className="size-3.5 text-primary" />
+                </div>
+                <div className="rounded-2xl rounded-tl-sm bg-gradient-to-br from-muted to-muted/60 border border-border/50 px-3.5 py-2.5">
+                  <span className="inline-flex gap-1">
+                    <span className="size-1.5 rounded-full bg-current animate-bounce" />
+                    <span
+                      className="size-1.5 rounded-full bg-current animate-bounce"
+                      style={{ animationDelay: "0.15s" }}
+                    />
+                    <span
+                      className="size-1.5 rounded-full bg-current animate-bounce"
+                      style={{ animationDelay: "0.3s" }}
+                    />
+                  </span>
+                </div>
+              </div>
+            )}
+            <div ref={messagesEndRef} />
+          </div>
+
+          {/* Composer — mirrors the real textarea + send button */}
+          <div className="shrink-0 px-3 pb-3 pt-2">
+            <div
+              data-tour="ai-composer"
+              className={cn(
+                "relative rounded-2xl border-2 backdrop-blur-md transition-all duration-200",
+                isConfiguring && !chatBusy
+                  ? "shadow-lg shadow-primary/8 border-primary/20 bg-card/95"
+                  : "border-border/20 bg-card/80 opacity-60",
+              )}
+            >
+              <div className="px-4 pt-3 pb-1">
+                <textarea
+                  value={composer}
+                  onChange={(e) => setComposer(e.target.value)}
+                  placeholder={
+                    chatBusy
+                      ? t("evolution.chatTune.composerGenerating", {
+                          defaultValue: "AI 正在回复，请稍候...",
+                        })
+                      : t("evolution.chatTune.composerActive", {
+                          defaultValue: "用对话告诉 AI 你的需求...",
+                        })
+                  }
+                  className="w-full resize-none border-0 bg-transparent text-sm leading-relaxed placeholder:text-muted-foreground/60 focus:outline-none min-h-[40px]"
+                  disabled={!isConfiguring || chatBusy}
+                />
+              </div>
+              <div className="flex items-center justify-between px-3 pb-2.5">
+                <div className="flex items-center gap-1.5">
+                  <button
+                    type="button"
+                    disabled
+                    className="size-7 flex items-center justify-center rounded-lg text-muted-foreground/50 cursor-not-allowed"
+                  >
+                    <ChevronsUpDown className="size-3.5" />
+                  </button>
+                </div>
+                <button
+                  type="button"
+                  data-tour="ai-send"
+                  onClick={handleSend}
+                  disabled={!isConfiguring || chatBusy || !composer.trim()}
+                  className={cn(
+                    "inline-flex items-center gap-1.5 h-8 px-4 rounded-xl text-xs font-medium transition-all duration-200",
+                    isConfiguring && !chatBusy && composer.trim()
+                      ? "bg-primary text-primary-foreground shadow-md shadow-primary/25 hover:shadow-lg"
+                      : "bg-primary/10 text-primary/40 cursor-not-allowed",
+                  )}
+                >
+                  <Send className="size-3.5" />
+                  <span>
+                    {t("evolution.chatTune.send", { defaultValue: "发送" })}
+                  </span>
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/frontend/src/components/Evolution/TaskDetail/InitializedView.tsx
+++ b/src/frontend/src/components/Evolution/TaskDetail/InitializedView.tsx
@@ -10,6 +10,7 @@ import { useCallback, useEffect, useState } from "react"
 import { useTranslation } from "react-i18next"
 import type { TaskResponse } from "@/client"
 import { UtilsCodeServerService } from "@/client"
+import OnboardingTour from "@/components/Onboarding/OnboardingTour"
 import { useTheme } from "@/components/theme-provider"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import {
@@ -18,9 +19,9 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip"
+import { DEMO_BEST_CODE, isDemoTaskId } from "@/data/demoFixtures"
 import { useEvolution } from "@/hooks/useEvolution"
 import { cn } from "@/lib/utils"
-import OnboardingTour from "@/components/Onboarding/OnboardingTour"
 import InsightsSplitView from "./InsightsSplitView"
 import MultiPanelLayout from "./MultiPanelLayout"
 import RenderSplitView from "./RenderSplitView"
@@ -66,10 +67,13 @@ export default function InitializedView({ task }: InitializedViewProps) {
   }
 
   useEffect(() => {
+    // Demo tasks render a static code block in the IDE tab; skip the real
+    // code-server token fetch which would 404 against the live nginx proxy.
+    if (isDemoTaskId(task.id)) return
     if (activeTab === "ide" && ideState === "idle") {
       loadCodeToken()
     }
-  }, [activeTab, ideState, loadCodeToken])
+  }, [activeTab, ideState, loadCodeToken, task.id])
 
   const handleRefreshIDE = () => {
     if (isRefreshing) return
@@ -138,6 +142,7 @@ export default function InitializedView({ task }: InitializedViewProps) {
         </TabsTrigger>
         <TabsTrigger
           value="ide"
+          data-tour="demo-best-summary"
           className="font-bold text-sm gap-1.5 data-[state=active]:bg-primary/15 data-[state=active]:text-primary data-[state=active]:shadow-[0_0_10px] data-[state=active]:shadow-primary/15"
         >
           <Code className="size-3.5" />
@@ -200,42 +205,62 @@ export default function InitializedView({ task }: InitializedViewProps) {
       </TabsContent>
 
       <TabsContent value="ide" className="flex-1 min-h-0">
-        {ideState === "loading" && (
-          <div className="flex items-center justify-center rounded-lg border border-dashed bg-card/50 p-16">
-            <Loader2 className="mr-2 h-5 w-5 animate-spin" />
-            <span className="text-muted-foreground">
-              {t("evolution.startingIDE")}
-            </span>
+        {isDemoTaskId(task.id) ? (
+          <div
+            data-tour="demo-ide-code"
+            className="h-full rounded-lg border bg-card/60 backdrop-blur flex flex-col overflow-hidden"
+          >
+            <div className="shrink-0 px-4 py-2.5 border-b border-border/60 flex items-center gap-2 text-xs">
+              <Code className="size-3.5 text-primary" />
+              <span className="font-mono text-foreground">solve.py</span>
+              <span className="ml-auto text-[10px] uppercase tracking-wider text-muted-foreground">
+                {t("evolution.tabs.ide")}
+              </span>
+            </div>
+            <pre className="flex-1 min-h-0 overflow-auto px-4 py-4 text-xs leading-relaxed font-mono text-foreground/90 bg-background/30">
+              <code>{DEMO_BEST_CODE}</code>
+            </pre>
           </div>
-        )}
-        {ideState === "error" && (
-          <div className="flex flex-col items-center justify-center gap-3 rounded-lg border border-destructive bg-card/50 p-16">
-            <p className="text-destructive">{ideError}</p>
-            <button
-              type="button"
-              className="text-sm text-primary underline"
-              onClick={() => {
-                setIdeState("idle")
-                handleTabChange("ide")
-              }}
-            >
-              {t("common.retry")}
-            </button>
-          </div>
-        )}
-        {ideState === "success" && (
-          <div className="h-full">
-            <iframe
-              key={iframeKey}
-              id="vscodeFrame"
-              className="w-full h-full border rounded-lg"
-              src={`${import.meta.env.VITE_CODE_SERVER_URL || "/code_ide"}/?folder=/data/project_home/${task.id}/${selectedNodes.length === 1 ? `llm4ad/run/generated/` : ""}`}
-              title={t("evolution.vsCodeTitle")}
-              allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; fullscreen"
-              sandbox="allow-same-origin allow-scripts allow-popups allow-forms allow-modals allow-downloads allow-presentation"
-              loading="lazy"
-            />
-          </div>
+        ) : (
+          <>
+            {ideState === "loading" && (
+              <div className="flex items-center justify-center rounded-lg border border-dashed bg-card/50 p-16">
+                <Loader2 className="mr-2 h-5 w-5 animate-spin" />
+                <span className="text-muted-foreground">
+                  {t("evolution.startingIDE")}
+                </span>
+              </div>
+            )}
+            {ideState === "error" && (
+              <div className="flex flex-col items-center justify-center gap-3 rounded-lg border border-destructive bg-card/50 p-16">
+                <p className="text-destructive">{ideError}</p>
+                <button
+                  type="button"
+                  className="text-sm text-primary underline"
+                  onClick={() => {
+                    setIdeState("idle")
+                    handleTabChange("ide")
+                  }}
+                >
+                  {t("common.retry")}
+                </button>
+              </div>
+            )}
+            {ideState === "success" && (
+              <div className="h-full">
+                <iframe
+                  key={iframeKey}
+                  id="vscodeFrame"
+                  className="w-full h-full border rounded-lg"
+                  src={`${import.meta.env.VITE_CODE_SERVER_URL || "/code_ide"}/?folder=/data/project_home/${task.id}/${selectedNodes.length === 1 ? `llm4ad/run/generated/` : ""}`}
+                  title={t("evolution.vsCodeTitle")}
+                  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; fullscreen"
+                  sandbox="allow-same-origin allow-scripts allow-popups allow-forms allow-modals allow-downloads allow-presentation"
+                  loading="lazy"
+                />
+              </div>
+            )}
+          </>
         )}
       </TabsContent>
     </Tabs>

--- a/src/frontend/src/components/Evolution/TaskDetail/TaskDetail.tsx
+++ b/src/frontend/src/components/Evolution/TaskDetail/TaskDetail.tsx
@@ -4,9 +4,12 @@ import { useEffect, useState } from "react"
 import { useTranslation } from "react-i18next"
 
 import { Llm4AdTasksService } from "@/client"
+import { DEMO_TASK, isDemoTaskId } from "@/data/demoFixtures"
+import { useDemoState } from "@/hooks/useDemoMode"
 import { useEvolution } from "@/hooks/useEvolution"
 
 import ChatTuneView from "./ChatTuneView"
+import DemoBuildView from "./DemoBuildView"
 import InitializedView from "./InitializedView"
 import UninitializedView from "./UninitializedView"
 
@@ -24,15 +27,20 @@ export default function TaskDetail({ taskId }: TaskDetailProps) {
     isViewingAiBuildHistory,
     forceManualConfigTaskId,
   } = useEvolution()
+  const demoState = useDemoState()
   const [tuneMode, setTuneMode] = useState<TuneMode>("chat")
   // Reset to AI chat panel whenever the active task changes — otherwise a prior
   // task's "switched to stepper" state leaks into a freshly created AI task.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: intentional reset on taskId change
   useEffect(() => {
     setTuneMode("chat")
   }, [taskId])
   const { data: task, isLoading } = useQuery({
     queryKey: ["getTask", taskId],
-    queryFn: () => Llm4AdTasksService.getTask({ taskId }),
+    queryFn: () =>
+      isDemoTaskId(taskId)
+        ? Promise.resolve(DEMO_TASK)
+        : Llm4AdTasksService.getTask({ taskId }),
     enabled: !!taskId,
   })
 
@@ -50,6 +58,21 @@ export default function TaskDetail({ taskId }: TaskDetailProps) {
         <p className="text-muted-foreground">{t("evolution.cannotLoadTask")}</p>
       </div>
     )
+  }
+
+  // Demo mode dispatch: the simulated task swaps panels as the user clicks
+  // through the tour. uninitialized/configuring/building → fake AI Build panel
+  // (with progress + file animation); running/completed → real result view
+  // backed by fixture data.
+  if (isDemoTaskId(task.id)) {
+    if (
+      demoState.phase === "uninitialized" ||
+      demoState.phase === "configuring" ||
+      demoState.phase === "building"
+    ) {
+      return <DemoBuildView />
+    }
+    return <InitializedView task={task} />
   }
 
   // AI build history → reuse the AI panel. Running/pending tasks are read-only

--- a/src/frontend/src/components/Evolution/TaskVersionTree.tsx
+++ b/src/frontend/src/components/Evolution/TaskVersionTree.tsx
@@ -24,6 +24,7 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover"
+import { DEMO_TASK, isDemoTaskId } from "@/data/demoFixtures"
 import useCustomToast from "@/hooks/useCustomToast"
 import { useEvolution } from "@/hooks/useEvolution"
 import { INPUT_LIMITS } from "@/lib/inputLimits"
@@ -213,7 +214,23 @@ export default function TaskVersionTree() {
 
   const treeQuery = useQuery({
     queryKey: taskKeys.tree(rootId),
-    queryFn: () => Llm4AdTasksService.getTaskTree({ taskId: rootId }),
+    queryFn: (): Promise<TaskTreeResponse> => {
+      if (isDemoTaskId(rootId)) {
+        return Promise.resolve({
+          root: {
+            id: DEMO_TASK.id,
+            name: DEMO_TASK.name,
+            description: DEMO_TASK.description,
+            status: DEMO_TASK.status,
+            created_time: DEMO_TASK.created_time,
+            updated_time: DEMO_TASK.updated_time,
+            project_id: DEMO_TASK.project_id,
+          },
+          children: [],
+        })
+      }
+      return Llm4AdTasksService.getTaskTree({ taskId: rootId })
+    },
     enabled: !!rootId,
   })
 

--- a/src/frontend/src/components/Onboarding/DemoEvolutionTour.tsx
+++ b/src/frontend/src/components/Onboarding/DemoEvolutionTour.tsx
@@ -1,0 +1,693 @@
+import { useNavigate } from "@tanstack/react-router"
+import { useEffect, useMemo, useRef, useState } from "react"
+import { createPortal } from "react-dom"
+import { useTranslation } from "react-i18next"
+import type { DemoPhase } from "@/hooks/useDemoMode"
+import { setDemoPhase, useDemoState } from "@/hooks/useDemoMode"
+import { useEvolution } from "@/hooks/useEvolution"
+
+/**
+ * Phase-driven walkthrough for the demo project. Unlike the generic
+ * OnboardingTour which advances on click, this overlay tracks the demo phase
+ * and follows the user as they perform real interactions (create the task,
+ * send, run). The Next button is offered as an escape hatch when the user
+ * just wants the simulation to keep moving without clicking the underlying
+ * controls.
+ */
+
+interface Step {
+  /** CSS selector for the highlighted element. */
+  selector: string
+  /** Phase this step belongs to. */
+  phase: DemoPhase
+  /** i18n key for the title. */
+  titleKey: string
+  /** i18n key for the body. */
+  contentKey: string
+  /** Default text if i18n key is missing. */
+  titleFallback: string
+  /** Default body if i18n key is missing. */
+  contentFallback: string
+  /** Where to place the tooltip relative to the spotlight. */
+  placement?: "top" | "bottom" | "left" | "right"
+  /**
+   * If true, this step has no underlying button — the user advances by
+   * clicking an "I see" button on the tooltip itself. When the step is the
+   * LAST one in its phase, clicking the button instead transitions the demo
+   * to `manualNextPhase`.
+   */
+  manualNext?: boolean
+  /**
+   * When `manualNext` is true and this is the last step in the phase, advance
+   * to this phase on click instead of stepping within the current phase.
+   */
+  manualNextPhase?: DemoPhase
+  /**
+   * If true, automatically advance to this step the moment its anchor element
+   * mounts in the DOM. Use it for steps that are gated by a UI surface
+   * appearing (e.g. opening a dialog) rather than by the user clicking a
+   * specific button.
+   */
+  autoAdvanceOnAnchor?: boolean
+  /**
+   * Optional inner element to highlight with a secondary pulse ring inside
+   * the main spotlight — used to point the user at the specific button
+   * (e.g. 创建, 发送) within a larger highlighted region (the dialog, the
+   * chat panel) without occluding the surrounding context.
+   */
+  pulseSelector?: string
+}
+
+const STEPS: Step[] = [
+  {
+    phase: "uninitialized",
+    selector: '[data-tour="new-task-btn"]',
+    titleKey: "demoTour.create.title",
+    contentKey: "demoTour.create.content",
+    titleFallback: "Step 1 · Open the new-task dialog",
+    contentFallback:
+      "Click 新建任务 to open the create-task dialog. We'll walk through choosing AI build and naming the task next.",
+    placement: "bottom",
+  },
+  {
+    phase: "uninitialized",
+    selector: '[data-tour="create-task-dialog"]',
+    titleKey: "demoTour.createSubmit.title",
+    contentKey: "demoTour.createSubmit.content",
+    titleFallback: "Step 1b · Pick AI build and create",
+    contentFallback:
+      "AI 构建 is already selected for this demo. The task name is pre-filled — click 创建 to start the simulated AI-build session.",
+    placement: "right",
+    autoAdvanceOnAnchor: true,
+    // Inner pulse ring on the 创建 button so the user knows to click it.
+    pulseSelector: '[data-tour="create-task-submit"]',
+  },
+  {
+    phase: "configuring",
+    selector: '[data-tour="demo-task-row"]',
+    titleKey: "demoTour.taskRow.title",
+    contentKey: "demoTour.taskRow.content",
+    titleFallback: "Step 2 · Your task is in the sidebar",
+    contentFallback:
+      "The task you just created shows up in the left task list. Real projects can have many tasks here — click any row to switch between them.",
+    placement: "right",
+    manualNext: true,
+  },
+  {
+    phase: "configuring",
+    selector: '[data-tour="ai-chat-panel"]',
+    titleKey: "demoTour.send.title",
+    contentKey: "demoTour.send.content",
+    titleFallback: "Step 3 · Chat with the AI",
+    contentFallback:
+      "The AI greets you in the composer. Click 发送 to send each turn — the AI will gather requirements, then ask if you want to start building. The build kicks off after you send 「开始构建」.",
+    placement: "left",
+    // Pulse the Send button so the user knows what to click without occluding
+    // the surrounding chat history.
+    pulseSelector: '[data-tour="ai-send"]',
+  },
+  {
+    phase: "building",
+    selector: '[data-tour="ai-preview-body"]',
+    titleKey: "demoTour.building.title",
+    contentKey: "demoTour.building.content",
+    titleFallback: "Step 3 · Watch the AI work",
+    contentFallback:
+      "The left panel shows the build pipeline: 配置进度 fills as the AI moves through 需求分析 → 开始构建 → 审阅. Generated files appear in 文件列表 below.",
+    placement: "right",
+    manualNext: true,
+  },
+  {
+    phase: "building",
+    selector: '[data-tour="ai-run"]',
+    titleKey: "demoTour.run.title",
+    contentKey: "demoTour.run.content",
+    titleFallback: "Step 4 · Submit the run",
+    contentFallback:
+      "Build is done. Click 提交运行 at the bottom of the left panel to start the evolution loop — candidates appear one generation at a time.",
+    placement: "top",
+  },
+  {
+    phase: "running",
+    selector: '[data-tour="result-canvas"]',
+    titleKey: "demoTour.canvas.title",
+    contentKey: "demoTour.canvas.content",
+    titleFallback: "Step 5 · The evolution graph",
+    contentFallback:
+      "Each node is one candidate. Edges connect a candidate to its parents; color encodes the score. Watch as the graph fills in.",
+    placement: "right",
+    // No real button to click here either — let the user dismiss when ready.
+    manualNext: true,
+    manualNextPhase: "completed",
+  },
+  {
+    phase: "completed",
+    selector: '[data-tour="demo-best-summary"]',
+    titleKey: "demoTour.ide.title",
+    contentKey: "demoTour.ide.content",
+    titleFallback: "Step 7 · Read the final algorithm",
+    contentFallback:
+      "Click the IDE tab to read the algorithm LLM4AD synthesized — in a real run this is the code you'd copy into your project.",
+    // bottom keeps the tooltip clear of the IDE button itself.
+    placement: "bottom",
+    // No "Got it" here — the user has to actually click the IDE tab to
+    // proceed. The activeTab listener jumps the tour to the next sub-step on
+    // the transition into "ide".
+  },
+  {
+    phase: "completed",
+    selector: '[data-tour="demo-ide-code"]',
+    titleKey: "demoTour.ideCode.title",
+    contentKey: "demoTour.ideCode.content",
+    titleFallback: "Step 8 · Read the generated code",
+    contentFallback:
+      "This is the algorithm LLM4AD evolved — a greedy nearest-neighbor with 2-opt refinement. Skim through it, then click 了解 to wrap up.",
+    placement: "left",
+    manualNext: true,
+  },
+  {
+    phase: "completed",
+    selector: '[data-tour="demo-exit"]',
+    titleKey: "demoTour.exit.title",
+    contentKey: "demoTour.exit.content",
+    titleFallback: "You're ready",
+    contentFallback:
+      "Head back to the project list, configure an LLM provider, and create your first real project. The walkthrough is always one click away from your user menu.",
+    placement: "bottom",
+  },
+]
+
+const PHASE_ORDER: DemoPhase[] = [
+  "uninitialized",
+  "configuring",
+  "building",
+  "running",
+  "completed",
+]
+
+const PADDING = 6
+const TOOLTIP_WIDTH = 340
+const TOOLTIP_GAP = 12
+const VIEWPORT_MARGIN = 12
+
+interface Rect {
+  top: number
+  left: number
+  width: number
+  height: number
+}
+
+function getRect(el: Element): Rect {
+  const r = el.getBoundingClientRect()
+  return { top: r.top, left: r.left, width: r.width, height: r.height }
+}
+
+function placeTooltip(
+  rect: Rect,
+  preferred: Step["placement"],
+  tooltipHeight: number,
+): { top: number; left: number } {
+  const vw = window.innerWidth
+  const vh = window.innerHeight
+  let top = 0
+  let left = 0
+  switch (preferred ?? "bottom") {
+    case "top":
+      top = rect.top - TOOLTIP_GAP - tooltipHeight
+      left = rect.left + rect.width / 2 - TOOLTIP_WIDTH / 2
+      break
+    case "bottom":
+      top = rect.top + rect.height + TOOLTIP_GAP
+      left = rect.left + rect.width / 2 - TOOLTIP_WIDTH / 2
+      break
+    case "left":
+      top = rect.top + rect.height / 2 - tooltipHeight / 2
+      left = rect.left - TOOLTIP_GAP - TOOLTIP_WIDTH
+      break
+    case "right":
+      top = rect.top + rect.height / 2 - tooltipHeight / 2
+      left = rect.left + rect.width + TOOLTIP_GAP
+      break
+  }
+  left = Math.max(
+    VIEWPORT_MARGIN,
+    Math.min(left, vw - TOOLTIP_WIDTH - VIEWPORT_MARGIN),
+  )
+  top = Math.max(
+    VIEWPORT_MARGIN,
+    Math.min(top, vh - tooltipHeight - VIEWPORT_MARGIN),
+  )
+  return { top, left }
+}
+
+export default function DemoEvolutionTour() {
+  const { t } = useTranslation()
+  const navigate = useNavigate()
+  const demoState = useDemoState()
+  const { activeTab } = useEvolution()
+  // Within a phase that has multiple steps (building has 2), track which one
+  // is active. Reset whenever the phase changes.
+  const [subStepIdx, setSubStepIdx] = useState(0)
+  const [rect, setRect] = useState<Rect | null>(null)
+  // Optional inner pulse ring rect (e.g. the Send button inside the chat
+  // panel) — kept separate from the main spotlight rect so the two can move
+  // independently as the underlying layout shifts.
+  const [pulseRect, setPulseRect] = useState<Rect | null>(null)
+  const [tooltipHeight, setTooltipHeight] = useState(180)
+  const [tooltipPos, setTooltipPos] = useState<{ top: number; left: number }>({
+    top: 0,
+    left: 0,
+  })
+  const tooltipRef = useRef<HTMLDivElement | null>(null)
+
+  // Reset sub-step index whenever the demo phase changes — every phase opens
+  // on its first matching step. Also flush the spotlight rect so we don't
+  // briefly render against an anchor that just unmounted (e.g. the create-task
+  // dialog after the user clicked 创建).
+  // biome-ignore lint/correctness/useExhaustiveDependencies: only re-fire on phase change
+  useEffect(() => {
+    setSubStepIdx(0)
+    setRect(null)
+    setPulseRect(null)
+  }, [demoState.phase])
+
+  // The IDE step has no "Got it" button — it advances when the user actually
+  // clicks the IDE tab. Track previous activeTab so we only fire on the
+  // transition into "ide", otherwise hitting Back to the IDE step would
+  // immediately bounce forward again because activeTab is still "ide".
+  const prevTabRef = useRef<string | null>(null)
+  useEffect(() => {
+    const prev = prevTabRef.current
+    prevTabRef.current = activeTab
+    if (demoState.phase !== "completed") return
+    if (subStepIdx !== 0) return
+    if (prev !== "ide" && activeTab === "ide") {
+      setSubStepIdx(1)
+    }
+  }, [demoState.phase, subStepIdx, activeTab])
+
+  // Auto-advance to the next sub-step when its anchor appears in the DOM —
+  // but only when that step opted in via `autoAdvanceOnAnchor`. This is how
+  // opening the New Task dialog hops the tour onto its create-task-submit
+  // anchor without requiring a manual click.
+  useEffect(() => {
+    const matching = STEPS.filter((s) => s.phase === demoState.phase)
+    const next = matching[subStepIdx + 1]
+    if (!next?.autoAdvanceOnAnchor) return
+    let cancelled = false
+    const tick = () => {
+      if (cancelled) return
+      const el = document.querySelector(next.selector) as HTMLElement | null
+      if (el) {
+        const r = el.getBoundingClientRect()
+        if (r.width > 0 && r.height > 0) {
+          setSubStepIdx((i) => i + 1)
+          return
+        }
+      }
+      window.setTimeout(tick, 200)
+    }
+    const id = window.setTimeout(tick, 200)
+    return () => {
+      cancelled = true
+      window.clearTimeout(id)
+    }
+  }, [demoState.phase, subStepIdx])
+
+  const currentStep = useMemo(() => {
+    const matching = STEPS.filter((s) => s.phase === demoState.phase)
+    const idx = Math.min(subStepIdx, matching.length - 1)
+    return matching[idx] ?? null
+  }, [demoState.phase, subStepIdx])
+
+  // Locate the highlighted element. Retry a few times because some anchors
+  // mount only after a phase transition (e.g. result-canvas after running).
+  useEffect(() => {
+    if (!currentStep) return
+    // Clear the previous spotlight rect immediately so the overlay doesn't
+    // render against a stale (or zero-sized post-unmount) bounding box while
+    // the new anchor is still mounting — that's what produced the "tooltip
+    // glued to the top-left corner" symptom when the user used Skip ahead.
+    setRect(null)
+    let cancelled = false
+    let attempts = 0
+    const tick = () => {
+      if (cancelled) return
+      const el = document.querySelector(currentStep.selector)
+      if (el) {
+        const r = getRect(el)
+        // Reject zero-sized rects — the element exists but is detached or
+        // not laid out yet. Keep retrying until it has real geometry.
+        if (r.width > 0 && r.height > 0) {
+          setRect(r)
+          return
+        }
+      }
+      attempts += 1
+      if (attempts < 40) window.setTimeout(tick, 100)
+    }
+    tick()
+    const onUpdate = () => {
+      const el = document.querySelector(currentStep.selector)
+      if (!el) return
+      const r = getRect(el)
+      if (r.width > 0 && r.height > 0) setRect(r)
+    }
+    // Poll for anchor disappearance — dialogs that close don't fire scroll/
+    // resize, but their anchor is gone afterwards. If the element vanishes,
+    // clear the rect so the stale spotlight doesn't linger over empty space.
+    const presenceCheck = window.setInterval(() => {
+      const el = document.querySelector(currentStep.selector)
+      if (!el) {
+        setRect(null)
+        return
+      }
+      const r = getRect(el)
+      if (r.width === 0 || r.height === 0) setRect(null)
+    }, 250)
+    window.addEventListener("resize", onUpdate)
+    window.addEventListener("scroll", onUpdate, true)
+    return () => {
+      cancelled = true
+      window.clearInterval(presenceCheck)
+      window.removeEventListener("resize", onUpdate)
+      window.removeEventListener("scroll", onUpdate, true)
+    }
+  }, [currentStep])
+
+  // Track the optional inner pulse target. Mirrors the main locator but for
+  // pulseSelector — runs independently so the inner ring can settle even
+  // after the outer rect is already on-screen.
+  useEffect(() => {
+    setPulseRect(null)
+    if (!currentStep?.pulseSelector) return
+    const sel = currentStep.pulseSelector
+    let cancelled = false
+    let attempts = 0
+    const tick = () => {
+      if (cancelled) return
+      const el = document.querySelector(sel)
+      if (el) {
+        const r = getRect(el)
+        if (r.width > 0 && r.height > 0) {
+          setPulseRect(r)
+          return
+        }
+      }
+      attempts += 1
+      if (attempts < 40) window.setTimeout(tick, 100)
+    }
+    tick()
+    const onUpdate = () => {
+      const el = document.querySelector(sel)
+      if (!el) return
+      const r = getRect(el)
+      if (r.width > 0 && r.height > 0) setPulseRect(r)
+    }
+    window.addEventListener("resize", onUpdate)
+    window.addEventListener("scroll", onUpdate, true)
+    return () => {
+      cancelled = true
+      window.removeEventListener("resize", onUpdate)
+      window.removeEventListener("scroll", onUpdate, true)
+    }
+  }, [currentStep])
+
+  // Recompute tooltip position whenever the spotlight rect or tooltip size
+  // changes (the latter happens once on first paint after measurement).
+  useEffect(() => {
+    if (!rect || !currentStep) return
+    setTooltipPos(placeTooltip(rect, currentStep.placement, tooltipHeight))
+  }, [rect, currentStep, tooltipHeight])
+
+  // Measure tooltip height after render so the clamp keeps it on-screen.
+  useEffect(() => {
+    if (!tooltipRef.current) return
+    const h = tooltipRef.current.getBoundingClientRect().height
+    if (h > 0 && Math.abs(h - tooltipHeight) > 1) setTooltipHeight(h)
+  })
+
+  if (!currentStep || !rect) return null
+
+  const handleExit = () => {
+    // Route away from the demo URL — the evolution layout's cleanup effect
+    // calls exitDemo() on unmount, which clears the demo state in one place
+    // instead of trying to keep two sources of truth in sync.
+    navigate({ to: "/projects" })
+  }
+
+  const handleBack = () => {
+    // Walk back inside the current phase first; if we're already on the
+    // phase's first step, drop to the previous phase and land on its last
+    // step so the user sees the panel that pushed them forward.
+    if (subStepIdx > 0) {
+      setSubStepIdx((i) => i - 1)
+      return
+    }
+    const phaseIdx = PHASE_ORDER.indexOf(demoState.phase)
+    if (phaseIdx <= 0) return
+    const prevPhase = PHASE_ORDER[phaseIdx - 1]
+    const prevSteps = STEPS.filter((s) => s.phase === prevPhase)
+    setDemoPhase(prevPhase)
+    // The phase-change effect resets subStepIdx to 0; schedule the last-index
+    // jump on the next tick so it doesn't get clobbered.
+    window.setTimeout(() => setSubStepIdx(prevSteps.length - 1), 0)
+  }
+
+  // First step of the very first phase has nothing to go back to.
+  const canGoBack =
+    subStepIdx > 0 || PHASE_ORDER.indexOf(demoState.phase) > 0
+
+  // Spotlight visuals
+  const isDark =
+    typeof document !== "undefined" &&
+    document.documentElement.classList.contains("dark")
+  const overlayBg = "rgba(0, 8, 24, 0.55)"
+  const ringColor = isDark
+    ? "rgba(0, 212, 255, 0.85)"
+    : "rgba(37, 99, 235, 0.9)"
+  const ringGlow = isDark
+    ? "rgba(0, 212, 255, 0.45)"
+    : "rgba(37, 99, 235, 0.35)"
+  const tooltipBorder = isDark
+    ? "rgba(0, 212, 255, 0.35)"
+    : "rgba(37, 99, 235, 0.25)"
+  const cutout = {
+    top: rect.top - PADDING,
+    left: rect.left - PADDING,
+    width: rect.width + PADDING * 2,
+    height: rect.height + PADDING * 2,
+  }
+
+  const totalSteps = STEPS.length
+  const stepNumber = STEPS.indexOf(currentStep) + 1
+
+  return createPortal(
+    <div
+      style={{
+        position: "fixed",
+        inset: 0,
+        zIndex: 9999,
+        pointerEvents: "none",
+      }}
+    >
+      {/* Four overlay rectangles around the spotlight cutout. They allow
+          clicks to pass through over the highlighted element so the user can
+          actually press the underlying button. */}
+      <div
+        style={{
+          position: "fixed",
+          top: 0,
+          left: 0,
+          right: 0,
+          height: Math.max(0, cutout.top),
+          background: overlayBg,
+        }}
+      />
+      <div
+        style={{
+          position: "fixed",
+          top: cutout.top + cutout.height,
+          left: 0,
+          right: 0,
+          bottom: 0,
+          background: overlayBg,
+        }}
+      />
+      <div
+        style={{
+          position: "fixed",
+          top: cutout.top,
+          left: 0,
+          width: Math.max(0, cutout.left),
+          height: cutout.height,
+          background: overlayBg,
+        }}
+      />
+      <div
+        style={{
+          position: "fixed",
+          top: cutout.top,
+          left: cutout.left + cutout.width,
+          right: 0,
+          height: cutout.height,
+          background: overlayBg,
+        }}
+      />
+
+      {/* Highlight ring (purely decorative, doesn't block clicks). */}
+      <div
+        style={{
+          position: "fixed",
+          top: cutout.top,
+          left: cutout.left,
+          width: cutout.width,
+          height: cutout.height,
+          borderRadius: 8,
+          boxShadow: `0 0 0 2px ${ringColor}, 0 0 24px 4px ${ringGlow}`,
+          pointerEvents: "none",
+          transition: "all 0.2s ease",
+        }}
+      />
+
+      {/* Inner pulse ring on the actionable button inside the spotlight, if
+          the step opted into double-spotlight mode. Pure CSS animation —
+          purely decorative, doesn't block clicks on the real button. */}
+      {pulseRect && (
+        <div
+          style={{
+            position: "fixed",
+            top: pulseRect.top - 4,
+            left: pulseRect.left - 4,
+            width: pulseRect.width + 8,
+            height: pulseRect.height + 8,
+            borderRadius: 10,
+            border: `2px solid ${ringColor}`,
+            boxShadow: `0 0 0 4px ${ringGlow}, 0 0 18px 6px ${ringGlow}`,
+            pointerEvents: "none",
+            animation: "demoPulseRing 1.4s ease-in-out infinite",
+            zIndex: 1,
+          }}
+        />
+      )}
+
+      {/* Tooltip card */}
+      <div
+        ref={tooltipRef}
+        role="dialog"
+        aria-modal="false"
+        style={{
+          position: "fixed",
+          top: tooltipPos.top,
+          left: tooltipPos.left,
+          width: TOOLTIP_WIDTH,
+          background: "var(--popover)",
+          color: "var(--popover-foreground)",
+          border: `1px solid ${tooltipBorder}`,
+          borderRadius: 10,
+          padding: 16,
+          boxShadow: isDark
+            ? "0 12px 32px rgba(0, 0, 0, 0.45), 0 0 16px rgba(0, 212, 255, 0.15)"
+            : "0 12px 32px rgba(15, 23, 42, 0.18), 0 0 16px rgba(37, 99, 235, 0.08)",
+          pointerEvents: "auto",
+          fontSize: 13,
+          lineHeight: 1.55,
+        }}
+      >
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+            marginBottom: 6,
+          }}
+        >
+          <div style={{ fontSize: 14, fontWeight: 600 }}>
+            {t(currentStep.titleKey, {
+              defaultValue: currentStep.titleFallback,
+            })}
+          </div>
+          <div style={{ fontSize: 11, opacity: 0.6 }}>
+            {stepNumber} / {totalSteps}
+          </div>
+        </div>
+        <div style={{ marginBottom: 14, opacity: 0.92 }}>
+          {t(currentStep.contentKey, {
+            defaultValue: currentStep.contentFallback,
+          })}
+        </div>
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+            gap: 8,
+          }}
+        >
+          <div style={{ display: "flex", alignItems: "center", gap: 12 }}>
+            <button
+              type="button"
+              onClick={handleExit}
+              style={{
+                fontSize: 11,
+                color: "var(--muted-foreground)",
+                background: "transparent",
+                border: "none",
+                cursor: "pointer",
+                padding: 0,
+                textDecoration: "underline",
+              }}
+            >
+              {t("demoTour.exitDemo", { defaultValue: "Exit demo" })}
+            </button>
+            {canGoBack && (
+              <button
+                type="button"
+                onClick={handleBack}
+                style={{
+                  fontSize: 12,
+                  padding: "5px 12px",
+                  borderRadius: 6,
+                  border: "1px solid var(--border)",
+                  background: "transparent",
+                  color: "var(--foreground)",
+                  cursor: "pointer",
+                }}
+              >
+                {t("demoTour.back", { defaultValue: "Back" })}
+              </button>
+            )}
+          </div>
+          {currentStep.manualNext && (
+            <button
+              type="button"
+              onClick={() => {
+                const matching = STEPS.filter(
+                  (s) => s.phase === demoState.phase,
+                )
+                if (subStepIdx < matching.length - 1) {
+                  setSubStepIdx((i) => i + 1)
+                } else if (currentStep.manualNextPhase) {
+                  setDemoPhase(currentStep.manualNextPhase)
+                }
+              }}
+              style={{
+                fontSize: 12,
+                padding: "5px 14px",
+                borderRadius: 6,
+                border: "1px solid var(--primary)",
+                background: "var(--primary)",
+                color: "var(--primary-foreground)",
+                cursor: "pointer",
+                fontWeight: 500,
+              }}
+            >
+              {t("demoTour.gotIt", { defaultValue: "Got it" })}
+            </button>
+          )}
+        </div>
+      </div>
+    </div>,
+    document.body,
+  )
+}

--- a/src/frontend/src/components/Onboarding/OnboardingTour.tsx
+++ b/src/frontend/src/components/Onboarding/OnboardingTour.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useLayoutEffect, useRef, useState } from "react"
 import { createPortal } from "react-dom"
 import { useTranslation } from "react-i18next"
+import { getDemoState } from "@/hooks/useDemoMode"
 import { isTourDone, markAllToursDone, markTourDone } from "./tourStorage"
 
 export interface TourStep {
@@ -12,6 +13,11 @@ export interface TourStep {
   content: string
   /** Optional preferred placement; defaults to auto-detect. */
   placement?: "top" | "bottom" | "left" | "right"
+  /**
+   * Optional hook fired when this step becomes active. Used by demo mode to
+   * advance the simulated task phase as the user clicks through the tour.
+   */
+  onEnter?: () => void
 }
 
 interface OnboardingTourProps {
@@ -21,6 +27,12 @@ interface OnboardingTourProps {
   enabled?: boolean
   /** Delay (ms) before searching for the first target. */
   startDelay?: number
+  /**
+   * If true this tour is treated as the demo-mode walkthrough — it runs only
+   * while demo mode is active. All other tours are suppressed during demo mode
+   * to avoid stacking with the demo walkthrough.
+   */
+  isDemoTour?: boolean
 }
 
 interface Rect {
@@ -114,6 +126,7 @@ export default function OnboardingTour({
   steps,
   enabled = true,
   startDelay = 200,
+  isDemoTour = false,
 }: OnboardingTourProps) {
   const { t } = useTranslation()
   const [active, setActive] = useState(false)
@@ -132,11 +145,24 @@ export default function OnboardingTour({
   useEffect(() => {
     if (!enabled) return
     if (isTourDone(tourId)) return
+    // Demo-mode coordination: while demo is active, only the demo tour itself
+    // may run; while demo is inactive, demo-only tours stay dormant.
+    const demoActive = getDemoState().active
+    if (demoActive && !isDemoTour) return
+    if (!demoActive && isDemoTour) return
     const t = window.setTimeout(() => setActive(true), startDelay)
     return () => window.clearTimeout(t)
-  }, [enabled, tourId, startDelay])
+  }, [enabled, tourId, startDelay, isDemoTour])
 
   const currentStep = steps[stepIndex]
+
+  // Notify the active step that it has become current. Wrapped in an effect
+  // (not inline in render) so demo-mode side effects don't fire during render.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: only re-fire on step change
+  useEffect(() => {
+    if (!active || !currentStep) return
+    currentStep.onEnter?.()
+  }, [active, stepIndex])
 
   // Locate the current target element and recompute geometry.
   useLayoutEffect(() => {
@@ -161,11 +187,7 @@ export default function OnboardingTour({
             const r2 = getRect(el)
             setRect(r2)
             setTooltipPos(
-              computeTooltipPosition(
-                r2,
-                currentStep.placement,
-                tooltipHeight,
-              ),
+              computeTooltipPosition(r2, currentStep.placement, tooltipHeight),
             )
           })
         } else {
@@ -215,7 +237,7 @@ export default function OnboardingTour({
     const ro = new ResizeObserver(measure)
     ro.observe(el)
     return () => ro.disconnect()
-  }, [active, stepIndex, tooltipHeight])
+  }, [tooltipHeight])
 
   if (!active || !currentStep || !rect || !tooltipPos) return null
 

--- a/src/frontend/src/components/Projects/DemoProjectCard.tsx
+++ b/src/frontend/src/components/Projects/DemoProjectCard.tsx
@@ -1,0 +1,90 @@
+import { useNavigate } from "@tanstack/react-router"
+import { ArrowRight, Sparkles } from "lucide-react"
+import { useTranslation } from "react-i18next"
+
+import {
+  Card,
+  CardContent,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+import { DEMO_PROJECT } from "@/data/demoFixtures"
+import { enterDemo } from "@/hooks/useDemoMode"
+import { getProjectIcon } from "./ProjectIcons"
+
+export default function DemoProjectCard() {
+  const navigate = useNavigate()
+  const { t } = useTranslation()
+  const Icon = getProjectIcon(DEMO_PROJECT.icon)
+
+  const handleEnter = () => {
+    enterDemo("uninitialized")
+    navigate({ to: "/evolution", search: { projectId: DEMO_PROJECT.id } })
+  }
+
+  return (
+    <Card
+      data-tour="demo-project-card"
+      onClick={handleEnter}
+      className="group relative overflow-hidden cursor-pointer transition-all duration-200
+        border-primary/40 bg-gradient-to-br from-primary/[0.06] via-primary/[0.02] to-transparent
+        hover:border-primary/70 hover:shadow-lg hover:shadow-primary/15 hover:-translate-y-0.5"
+    >
+      <div
+        className="pointer-events-none absolute -top-12 -right-12 size-32 rounded-full bg-primary/15 blur-2xl opacity-60 group-hover:opacity-100 transition-opacity duration-500"
+        aria-hidden="true"
+      />
+
+      <span
+        className="absolute top-2.5 right-2.5 z-10 inline-flex items-center gap-1
+          rounded-full bg-primary/15 text-primary border border-primary/30
+          px-2 py-0.5 text-[10px] font-semibold tracking-wider uppercase"
+      >
+        <Sparkles className="size-3" />
+        {t("demo.badge", { defaultValue: "DEMO" })}
+      </span>
+
+      <CardHeader className="flex flex-row items-start justify-between space-y-0 pb-1.5 pt-4 px-4">
+        <div className="flex items-center gap-2.5 min-w-0 pr-2">
+          <div className="shrink-0 size-8 rounded-md bg-primary/10 text-primary flex items-center justify-center transition-transform duration-300 group-hover:scale-110 group-hover:rotate-3">
+            <Icon className="size-4.5" />
+          </div>
+          <CardTitle className="text-sm font-semibold leading-tight truncate">
+            {t("demo.projectName", {
+              defaultValue: "✨ Example · TSP Heuristic",
+            })}
+          </CardTitle>
+        </div>
+      </CardHeader>
+
+      <CardContent className="pb-3 px-4">
+        <p className="text-sm text-muted-foreground line-clamp-2 min-h-[2.5rem]">
+          {t("demo.projectDescription", {
+            defaultValue:
+              "Read-only example. Walk through it to see how LLM4AD designs an algorithm end-to-end.",
+          })}
+        </p>
+      </CardContent>
+
+      <CardFooter className="pt-0 pb-3 px-4 flex items-center justify-between gap-2">
+        <span className="text-xs text-muted-foreground/80">
+          {t("demo.readOnly", { defaultValue: "Read-only · No LLM calls" })}
+        </span>
+        <button
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation()
+            handleEnter()
+          }}
+          className="relative shrink-0 inline-flex items-center gap-1.5 px-3.5 py-1.5 rounded-full text-xs font-medium text-primary border border-primary/40 bg-primary/5 transition-all duration-300 group-hover:bg-primary group-hover:text-primary-foreground group-hover:border-primary hover:opacity-90 active:scale-95"
+        >
+          <span>
+            {t("demo.startTour", { defaultValue: "Start guided tour" })}
+          </span>
+          <ArrowRight className="size-3.5 transition-transform duration-300 group-hover:translate-x-0.5" />
+        </button>
+      </CardFooter>
+    </Card>
+  )
+}

--- a/src/frontend/src/data/demoFixtures/constants.ts
+++ b/src/frontend/src/data/demoFixtures/constants.ts
@@ -1,0 +1,12 @@
+// Sentinel ids for the read-only demo project. Hooks/services check these
+// before issuing real network calls.
+export const DEMO_PROJECT_ID = "__demo_project__"
+export const DEMO_TASK_ID = "__demo_task__"
+
+export function isDemoProjectId(id: string | null | undefined): boolean {
+  return id === DEMO_PROJECT_ID
+}
+
+export function isDemoTaskId(id: string | null | undefined): boolean {
+  return id === DEMO_TASK_ID
+}

--- a/src/frontend/src/data/demoFixtures/index.ts
+++ b/src/frontend/src/data/demoFixtures/index.ts
@@ -1,0 +1,201 @@
+import type { ProjectResponse, TaskResponse, TaskStatus } from "@/client"
+import type {
+  GANode,
+  IslandGAData,
+} from "@/components/Evolution/TaskDetail/island-ga-mock-data"
+import type { DemoPhase } from "@/hooks/useDemoMode"
+import { DEMO_PROJECT_ID, DEMO_TASK_ID } from "./constants"
+
+export {
+  DEMO_PROJECT_ID,
+  DEMO_TASK_ID,
+  isDemoProjectId,
+  isDemoTaskId,
+} from "./constants"
+
+const NOW = "2026-06-01T00:00:00Z"
+
+export const DEMO_PROJECT: ProjectResponse = {
+  id: DEMO_PROJECT_ID,
+  created_time: NOW,
+  updated_time: NOW,
+  name: "✨ Demo · TSP Heuristic",
+  description:
+    "Read-only example project. Walk through it to see how LLM4AD designs an algorithm end-to-end.",
+  icon: "nexus",
+  user_id: "__demo__",
+}
+
+export const DEMO_TASK: TaskResponse = {
+  id: DEMO_TASK_ID,
+  created_time: NOW,
+  updated_time: NOW,
+  project_id: DEMO_PROJECT_ID,
+  name: "Demo · Greedy + Local Search",
+  description: "Auto-designed heuristic for the Travelling Salesman Problem.",
+  status: "completed",
+  active_status: "completed",
+  input_args: {
+    task_name: "tsp_construct",
+    population_size: 8,
+    max_generations: 12,
+  },
+  ai_built: true,
+  ai_build_started: true,
+  children_count: 0,
+}
+
+/**
+ * Map a demo phase to the task `status` field. The view picker in
+ * `_layout_evolution` reads `effectiveStatus` and chooses
+ * UninitializedView / ChatTuneView / InitializedView based on it, so swapping
+ * the status as the user advances drives the live view transitions for free.
+ */
+export function demoPhaseToStatus(phase: DemoPhase): TaskStatus {
+  switch (phase) {
+    case "uninitialized":
+    case "configuring":
+      return "uninitialized"
+    case "building":
+    case "running":
+      return "running"
+    case "completed":
+      return "completed"
+  }
+}
+
+/** Build a demo task whose status reflects the current demo phase. */
+export function buildDemoTask(phase: DemoPhase): TaskResponse {
+  const status = demoPhaseToStatus(phase)
+  return {
+    ...DEMO_TASK,
+    status,
+    active_status: status,
+    // ai_built only flips on once the simulated AI Build finishes — before that
+    // the AI panel is the active surface; after it, the task moves into the
+    // initialized result views.
+    ai_built: phase === "running" || phase === "completed",
+    ai_build_started: phase !== "uninitialized",
+  }
+}
+
+/**
+ * Pre-baked evolution graph for the demo task. Nodes are spread across two
+ * islands and 12 generations; scores monotonically improve so the trajectory
+ * looks like a successful run.
+ */
+function buildDemoNodes(): GANode[] {
+  const nodes: GANode[] = []
+  const islands = ["A", "B"]
+  const prevByIsland: Record<string, string | null> = { A: null, B: null }
+  // Deterministic pseudo-random for reproducible demo geometry.
+  let seed = 42
+  const rand = () => {
+    seed = (seed * 1103515245 + 12345) & 0x7fffffff
+    return seed / 0x7fffffff
+  }
+
+  for (let gen = 0; gen <= 12; gen++) {
+    for (const island of islands) {
+      const id = `demo-${island}-${gen}`
+      const baseRaw = 100 - gen * 5
+      const raw = baseRaw + rand() * 4 - 2
+      const parents: string[] = []
+      const prev = prevByIsland[island]
+      if (prev) parents.push(prev)
+      // Cross-island parent every 3 generations to make the graph interesting.
+      if (gen > 1 && gen % 3 === 0) {
+        const otherIsland = island === "A" ? "B" : "A"
+        const otherPrev = prevByIsland[otherIsland]
+        if (otherPrev) parents.push(otherPrev)
+      }
+      nodes.push({
+        id,
+        generation: gen,
+        island: island === "A" ? 0 : 1,
+        islandId: island,
+        name: `gen${gen}_${island}`,
+        fileName: `gen_${gen}_${island}.py`,
+        score: 0, // filled in by the caller's normalize step
+        rawScore: raw,
+        parentIds: parents,
+      })
+      prevByIsland[island] = id
+    }
+  }
+  // Min-max normalize so the renderer has a [0,1] score column.
+  const min = Math.min(...nodes.map((n) => n.rawScore))
+  const max = Math.max(...nodes.map((n) => n.rawScore))
+  const range = max - min
+  for (const n of nodes) {
+    n.score = range > 0 ? (n.rawScore - min) / range : 0.5
+  }
+  return nodes
+}
+
+const ALL_NODES = buildDemoNodes()
+
+/** Slice nodes up to the given generation (inclusive). */
+export function buildDemoEvolutionData(maxGen: number): IslandGAData {
+  const nodes = ALL_NODES.filter((n) => n.generation <= maxGen)
+  const islandIds = ["A", "B"]
+  return {
+    nodes,
+    unscoredNodes: [],
+    maxGeneration: nodes.length
+      ? Math.max(...nodes.map((n) => n.generation))
+      : 0,
+    islandCount: islandIds.length,
+    islandIds,
+  }
+}
+
+export const DEMO_BEST_CODE = `def solve(distance_matrix):
+    """Greedy nearest-neighbor with 2-opt local search.
+
+    Auto-designed by LLM4AD. Score: 0.93 (normalized).
+    """
+    n = len(distance_matrix)
+    visited = [False] * n
+    tour = [0]
+    visited[0] = True
+    for _ in range(n - 1):
+        current = tour[-1]
+        best, best_d = -1, float("inf")
+        for j in range(n):
+            if not visited[j] and distance_matrix[current][j] < best_d:
+                best, best_d = j, distance_matrix[current][j]
+        tour.append(best)
+        visited[best] = True
+    # 2-opt refinement
+    improved = True
+    while improved:
+        improved = False
+        for i in range(1, n - 2):
+            for k in range(i + 1, n):
+                a, b = tour[i - 1], tour[i]
+                c, d = tour[k], tour[(k + 1) % n]
+                if (
+                    distance_matrix[a][c] + distance_matrix[b][d]
+                    < distance_matrix[a][b] + distance_matrix[c][d]
+                ):
+                    tour[i : k + 1] = tour[i : k + 1][::-1]
+                    improved = True
+    return tour
+`
+
+export const DEMO_LOG_LINES: string[] = [
+  "[demo] Loading dataset: tsp_50.json",
+  "[demo] Initializing 2 islands with population 8",
+  "[demo] Generation 1: best score 0.31",
+  "[demo] Generation 4: best score 0.58",
+  "[demo] Generation 8: best score 0.81",
+  "[demo] Generation 12: best score 0.93 ← convergence",
+  "[demo] Run finished in 00:01:24",
+]
+
+export const DEMO_AI_BUILD_FILES = [
+  { name: "config.yaml", language: "yaml" },
+  { name: "evaluator.py", language: "python" },
+  { name: "task.py", language: "python" },
+]

--- a/src/frontend/src/hooks/useDemoMode.ts
+++ b/src/frontend/src/hooks/useDemoMode.ts
@@ -1,0 +1,145 @@
+import { useSyncExternalStore } from "react"
+
+/**
+ * Phases the simulated demo task walks through as the user advances the tour.
+ * Each phase decides what fixture data is exposed by the demo-aware hooks.
+ */
+export type DemoPhase =
+  | "uninitialized" // task created, configuration not started
+  | "configuring" // user is filling in config / AI Build
+  | "building" // AI Build working
+  | "running" // evolution producing nodes
+  | "completed" // results available
+
+interface DemoState {
+  /** Whether the user is currently inside the demo (read-only) project. */
+  active: boolean
+  /** How far the simulated task has progressed. */
+  phase: DemoPhase
+  /** Generation index to expose for evolution data (0..MAX). */
+  generation: number
+}
+
+const STORAGE_KEY = "llm4ad:demoState"
+const PHASE_ORDER: DemoPhase[] = [
+  "uninitialized",
+  "configuring",
+  "building",
+  "running",
+  "completed",
+]
+
+const DEFAULT_STATE: DemoState = {
+  active: false,
+  phase: "uninitialized",
+  generation: 0,
+}
+
+let state: DemoState = loadState()
+const listeners = new Set<() => void>()
+
+function loadState(): DemoState {
+  if (typeof window === "undefined") return DEFAULT_STATE
+  try {
+    const raw = window.sessionStorage.getItem(STORAGE_KEY)
+    if (!raw) return DEFAULT_STATE
+    const parsed = JSON.parse(raw) as Partial<DemoState>
+    return {
+      active: !!parsed.active,
+      phase: (parsed.phase as DemoPhase) ?? "uninitialized",
+      generation: typeof parsed.generation === "number" ? parsed.generation : 0,
+    }
+  } catch {
+    return DEFAULT_STATE
+  }
+}
+
+function persist(): void {
+  if (typeof window === "undefined") return
+  try {
+    window.sessionStorage.setItem(STORAGE_KEY, JSON.stringify(state))
+  } catch {
+    // ignore storage failures (private mode, quota)
+  }
+}
+
+function emit(): void {
+  persist()
+  listeners.forEach((l) => {
+    l()
+  })
+}
+
+function subscribe(l: () => void): () => void {
+  listeners.add(l)
+  return () => listeners.delete(l)
+}
+
+function getSnapshot(): DemoState {
+  return state
+}
+
+export function enterDemo(phase: DemoPhase = "uninitialized"): void {
+  state = { active: true, phase, generation: phaseToGeneration(phase) }
+  emit()
+}
+
+export function exitDemo(): void {
+  state = { ...DEFAULT_STATE }
+  emit()
+}
+
+export function setDemoPhase(phase: DemoPhase): void {
+  if (!state.active) return
+  state = {
+    ...state,
+    phase,
+    generation: phaseToGeneration(phase),
+  }
+  emit()
+}
+
+/**
+ * Override the visible generation count without changing the phase. Used by
+ * the running-phase animation to push nodes onto the canvas one generation
+ * at a time. No-op when demo mode is inactive or the phase is anything other
+ * than `running` (other phases derive their generation from `phaseToGeneration`).
+ */
+export function setDemoGeneration(generation: number): void {
+  if (!state.active) return
+  if (state.phase !== "running") return
+  state = {
+    ...state,
+    generation: Math.max(0, generation),
+  }
+  emit()
+}
+
+export function advanceDemoPhase(): void {
+  if (!state.active) return
+  const idx = PHASE_ORDER.indexOf(state.phase)
+  if (idx < 0 || idx >= PHASE_ORDER.length - 1) return
+  setDemoPhase(PHASE_ORDER[idx + 1])
+}
+
+/** Number of generations to expose for a given phase. */
+function phaseToGeneration(phase: DemoPhase): number {
+  switch (phase) {
+    case "running":
+      return 0
+    case "completed":
+      return 12
+    default:
+      return 0
+  }
+}
+
+/** React hook: subscribe to the current demo state. */
+export function useDemoState(): DemoState {
+  return useSyncExternalStore(subscribe, getSnapshot, () => DEFAULT_STATE)
+}
+
+/** Snapshot accessor for non-component code (services, utilities). */
+export function getDemoState(): DemoState {
+  return state
+}

--- a/src/frontend/src/hooks/useEvolutionNodes.ts
+++ b/src/frontend/src/hooks/useEvolutionNodes.ts
@@ -7,6 +7,8 @@ import type {
   IslandGAData,
 } from "@/components/Evolution/TaskDetail/island-ga-mock-data"
 import { EMPTY_DATA } from "@/components/Evolution/TaskDetail/island-ga-mock-data"
+import { buildDemoEvolutionData, isDemoTaskId } from "@/data/demoFixtures"
+import { useDemoState } from "@/hooks/useDemoMode"
 import { taskKeys } from "@/lib/task-queries"
 
 /* ── Raw generated entry from SSE / REST ── */
@@ -132,6 +134,8 @@ export function useEvolutionNodes(
   isLoading: boolean
   feedGenerated: (entry: Record<string, unknown>) => void
 } {
+  const isDemo = isDemoTaskId(taskId)
+  const demoState = useDemoState()
   const isTerminal = taskStatus === "completed" || taskStatus === "failed"
   const isActive = taskStatus === "pending" || taskStatus === "running"
   // Only fetch `generated` history for terminal tasks. Uninitialized tasks show
@@ -148,7 +152,7 @@ export function useEvolutionNodes(
         logType: "generated",
         limit: 0,
       }),
-    enabled: enabled && !!taskId && shouldRestFetch,
+    enabled: enabled && !!taskId && !isDemo && shouldRestFetch,
   })
 
   const restData = useMemo<IslandGAData>(() => {
@@ -216,6 +220,22 @@ export function useEvolutionNodes(
   )
 
   if (!taskId) return { data: EMPTY_DATA, isLoading: false, feedGenerated }
+  if (isDemo) {
+    // Demo phases gate visible generations: running streams nodes one
+    // generation at a time (via setDemoGeneration), completed shows the full
+    // graph, earlier phases hide the canvas.
+    const visibleGen =
+      demoState.phase === "completed"
+        ? 12
+        : demoState.phase === "running"
+          ? demoState.generation
+          : -1
+    return {
+      data: visibleGen >= 0 ? buildDemoEvolutionData(visibleGen) : EMPTY_DATA,
+      isLoading: false,
+      feedGenerated,
+    }
+  }
   if (shouldRestFetch)
     return {
       data: restData,

--- a/src/frontend/src/hooks/useTaskLogs.ts
+++ b/src/frontend/src/hooks/useTaskLogs.ts
@@ -4,6 +4,8 @@ import { useTranslation } from "react-i18next"
 import type { TaskStatus } from "@/client"
 import { Llm4AdTasksService } from "@/client"
 import type { LogLevel } from "@/components/Evolution/TaskDetail/log-renderers"
+import { DEMO_LOG_LINES, isDemoTaskId } from "@/data/demoFixtures"
+import { useDemoState } from "@/hooks/useDemoMode"
 import { taskKeys } from "@/lib/task-queries"
 import { authFetch } from "@/utils/auth"
 
@@ -50,7 +52,12 @@ export function useTaskLogs(
 ): UseTaskLogsReturn {
   const queryClient = useQueryClient()
   const { t } = useTranslation()
-  const isActive = taskStatus === "pending" || taskStatus === "running"
+  const isDemo = isDemoTaskId(taskId)
+  const demoState = useDemoState()
+  // Demo tasks never go through SSE; treat them as inactive so the streaming
+  // effect below short-circuits.
+  const isActive =
+    !isDemo && (taskStatus === "pending" || taskStatus === "running")
 
   const onResetTaskRef = useRef(options?.onResetTask)
   onResetTaskRef.current = options?.onResetTask
@@ -269,6 +276,31 @@ export function useTaskLogs(
   }, [taskId, isActive, enabled, queryClient, t])
 
   // ---------- Return ----------
+  if (isDemo) {
+    // Walk through the canned log lines as the demo phase advances so the
+    // logs panel feels alive while the user clicks through the tour.
+    const phase = demoState.phase
+    const visibleCount =
+      phase === "completed"
+        ? DEMO_LOG_LINES.length
+        : phase === "running"
+          ? Math.min(DEMO_LOG_LINES.length, 5)
+          : phase === "building"
+            ? 2
+            : 0
+    const entries: LogEntry[] = DEMO_LOG_LINES.slice(0, visibleCount).map(
+      (line, idx) => ({
+        _kind: "log",
+        type: "log",
+        level: "info",
+        message: line,
+        timestamp: new Date(
+          Date.now() - (visibleCount - idx) * 1000,
+        ).toISOString(),
+      }),
+    )
+    return { entries, isLoading: false, error: null }
+  }
   if (isActive) {
     return {
       entries: streamEntries,

--- a/src/frontend/src/i18n/locales/en.json
+++ b/src/frontend/src/i18n/locales/en.json
@@ -138,6 +138,8 @@
     "overview": "Overview",
     "logout": "Logout",
     "systemManagement": "System Management",
+    "replayTour": "Replay guided tour",
+    "replayTourReset": "All walkthroughs reset — they'll show up again as you visit each page",
     "userManual": "User Manual",
     "liveCode": "WeChat Group QR"
   },
@@ -1180,6 +1182,8 @@
     "next": "Next",
     "finish": "Done",
     "projects": {
+      "demoTitle": "Try the example project first",
+      "demoContent": "Click this read-only example to walk through a full algorithm-design run in seconds. No LLM keys needed.",
       "createProjectTitle": "Create your first project",
       "createProjectContent": "Click the \"New Project\" button to create a project. Projects help you organize and manage your algorithm design tasks.",
       "configProviderTitle": "Configure global LLM providers",
@@ -1211,6 +1215,83 @@
       "actionsTitle": "Task actions",
       "actionsContent": "View task status and the version tree here. You can View params, Adjust params (copies a new version), and Run / Stop / Re-run the task."
     }
+  },
+  "demo": {
+    "badge": "DEMO",
+    "projectName": "✨ Example · TSP Heuristic",
+    "projectDescription": "Read-only example. Walk through it to see how LLM4AD designs an algorithm end-to-end.",
+    "readOnly": "Read-only · No LLM calls",
+    "startTour": "Start guided tour",
+    "banner": "Demo",
+    "exitTitle": "Exit demo"
+  },
+  "demoTour": {
+    "create": {
+      "title": "Step 1 · Create a task",
+      "content": "Click \"New Task\" to follow the full guided experience."
+    },
+    "createSubmit": {
+      "title": "Step 1b · Pick a build mode",
+      "content": "LLM4AD_Next supports a classic Manual mode and the convenient AI build mode. This demo walks through the AI path. Type a task name and click \"Create\" to open a session with the agent."
+    },
+    "taskRow": {
+      "title": "Step 2 · Your task appears in the sidebar",
+      "content": "The task you just created shows up in the left task list. In real projects you'll see every task here — click any row to switch between them."
+    },
+    "send": {
+      "title": "Step 3 · Chat with the AI",
+      "content": "The agent gathers your design requirements through a back-and-forth conversation. We've pre-filled the first turn. Click \"Send\" to start; after a few turns the AI will ask whether to begin building, and sending \"Start build\" kicks the build off."
+    },
+    "building": {
+      "title": "Step 4 · Wait while the build runs",
+      "content": "The left panel is the build pipeline: the progress bar fills as the agent moves through Gathering → Build → Review. Generated files appear in the file list below."
+    },
+    "run": {
+      "title": "Step 5 · Submit and start the auto-design loop",
+      "content": "Build is done. Click \"Submit & Run\" at the bottom of the left panel to kick off the evolution loop — candidate algorithms appear generation by generation."
+    },
+    "canvas": {
+      "title": "Step 6 · Watch the design process unfold",
+      "content": "While the loop runs you can inspect the evolution graph and ask the agent to analyse it. The tree grows as it goes — every node is one algorithm the system designed."
+    },
+    "ide": {
+      "title": "Step 7 · Read the final algorithm",
+      "content": "Click the IDE tab to see the actual code LLM4AD_Next evolved — in a real run this is the artifact you'd take with you and use."
+    },
+    "ideCode": {
+      "title": "Step 8 · Skim the generated code",
+      "content": "This is the algorithm LLM4AD_Next evolved — a greedy nearest-neighbor with 2-opt refinement TSP heuristic. In a real run you can copy it straight into your project, or keep iterating with the AI. Click \"Got it\" when you're ready to wrap up."
+    },
+    "exit": {
+      "title": "You're ready",
+      "content": "Head back to the project list, configure an LLM provider, and create your first real project. The walkthrough is always one click away from your user menu."
+    },
+    "exitDemo": "Exit demo",
+    "skipAhead": "Skip ahead",
+    "gotIt": "Got it",
+    "back": "Back"
+  },
+  "demoBuild": {
+    "chatTitle": "AI Build · Chat",
+    "previewTitle": "Build progress · Files",
+    "filesLabel": "Generated files",
+    "composerHint": "Click Send to let the AI build this for you...",
+    "composerLocked": "Building — chat is paused",
+    "send": "Send",
+    "run": "Run",
+    "progressIdle": "Awaiting your request",
+    "progressBuilding": "Building...",
+    "progressDone": "Build complete",
+    "readyHint": "Ready to run the evolution",
+    "runHint": "Run unlocks once the build is complete",
+    "noFilesYet": "Generated files will appear here once the AI finishes building.",
+    "buildingMessage": "Generating config.yaml, evaluator.py, task.py...",
+    "buildDoneMessage": "Build complete — three files are ready. Review them on the left, then click Submit & Run to kick off the evolution."
+  },
+  "guide": {
+    "replayTour": "Replay the guided tour",
+    "tourReplayReset": "All walkthroughs reset — they'll show up again as you visit each page",
+    "tourReplayStarted": "Walkthrough reset — taking you to the demo project."
   },
   "configForm": {
     "sections": {

--- a/src/frontend/src/i18n/locales/zh.json
+++ b/src/frontend/src/i18n/locales/zh.json
@@ -138,6 +138,8 @@
     "overview": "概览",
     "logout": "退出登录",
     "systemManagement": "系统管理",
+    "replayTour": "重新看引导",
+    "replayTourReset": "已重置所有引导 — 访问对应页面时会再次出现",
     "userManual": "使用手册",
     "liveCode": "微信群活码"
   },
@@ -1181,6 +1183,8 @@
     "next": "下一步",
     "finish": "完成",
     "projects": {
+      "demoTitle": "先试试示例项目",
+      "demoContent": "点击这个只读的示例项目，几秒钟跟着走完一次完整的算法设计流程。无需配置 LLM，立刻就能上手。",
       "createProjectTitle": "创建你的第一个项目",
       "createProjectContent": "点击「新建项目」按钮即可创建项目。项目用于组织和管理你的算法设计任务。",
       "configProviderTitle": "配置全局模型供应商",
@@ -1212,6 +1216,83 @@
       "actionsTitle": "任务操作区",
       "actionsContent": "在这里查看任务状态与版本树，可「查看参数」「调整参数」（会复制新版本），以及运行 / 停止 / 重新运行任务。"
     }
+  },
+  "demo": {
+    "badge": "示例",
+    "projectName": "✨ 示例项目 · TSP 启发式",
+    "projectDescription": "只读示例。点进来跟着走一遍，看看 LLM4AD 如何端到端设计算法。",
+    "readOnly": "只读 · 不调用任何 LLM",
+    "startTour": "开始体验",
+    "banner": "示例",
+    "exitTitle": "退出示例"
+  },
+  "demoTour": {
+    "create": {
+      "title": "第 1 步 · 新建任务",
+      "content": "点击「新建任务」开始跟随完整的体验流程。"
+    },
+    "createSubmit": {
+      "title": "第 1b 步 · 选择构建方式",
+      "content": "LLM4AD_Next支持传统的「手工构建」和便捷的「AI 构建」。Demo中我们以「AI 构建」为例。填写任务名后，然后点击「创建」开启与智能体的对话。"
+    },
+    "taskRow": {
+      "title": "第 2 步 · 任务出现在左侧列表",
+      "content": "你刚才创建的任务出现在左侧「演化任务列表」里。真实项目中你可以在这里看到所有任务，点击任意一行即可切换。"
+    },
+    "send": {
+      "title": "第 3 步 · 与 AI 对话",
+      "content": "通过多轮对话的方式，智能体将收集您的算法设计需求。在Demo中，我们替您打了第一句话。点击「发送」交流，AI 会问几轮需求然后问你是否开始构建；当你发送「开始构建」时，会自动进入构建阶段。"
+    },
+    "building": {
+      "title": "第 4 步 · 等待算法设计任务构建",
+      "content": "左侧面板就是构建过程：「配置进度」随阶段推进，下面「文件列表」会逐步出现 AI 生成的文件。"
+    },
+    "run": {
+      "title": "第 5 步 · 提交运行，开始自动算法设计",
+      "content": "构建完成。点击左侧底部的「提交运行」启动进化循环 —— 候选算法会一代代出现。"
+    },
+    "canvas": {
+      "title": "第 6 步 · 随时查看的算法设计过程",
+      "content": "算法设计过程中，查看算法的演化情况、让智能体分析演化过程。您可以看到算法树不断生长。每一个节点是一个被设计出来的算法。"
+    },
+    "ide": {
+      "title": "第 7 步 · 查看最终算法",
+      "content": "点击 IDE 标签查看 LLM4AD_Next 进化出来的真实代码 —— 在真实运行中，这就是您能拿走用的产物。"
+    },
+    "ideCode": {
+      "title": "第 8 步 · 读一读生成的代码",
+      "content": "这就是 LLM4AD_Next 进化出来的真实算法 —— 一个贪心最近邻 + 2-opt 局部搜索的 TSP 启发式。在真实运行中你可以直接复制带走，也可以继续和 AI 迭代改进。读完后点「了解」结束体验。"
+    },
+    "exit": {
+      "title": "你已经准备好了",
+      "content": "回到项目列表，配好 LLM 供应商，就可以创建你自己的项目了。这个引导随时能从用户菜单里再次打开。"
+    },
+    "exitDemo": "退出示例",
+    "skipAhead": "跳到下一步",
+    "gotIt": "了解",
+    "back": "上一步"
+  },
+  "demoBuild": {
+    "chatTitle": "AI 构建 · 对话",
+    "previewTitle": "构建进度 · 文件",
+    "filesLabel": "生成的文件",
+    "composerHint": "点击 Send 让 AI 帮你构建...",
+    "composerLocked": "构建中 — 对话暂停",
+    "send": "发送",
+    "run": "运行",
+    "progressIdle": "等待你的请求",
+    "progressBuilding": "构建中...",
+    "progressDone": "构建完成",
+    "readyHint": "已就绪，可以启动进化",
+    "runHint": "构建完成后即可点击 Run",
+    "noFilesYet": "AI 完成构建后，生成的文件会在这里出现",
+    "buildingMessage": "正在生成 config.yaml、evaluator.py、task.py……",
+    "buildDoneMessage": "构建完成，三个文件已生成。请在左侧审阅后点击「提交运行」启动进化。"
+  },
+  "guide": {
+    "replayTour": "重新看引导",
+    "tourReplayReset": "已重置所有引导 — 访问对应页面时会再次出现",
+    "tourReplayStarted": "已重置引导，正在带你回到示例项目"
   },
   "configForm": {
     "sections": {

--- a/src/frontend/src/index.css
+++ b/src/frontend/src/index.css
@@ -515,3 +515,17 @@
     animation: none;
   }
 }
+
+/* Demo tour secondary pulse ring — drawn around an inner action button when
+   the step uses a wide outer spotlight (e.g. dialog or chat panel). */
+@keyframes demoPulseRing {
+  0%,
+  100% {
+    transform: scale(1);
+    opacity: 0.85;
+  }
+  50% {
+    transform: scale(1.06);
+    opacity: 1;
+  }
+}

--- a/src/frontend/src/routes/_layout.tsx
+++ b/src/frontend/src/routes/_layout.tsx
@@ -5,12 +5,13 @@ import {
   useNavigate,
   useRouterState,
 } from "@tanstack/react-router"
-import { LogOut, Settings } from "lucide-react"
+import { LogOut, RotateCcw, Settings } from "lucide-react"
 import { useTranslation } from "react-i18next"
 
 import { Footer } from "@/components/Common/Footer"
 import LanguageToggle from "@/components/Common/LanguageToggle"
 import ThemeToggle from "@/components/Common/ThemeToggle"
+import { resetAllTours } from "@/components/Onboarding/tourStorage"
 import AppSidebar from "@/components/Sidebar/AppSidebar"
 import { Avatar, AvatarFallback } from "@/components/ui/avatar"
 import {
@@ -27,6 +28,7 @@ import {
   SidebarTrigger,
 } from "@/components/ui/sidebar"
 import useAuth, { isLoggedIn } from "@/hooks/useAuth"
+import useCustomToast from "@/hooks/useCustomToast"
 import { getInitials } from "@/utils"
 
 export const Route = createFileRoute("/_layout")({
@@ -64,8 +66,22 @@ function HeaderUserMenu() {
   const { t } = useTranslation()
   const { user, logout } = useAuth()
   const navigate = useNavigate()
+  const { showSuccessToast } = useCustomToast()
 
   if (!user) return null
+
+  const handleReplayTour = () => {
+    // Reset every tour back to the freshly-registered state — projects /
+    // demo / evolution-create / evolution-task-config / evolution-ai-build /
+    // evolution-results all become "unseen" again. Each one will re-trigger
+    // the next time the user lands on its host page.
+    resetAllTours()
+    showSuccessToast(
+      t("layout.replayTourReset", {
+        defaultValue: "Walkthroughs reset — they'll show up again as you visit each page.",
+      }),
+    )
+  }
 
   return (
     <DropdownMenu>
@@ -98,6 +114,12 @@ function HeaderUserMenu() {
         >
           <Settings className="size-4 mr-2" />
           {t("layout.accountSettings")}
+        </DropdownMenuItem>
+        <DropdownMenuItem className="cursor-pointer" onClick={handleReplayTour}>
+          <RotateCcw className="size-4 mr-2" />
+          {t("layout.replayTour", {
+            defaultValue: "Replay guided tour",
+          })}
         </DropdownMenuItem>
         <DropdownMenuSeparator />
         <DropdownMenuItem

--- a/src/frontend/src/routes/_layout/guide.tsx
+++ b/src/frontend/src/routes/_layout/guide.tsx
@@ -1,10 +1,12 @@
 import { createFileRoute } from "@tanstack/react-router"
-import { Maximize2, Minimize2 } from "lucide-react"
+import { Maximize2, Minimize2, RotateCcw } from "lucide-react"
 import { useState } from "react"
 import { useTranslation } from "react-i18next"
 
 import { UserManualContent } from "@/components/Guide/UserManualContent"
+import { resetAllTours } from "@/components/Onboarding/tourStorage"
 import { Button } from "@/components/ui/button"
+import useCustomToast from "@/hooks/useCustomToast"
 import { cn } from "@/lib/utils"
 
 export const Route = createFileRoute("/_layout/guide")({
@@ -20,7 +22,20 @@ export const Route = createFileRoute("/_layout/guide")({
 
 function GuidePage() {
   const { t } = useTranslation()
+  const { showSuccessToast } = useCustomToast()
   const [fullscreen, setFullscreen] = useState(false)
+
+  const handleReplayTour = () => {
+    // Reset every tour back to the freshly-registered state. Each one will
+    // re-trigger when the user lands on its host page.
+    resetAllTours()
+    showSuccessToast(
+      t("guide.tourReplayReset", {
+        defaultValue:
+          "Walkthroughs reset — they'll show up again as you visit each page.",
+      }),
+    )
+  }
 
   return (
     <div
@@ -31,31 +46,45 @@ function GuidePage() {
           : "h-full overflow-hidden",
       )}
     >
-      <Button
-        variant="outline"
-        size="sm"
-        className="absolute top-2 right-2 z-10 gap-1.5"
-        onClick={() => setFullscreen((v) => !v)}
-        title={
-          fullscreen
+      <div className="absolute top-2 right-2 z-10 flex items-center gap-2">
+        <Button
+          variant="outline"
+          size="sm"
+          className="gap-1.5"
+          onClick={handleReplayTour}
+          title={t("guide.replayTour", {
+            defaultValue: "Replay the guided tour",
+          })}
+        >
+          <RotateCcw className="size-3.5" />
+          {t("guide.replayTour", { defaultValue: "Replay the guided tour" })}
+        </Button>
+        <Button
+          variant="outline"
+          size="sm"
+          className="gap-1.5"
+          onClick={() => setFullscreen((v) => !v)}
+          title={
+            fullscreen
+              ? t("userManual.exitFullscreen")
+              : t("userManual.enterFullscreen")
+          }
+          aria-label={
+            fullscreen
+              ? t("userManual.exitFullscreen")
+              : t("userManual.enterFullscreen")
+          }
+        >
+          {fullscreen ? (
+            <Minimize2 className="size-3.5" />
+          ) : (
+            <Maximize2 className="size-3.5" />
+          )}
+          {fullscreen
             ? t("userManual.exitFullscreen")
-            : t("userManual.enterFullscreen")
-        }
-        aria-label={
-          fullscreen
-            ? t("userManual.exitFullscreen")
-            : t("userManual.enterFullscreen")
-        }
-      >
-        {fullscreen ? (
-          <Minimize2 className="size-3.5" />
-        ) : (
-          <Maximize2 className="size-3.5" />
-        )}
-        {fullscreen
-          ? t("userManual.exitFullscreen")
-          : t("userManual.enterFullscreen")}
-      </Button>
+            : t("userManual.enterFullscreen")}
+        </Button>
+      </div>
       <UserManualContent className="h-full" />
     </div>
   )

--- a/src/frontend/src/routes/_layout/projects.tsx
+++ b/src/frontend/src/routes/_layout/projects.tsx
@@ -16,6 +16,7 @@ import { Llm4AdProjectsService } from "@/client"
 import { PageNumbers } from "@/components/Common/PageNumbers"
 import OnboardingTour from "@/components/Onboarding/OnboardingTour"
 import AddProject from "@/components/Projects/AddProject"
+import DemoProjectCard from "@/components/Projects/DemoProjectCard"
 import ProjectCard from "@/components/Projects/ProjectCard"
 import ProjectListItem from "@/components/Projects/ProjectListItem"
 import { Button } from "@/components/ui/button"
@@ -115,6 +116,17 @@ function ProjectsPage() {
         tourId="projects"
         enabled={!isLoading}
         steps={[
+          {
+            selector: '[data-tour="demo-project-card"]',
+            title: t("tour.projects.demoTitle", {
+              defaultValue: "Try the example project first",
+            }),
+            content: t("tour.projects.demoContent", {
+              defaultValue:
+                "Click this read-only example to walk through a full algorithm-design run in seconds. No LLM keys needed.",
+            }),
+            placement: "bottom",
+          },
           {
             selector: '[data-tour="new-project-btn"]',
             title: t("tour.projects.createProjectTitle"),
@@ -265,36 +277,44 @@ function ProjectsPage() {
 
         {/* Empty state */}
         {!isLoading && items.length === 0 && (
-          <div className="flex flex-col items-center justify-center py-20 text-center">
-            <FolderOpen className="size-16 text-muted-foreground/40 mb-4" />
-            <h3 className="text-lg font-medium text-muted-foreground">
-              {search
-                ? t("projects.noSearchResults")
-                : t("projects.emptyTitle")}
-            </h3>
-            <p className="text-sm text-muted-foreground/70 mt-1 mb-6">
-              {search
-                ? t("projects.noSearchResultsDescription", { q: search })
-                : t("projects.emptyDescription")}
-            </p>
-            {search ? (
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={() => setSearchInput("")}
-              >
-                <X className="mr-2 size-4" />
-                {t("common.clear")}
-              </Button>
-            ) : (
-              <AddProject />
+          <div className="space-y-6">
+            {!search && (
+              <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4 xl:gap-5">
+                <DemoProjectCard />
+              </div>
             )}
+            <div className="flex flex-col items-center justify-center py-12 text-center">
+              <FolderOpen className="size-16 text-muted-foreground/40 mb-4" />
+              <h3 className="text-lg font-medium text-muted-foreground">
+                {search
+                  ? t("projects.noSearchResults")
+                  : t("projects.emptyTitle")}
+              </h3>
+              <p className="text-sm text-muted-foreground/70 mt-1 mb-6">
+                {search
+                  ? t("projects.noSearchResultsDescription", { q: search })
+                  : t("projects.emptyDescription")}
+              </p>
+              {search ? (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => setSearchInput("")}
+                >
+                  <X className="mr-2 size-4" />
+                  {t("common.clear")}
+                </Button>
+              ) : (
+                <AddProject />
+              )}
+            </div>
           </div>
         )}
 
         {/* Card grid */}
         {!isLoading && items.length > 0 && viewMode === "card" && (
           <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4 xl:gap-5">
+            {page === 0 && !search && <DemoProjectCard />}
             {items.map((project) => (
               <ProjectCard key={project.id} project={project} />
             ))}

--- a/src/frontend/src/routes/_layout_evolution.tsx
+++ b/src/frontend/src/routes/_layout_evolution.tsx
@@ -38,6 +38,7 @@ import ShortcutsHelp from "@/components/Evolution/ShortcutsHelp"
 import TechBackground from "@/components/Evolution/TechBackground"
 import TechCorner from "@/components/Evolution/TechCorner"
 import TechPanel from "@/components/Evolution/TechPanel"
+import DemoEvolutionTour from "@/components/Onboarding/DemoEvolutionTour"
 import { getProjectIcon } from "@/components/Projects/ProjectIcons"
 import { Avatar, AvatarFallback } from "@/components/ui/avatar"
 import {
@@ -53,7 +54,20 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip"
+import {
+  buildDemoTask,
+  DEMO_PROJECT,
+  DEMO_TASK,
+  isDemoProjectId,
+  isDemoTaskId,
+} from "@/data/demoFixtures"
 import useAuth, { isLoggedIn } from "@/hooks/useAuth"
+import {
+  enterDemo,
+  exitDemo,
+  setDemoGeneration,
+  useDemoState,
+} from "@/hooks/useDemoMode"
 import type { SelectedNodeInfo } from "@/hooks/useEvolution"
 import { EvolutionContext } from "@/hooks/useEvolution"
 import { useEvolutionNodes } from "@/hooks/useEvolutionNodes"
@@ -353,10 +367,67 @@ function Layout() {
   const { t } = useTranslation()
   const { projectId } = Route.useSearch()
   const queryClient = useQueryClient()
+  const isDemo = isDemoProjectId(projectId)
+  const demoState = useDemoState()
   const [selectedTask, setSelectedTaskRaw] = useState<TaskResponse | null>(null)
   const [selectedChildTaskId, setSelectedChildTaskId] = useState<string | null>(
     null,
   )
+
+  // Sync demo session: entering /evolution with the demo project id activates
+  // demo mode (covers the case where the user visits the URL directly).
+  // Switching to any non-demo project clears it. Cleanup on unmount also
+  // exits — but only if the same effect run started demo mode, so navigating
+  // demo → real → demo doesn't trigger an extra exit on the second cleanup.
+  useEffect(() => {
+    if (!isDemo) {
+      exitDemo()
+      // Clear any lingering demo task selection so a real project never
+      // briefly renders against the simulated DEMO_TASK while its first list
+      // query is in flight.
+      setSelectedTaskRaw(null)
+      setSelectedChildTaskId(null)
+      return
+    }
+    enterDemo("uninitialized")
+    return () => exitDemo()
+  }, [isDemo])
+
+  // Once the simulated task is created (phase ≠ uninitialized) auto-select it
+  // so the right panes mount; before that we want the user to land on the
+  // "no tasks yet — click New Task" empty state.
+  useEffect(() => {
+    if (!isDemo) return
+    if (demoState.phase === "uninitialized") {
+      setSelectedTaskRaw(null)
+      return
+    }
+    setSelectedTaskRaw(buildDemoTask(demoState.phase))
+    // Invalidate the cached demo task detail so views observing the query
+    // re-render with the new phase-derived status.
+    queryClient.invalidateQueries({ queryKey: taskKeys.detail(DEMO_TASK.id) })
+    queryClient.invalidateQueries({ queryKey: ["getTask", DEMO_TASK.id] })
+  }, [isDemo, demoState.phase, queryClient])
+
+  // Running-phase animation: stream the demo's pre-baked generations one at a
+  // time so the user sees the canvas come alive instead of jumping straight to
+  // the final state. Stops at the last generation; the user advances to the
+  // `completed` phase by clicking "Got it" on the tour tooltip.
+  useEffect(() => {
+    if (!isDemo || demoState.phase !== "running") return
+    const TOTAL_GENS = 12
+    const STEP_MS = 220
+    let gen = 0
+    const id = window.setInterval(() => {
+      gen += 1
+      if (gen > TOTAL_GENS) {
+        window.clearInterval(id)
+        return
+      }
+      setDemoGeneration(gen)
+    }, STEP_MS)
+    return () => window.clearInterval(id)
+  }, [isDemo, demoState.phase])
   // Wrap setSelectedTask: when switching to a *different* root task, clear any
   // explicit child override in the same render batch. This prevents the
   // detail query from firing twice (once for the stale root id, once for the
@@ -375,6 +446,11 @@ function Layout() {
     "evo:leftCollapsed",
     false,
   )
+  // Always show the left task panel in demo mode regardless of the user's
+  // persisted preference — the walkthrough relies on the side-by-side layout.
+  // The persisted preference is preserved for when the user returns to a real
+  // project.
+  const effectiveLeftCollapsed = isDemo ? false : leftCollapsed
   // Default collapse right panel on narrow screens (≤1280px) to give the
   // center workspace breathing room. Persists user override.
   const [rightCollapsed, setRightCollapsed] = usePersistentState(
@@ -616,7 +692,10 @@ function Layout() {
   // Fetch effective task to get its status for hooks
   const { data: effectiveTask } = useQuery({
     queryKey: taskKeys.detail(effectiveTaskId!),
-    queryFn: () => Llm4AdTasksService.getTask({ taskId: effectiveTaskId! }),
+    queryFn: () =>
+      isDemoTaskId(effectiveTaskId)
+        ? Promise.resolve(buildDemoTask(demoState.phase))
+        : Llm4AdTasksService.getTask({ taskId: effectiveTaskId! }),
     enabled: !!effectiveTaskId,
   })
 
@@ -673,7 +752,10 @@ function Layout() {
     isLoading: projectLoading,
   } = useQuery({
     queryKey: ["getProject", projectId],
-    queryFn: () => Llm4AdProjectsService.getProject({ projectId: projectId! }),
+    queryFn: () =>
+      isDemoProjectId(projectId)
+        ? Promise.resolve(DEMO_PROJECT)
+        : Llm4AdProjectsService.getProject({ projectId: projectId! }),
     enabled: !!projectId,
   })
 
@@ -761,7 +843,7 @@ function Layout() {
         setInsightSelectedBestNodeId,
         focusNodeRequest,
         requestFocusNode,
-        leftCollapsed,
+        leftCollapsed: effectiveLeftCollapsed,
         setLeftCollapsed,
         resetTaskData: handleResetTask,
         updateTaskStatus: handleStatusChange,
@@ -806,7 +888,7 @@ function Layout() {
               </span>
             </Link>
             {/* Current task selector: only when left panel collapsed (avoid duplication) */}
-            {leftCollapsed && projectId && (
+            {effectiveLeftCollapsed && projectId && (
               <CollapsedTaskSelector
                 projectId={projectId}
                 projectValid={projectValid}
@@ -859,7 +941,9 @@ function Layout() {
                       sideOffset={8}
                       className="max-w-[340px] space-y-1 px-3 py-2"
                     >
-                      <p className="font-semibold leading-snug">{projectName}</p>
+                      <p className="font-semibold leading-snug">
+                        {projectName}
+                      </p>
                       <p className="text-background/80 leading-relaxed whitespace-pre-wrap [overflow-wrap:anywhere]">
                         {description}
                       </p>
@@ -871,6 +955,19 @@ function Layout() {
 
           {/* Right: actions */}
           <div className="flex items-center justify-end gap-3 text-xs text-muted-foreground min-w-0">
+            {isDemo && (
+              <Link
+                to="/projects"
+                data-tour="demo-exit"
+                className="hidden md:inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full
+                  border border-primary/40 bg-primary/10 text-primary text-[11px] font-medium
+                  uppercase tracking-wider hover:bg-primary/20 transition-colors"
+                title={t("demo.exitTitle", { defaultValue: "Exit demo" })}
+              >
+                <span className="size-1.5 rounded-full bg-primary animate-pulse" />
+                {t("demo.banner", { defaultValue: "Demo" })}
+              </Link>
+            )}
             <ConnectionStatus />
             <ShortcutsHelp />
             <div className="hidden sm:flex items-center gap-3">
@@ -888,34 +985,37 @@ function Layout() {
           <aside
             className="shrink-0 flex flex-col overflow-hidden transition-[width] duration-300 ease-in-out bg-background/95"
             style={{
-              width: leftCollapsed ? "0px" : `${LEFT_PANEL_WIDTH}px`,
+              width: effectiveLeftCollapsed ? "0px" : `${LEFT_PANEL_WIDTH}px`,
             }}
-            {...(leftCollapsed ? { inert: true } : {})}
+            {...(effectiveLeftCollapsed ? { inert: true } : {})}
           >
             <TechPanel className="h-full flex flex-col w-64">
               <EvolutionTaskList />
             </TechPanel>
           </aside>
 
-          {/* Left collapse toggle */}
-          <button
-            type="button"
-            onClick={() => setLeftCollapsed(!leftCollapsed)}
-            className="group relative z-20 shrink-0 flex items-center justify-center w-6
-              hover:bg-primary/10 transition-colors text-muted-foreground hover:text-primary
-              border-l border-r border-border/40 hover:border-primary/30"
-            title={
-              leftCollapsed
-                ? t("evolution.expandTaskList")
-                : t("evolution.collapseTaskList")
-            }
-          >
-            {leftCollapsed ? (
-              <ChevronRight className="size-4" />
+          {/* Left collapse toggle — hidden in demo mode so the layout stays
+              fixed at side-by-side for the walkthrough. */}
+          {!isDemo && (
+            <button
+              type="button"
+              onClick={() => setLeftCollapsed(!leftCollapsed)}
+              className="group relative z-20 shrink-0 flex items-center justify-center w-6
+                hover:bg-primary/10 transition-colors text-muted-foreground hover:text-primary
+                border-l border-r border-border/40 hover:border-primary/30"
+              title={
+                leftCollapsed
+                  ? t("evolution.expandTaskList")
+                  : t("evolution.collapseTaskList")
+              }
+            >
+              {leftCollapsed ? (
+                <ChevronRight className="size-4" />
             ) : (
               <ChevronLeft className="size-4" />
             )}
           </button>
+          )}
 
           {/* Center - Main Content */}
           <main className="flex-1 min-w-0 relative overflow-hidden flex flex-col">
@@ -985,6 +1085,9 @@ function Layout() {
 
         {/* Floating AI Chat */}
         <AIChatFloating />
+
+        {/* Demo walkthrough — only renders in demo mode */}
+        {isDemo && <DemoEvolutionTour />}
       </div>
     </EvolutionContext.Provider>
   )


### PR DESCRIPTION
1. Add a read-only "Example · TSP Heuristic" project that every user sees pinned to the top of the project list, backed entirely by frontend fixtures (no backend calls, no DB writes).
2. Build a phase-driven walkthrough (DemoEvolutionTour) with 8 steps that advance as the user actually performs each interaction — open the new task dialog, send chat turns, click run, switch to the IDE tab.
3. Mock the AI Build panel (DemoBuildView) with a multi-turn requirements- gathering script, animated build progress, and node-by-node evolution reveal — visually aligned with the real ChatTuneView.
4. Short-circuit demo project / task ids in useEvolutionNodes, useTaskLogs, getTask, getProject, getTaskTree, listTasks, and the IDE code-server token fetch so demo mode never hits the backend.
5. Add "Replay guided tour" entries in the user menu and Guide page that reset every walkthrough back to its unseen state.
6. Full i18n coverage in zh + en for all new strings (demo card, tour steps, build panel, replay toast, welcome message, gather script).