### PR TITLE
ref: move demo walkthrough to a dedicated /demo route

### DIFF
--- a/src/frontend/src/components/Demo/DemoBuildShell.tsx
+++ b/src/frontend/src/components/Demo/DemoBuildShell.tsx
@@ -1,0 +1,672 @@
+import {
+  Bot,
+  ChevronsUpDown,
+  CircleAlert,
+  FolderOpen,
+  Layers,
+  Monitor,
+  Play,
+  Send,
+  Sparkles,
+  X,
+} from "lucide-react"
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
+import { useTranslation } from "react-i18next"
+
+import { useTypewriter } from "@/components/Demo/useTypewriter"
+import FileTreeView from "@/components/Evolution/TaskDetail/steps/FileTreeView"
+import { DEMO_AI_BUILD_FILES, DEMO_FILE_TREE } from "@/data/demoFixtures"
+import { setDemoPhase, useDemoState } from "@/hooks/useDemoMode"
+import { cn } from "@/lib/utils"
+
+/**
+ * Center pane during the AI Build phases (configuring → building).
+ *
+ * Keeps the visual structure of the real `ChatTuneView` (header with mode
+ * switcher, ✨ left preview / right chat split, composer at the bottom) but
+ * swaps every API-bound subsystem for fixture data:
+ *   - file tree → real `FileTreeView` fed `DEMO_FILE_TREE`
+ *   - composer → bound to `useTypewriter` so each turn types out char-by-char
+ *   - submit → flips demo phase, no `runTask` call
+ *
+ * The chat history is preserved across phase transitions (configuring →
+ * building → running) so the user always sees the conversation that led to
+ * the current state.
+ */
+
+interface ScriptedTurn {
+  userText: string
+  aiText: string
+  /** Delay before the AI reply lands after the user "sends". */
+  aiDelayMs: number
+  /** Pre-fill for the next user turn. Last turn omits this and flips phase. */
+  nextUserText?: string
+}
+
+const GATHER_SCRIPT_ZH: ScriptedTurn[] = [
+  {
+    userText:
+      "你好，我想设计一个旅行商问题（TSP）的启发式算法，目标是最小化总路径长度。",
+    aiText:
+      "好的，我先确认两点细节：\n\n1. 距离类型：欧氏距离还是其它（如曼哈顿、网络距离）？\n2. 问题规模：大约多少个城市？",
+    aiDelayMs: 700,
+    nextUserText: "1. 欧氏距离\n2. 50-100 个城市",
+  },
+  {
+    userText: "1. 欧氏距离\n2. 50-100 个城市",
+    aiText:
+      "明白。再确认一下评估指标 —— 除了路径长度，是否还需要考虑别的，比如运行时间、可视化输出？",
+    aiDelayMs: 650,
+    nextUserText: "只看路径长度即可",
+  },
+  {
+    userText: "只看路径长度即可",
+    aiText:
+      "好的，我已经收集到了所有信息：\n\n• 问题：旅行商问题（TSP）\n• 距离类型：欧氏距离\n• 问题规模：50-100 个城市\n• 评估指标：路径长度\n• 设计思路：贪心最近邻构造 + 2-opt 局部搜索\n• 预计产物：config.yaml、evaluator.py、task.py\n\n确认无误的话，要现在开始构建吗？",
+    aiDelayMs: 750,
+    nextUserText: "好的，开始构建",
+  },
+  {
+    userText: "好的，开始构建",
+    aiText: "收到，开始生成配置和代码……",
+    aiDelayMs: 400,
+  },
+]
+
+const GATHER_SCRIPT_EN: ScriptedTurn[] = [
+  {
+    userText:
+      "Hi, I'd like to design a heuristic for the Travelling Salesman Problem (TSP) to minimize the total tour length.",
+    aiText:
+      "Got it. Let me confirm two details first:\n\n1. Distance type: Euclidean, or something else (Manhattan, network distance, ...)?\n2. Problem size: roughly how many cities?",
+    aiDelayMs: 700,
+    nextUserText: "1. Euclidean\n2. 50-100 cities",
+  },
+  {
+    userText: "1. Euclidean\n2. 50-100 cities",
+    aiText:
+      "Understood. One more on evaluation — besides tour length, do you also care about runtime or any visual output?",
+    aiDelayMs: 650,
+    nextUserText: "Tour length is the only metric we care about.",
+  },
+  {
+    userText: "Tour length is the only metric we care about.",
+    aiText:
+      "Great, I've gathered everything I need:\n\n• Problem: Travelling Salesman Problem (TSP)\n• Distance: Euclidean\n• Size: 50-100 cities\n• Metric: tour length\n• Approach: greedy nearest-neighbor construction + 2-opt local search\n• Expected files: config.yaml, evaluator.py, task.py\n\nIf that all looks right, shall we start the build?",
+    aiDelayMs: 750,
+    nextUserText: "Yes, start the build.",
+  },
+  {
+    userText: "Yes, start the build.",
+    aiText: "On it — generating the config and code now...",
+    aiDelayMs: 400,
+  },
+]
+
+interface ChatMessage {
+  role: "user" | "ai" | "system"
+  text: string
+}
+
+function welcomeMessage(language: string): ChatMessage {
+  if (language?.startsWith("zh")) {
+    return {
+      role: "system",
+      text:
+        "👋 欢迎使用 LLM4AD AI 助手\n\n" +
+        "我将帮助你配置任务参数，让算法设计更加高效。你可以：\n" +
+        "• 直接描述你的需求，我来帮你生成配置\n" +
+        "• 随时对现有配置提出修改建议",
+    }
+  }
+  return {
+    role: "system",
+    text:
+      "👋 Welcome to the LLM4AD AI Assistant\n\n" +
+      "I'll help you configure task parameters for efficient algorithm design. You can:\n" +
+      "• Describe your needs and I'll generate a configuration\n" +
+      "• Ask for modifications to the current config at any time",
+  }
+}
+
+type StageState = "not_started" | "running" | "completed"
+
+interface StageRow {
+  key: "gathering" | "build" | "review"
+  state: StageState
+}
+
+export default function DemoBuildShell() {
+  const { t, i18n } = useTranslation()
+  const demoState = useDemoState()
+  const SCRIPT = i18n.language?.startsWith("zh")
+    ? GATHER_SCRIPT_ZH
+    : GATHER_SCRIPT_EN
+
+  const [gatherStep, setGatherStep] = useState(0)
+  const [messages, setMessages] = useState<ChatMessage[]>(() => [
+    welcomeMessage(i18n.language),
+  ])
+  const [chatBusy, setChatBusy] = useState(false)
+  const [phaseEnteredAt, setPhaseEnteredAt] = useState<number>(() => Date.now())
+  const [, setTick] = useState(0)
+  const replyTimerRef = useRef<number | null>(null)
+  const messagesEndRef = useRef<HTMLDivElement | null>(null)
+
+  // Reset the build animation clock + the gather script when phase changes.
+  useEffect(() => {
+    setPhaseEnteredAt(Date.now())
+    if (replyTimerRef.current) {
+      window.clearTimeout(replyTimerRef.current)
+      replyTimerRef.current = null
+    }
+    if (demoState.phase === "configuring") {
+      setGatherStep(0)
+      setMessages([welcomeMessage(i18n.language)])
+      setChatBusy(false)
+    }
+  }, [demoState.phase, i18n.language])
+
+  // 100ms tick during the build animation so progress / files refresh.
+  useEffect(() => {
+    if (demoState.phase !== "building") return
+    const id = window.setInterval(() => setTick((n) => n + 1), 100)
+    return () => window.clearInterval(id)
+  }, [demoState.phase])
+
+  // Auto-scroll the chat to the bottom whenever new content arrives.
+  useEffect(() => {
+    messagesEndRef.current?.scrollIntoView({ block: "end", behavior: "smooth" })
+  }, [messages.length, chatBusy, demoState.phase])
+
+  // Cleanup pending reply timer on unmount.
+  useEffect(
+    () => () => {
+      if (replyTimerRef.current) window.clearTimeout(replyTimerRef.current)
+    },
+    [],
+  )
+
+  const elapsed = Date.now() - phaseEnteredAt
+  const isConfiguring = demoState.phase === "configuring"
+  const isBuilding = demoState.phase === "building"
+  const buildDone = isBuilding && elapsed >= 2400
+
+  const stages: StageRow[] = useMemo(() => {
+    if (isConfiguring) {
+      return [
+        {
+          key: "gathering",
+          state: gatherStep >= SCRIPT.length ? "completed" : "running",
+        },
+        { key: "build", state: "not_started" },
+        { key: "review", state: "not_started" },
+      ]
+    }
+    if (!isBuilding) {
+      return [
+        { key: "gathering", state: "completed" },
+        { key: "build", state: "completed" },
+        { key: "review", state: "completed" },
+      ]
+    }
+    if (buildDone) {
+      return [
+        { key: "gathering", state: "completed" },
+        { key: "build", state: "completed" },
+        { key: "review", state: "completed" },
+      ]
+    }
+    if (elapsed < 1200) {
+      return [
+        { key: "gathering", state: "completed" },
+        { key: "build", state: "running" },
+        { key: "review", state: "not_started" },
+      ]
+    }
+    return [
+      { key: "gathering", state: "completed" },
+      { key: "build", state: "completed" },
+      { key: "review", state: "running" },
+    ]
+  }, [SCRIPT.length, buildDone, elapsed, gatherStep, isBuilding, isConfiguring])
+
+  const completedCount = stages.filter((s) => s.state === "completed").length
+  const total = stages.length
+  const progressPct = (completedCount / total) * 100
+  const filesVisible = isBuilding ? Math.min(3, Math.floor(elapsed / 700) + 1) : 0
+
+  // Composer state — bound to the typewriter for the current turn's prefill.
+  // When chatBusy is true the composer isn't typing (the AI is); when
+  // gatherStep >= SCRIPT.length there's nothing left to prefill either.
+  const currentPrefill =
+    chatBusy || gatherStep >= SCRIPT.length
+      ? ""
+      : (SCRIPT[gatherStep]?.userText ?? "")
+  const typewriter = useTypewriter(currentPrefill)
+
+  const handleSend = useCallback(() => {
+    if (!isConfiguring || chatBusy) return
+    if (gatherStep >= SCRIPT.length) return
+    if (typewriter.isTyping) return
+    if (!typewriter.text.trim()) return
+
+    const turn = SCRIPT[gatherStep]
+    const userText = typewriter.text.trim() || turn.userText
+    setMessages((m) => [...m, { role: "user", text: userText }])
+    setChatBusy(true)
+    replyTimerRef.current = window.setTimeout(() => {
+      setMessages((m) => [...m, { role: "ai", text: turn.aiText }])
+      setChatBusy(false)
+      const nextStep = gatherStep + 1
+      setGatherStep(nextStep)
+      if (!turn.nextUserText) {
+        // Last turn — flip into the build animation phase.
+        setDemoPhase("building")
+      }
+    }, turn.aiDelayMs)
+  }, [SCRIPT, chatBusy, gatherStep, isConfiguring, typewriter])
+
+  const handleRun = useCallback(() => {
+    if (!buildDone) return
+    setDemoPhase("running")
+  }, [buildDone])
+
+  const STAGE_LABELS: Record<StageRow["key"], string> = {
+    gathering: t("evolution.chatTune.buildSteps.gathering", {
+      defaultValue: "Gathering",
+    }),
+    build: t("evolution.chatTune.buildSteps.build", { defaultValue: "Build" }),
+    review: t("evolution.chatTune.buildSteps.review", {
+      defaultValue: "Review",
+    }),
+  }
+
+  // While building, append a synthetic AI bubble so the chat doesn't go
+  // silent during the 2.4s animation.
+  const buildPhaseMessages: ChatMessage[] = isBuilding
+    ? buildDone
+      ? [
+          {
+            role: "ai",
+            text: t("demoBuild.buildDoneMessage", {
+              defaultValue:
+                "Build complete — three files are ready. Review them on the left, then click Submit & Run to kick off the evolution.",
+            }),
+          },
+        ]
+      : [
+          {
+            role: "ai",
+            text: t("demoBuild.buildingMessage", {
+              defaultValue: "Generating config.yaml, evaluator.py, task.py...",
+            }),
+          },
+        ]
+    : []
+  const visibleMessages = [...messages, ...buildPhaseMessages]
+
+  // FileTreeView consumes the `tree` prop directly — no internal fetching.
+  // We expose a no-op selection handler since the user can't open files in
+  // the demo.
+  const noopSelect = useCallback(() => {}, [])
+  // Reference unused fixture to keep the import alive (display elsewhere).
+  void DEMO_AI_BUILD_FILES
+
+  return (
+    <div className="h-full flex flex-col">
+      {/* Header — mirrors the real ChatTuneView header */}
+      <div className="shrink-0 flex items-center justify-between px-1 pb-2 border-b mb-3">
+        <div className="flex items-center gap-2.5 min-w-0">
+          <span
+            className="flex items-center justify-center size-7 rounded-lg shrink-0 shadow-[0_0_12px] shadow-primary/30"
+            style={{
+              background:
+                "linear-gradient(135deg, color-mix(in srgb, var(--primary) 25%, transparent), color-mix(in srgb, #6366f1 25%, transparent))",
+              border:
+                "1px solid color-mix(in srgb, var(--primary) 40%, transparent)",
+            }}
+          >
+            <Sparkles className="size-3.5 text-primary" />
+          </span>
+          <div className="flex flex-col min-w-0">
+            <span className="text-sm font-semibold leading-tight truncate text-foreground">
+              {t("evolution.chatTune.headerTitle", {
+                defaultValue: "AI Assistant",
+              })}
+            </span>
+            <span className="text-[11px] text-muted-foreground leading-tight truncate">
+              {t("evolution.chatTune.headerHint", {
+                defaultValue:
+                  "Configure parameters quickly through conversation",
+              })}
+            </span>
+          </div>
+        </div>
+        <div className="flex items-center gap-2">
+          <div
+            role="tablist"
+            className="inline-flex items-center gap-0.5 p-0.5 rounded-md border border-primary/40 bg-primary/5 shadow-sm"
+          >
+            <button
+              type="button"
+              role="tab"
+              aria-selected="true"
+              className="flex items-center gap-1 px-2.5 py-1 rounded text-xs font-medium bg-primary text-primary-foreground shadow-sm"
+            >
+              <Sparkles className="size-3.5" />
+              <span>
+                {t("evolution.chatTune.modeAi", { defaultValue: "AI Build" })}
+              </span>
+            </button>
+            <button
+              type="button"
+              role="tab"
+              aria-selected="false"
+              disabled
+              className="flex items-center gap-1 px-2.5 py-1 rounded text-xs font-medium text-muted-foreground/60 cursor-not-allowed"
+            >
+              <Layers className="size-3.5" />
+              <span>
+                {t("evolution.chatTune.modeManual", {
+                  defaultValue: "Manual Build",
+                })}
+              </span>
+            </button>
+          </div>
+          <button
+            type="button"
+            disabled
+            className="p-1.5 rounded-md text-muted-foreground/40 cursor-not-allowed"
+          >
+            <X className="size-4" />
+          </button>
+        </div>
+      </div>
+
+      {/* Body: preview (left, 1/3) + chat (right, 2/3) */}
+      <div className="flex-1 min-h-0 grid grid-cols-1 lg:grid-cols-[minmax(0,1fr)_minmax(0,2fr)] gap-4">
+        {/* Preview column */}
+        <div
+          data-tour="ai-preview"
+          className="min-h-0 flex flex-col rounded-xl border border-border/60 bg-card/70 overflow-hidden"
+        >
+          <div
+            data-tour="ai-preview-body"
+            className="flex-1 min-h-0 flex flex-col"
+          >
+            <div className="shrink-0 px-4 py-3 border-b border-border/50 bg-muted/30">
+              <div className="flex items-center justify-between mb-2">
+                <span className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                  {t("evolution.chatTune.preview.progress", {
+                    defaultValue: "Progress",
+                  })}
+                </span>
+                <span className="text-xs font-semibold text-foreground">
+                  {completedCount} / {total}
+                </span>
+              </div>
+              <div className="h-1.5 rounded-full bg-muted overflow-hidden">
+                <div
+                  className="h-full bg-linear-to-r from-primary to-emerald-400 transition-[width] duration-300"
+                  style={{ width: `${progressPct}%` }}
+                />
+              </div>
+            </div>
+
+            <div className="shrink-0 px-4 py-3 border-b border-border/50">
+              <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground mb-2">
+                {t("evolution.chatTune.preview.stages", {
+                  defaultValue: "Stages",
+                })}
+              </p>
+              <ul className="space-y-1">
+                {stages.map(({ key, state }) => {
+                  const isActive = state === "running"
+                  return (
+                    <li
+                      key={key}
+                      className={cn(
+                        "flex items-center gap-2 px-2 py-1.5 rounded-md text-sm transition-colors",
+                        isActive
+                          ? "bg-primary/10 text-primary"
+                          : state === "completed"
+                            ? "text-foreground"
+                            : "text-muted-foreground",
+                      )}
+                    >
+                      <span className="shrink-0 size-4 flex items-center justify-center">
+                        {state === "completed" ? (
+                          <span className="size-2 rounded-full bg-emerald-500" />
+                        ) : isActive ? (
+                          <span className="size-2 rounded-full bg-primary animate-pulse" />
+                        ) : (
+                          <span className="size-2 rounded-full bg-muted-foreground/30" />
+                        )}
+                      </span>
+                      <span className="flex-1 truncate">{STAGE_LABELS[key]}</span>
+                      {isActive && (
+                        <span className="text-[10px] uppercase tracking-wider opacity-70">
+                          {t("evolution.chatTune.buildStepRunning", {
+                            defaultValue: "Running",
+                          })}
+                        </span>
+                      )}
+                    </li>
+                  )
+                })}
+              </ul>
+            </div>
+
+            <div className="flex-1 min-h-0 overflow-y-auto px-4 py-3">
+              <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground mb-2 flex items-center gap-1.5">
+                <FolderOpen className="size-3.5" />
+                {t("evolution.chatTune.preview.files", {
+                  defaultValue: "Files",
+                })}
+              </p>
+              {filesVisible === 0 ? (
+                <div className="text-xs text-muted-foreground/60 italic">
+                  {t("demoBuild.noFilesYet", {
+                    defaultValue:
+                      "Generated files will appear here once the AI finishes building.",
+                  })}
+                </div>
+              ) : (
+                <FileTreeView
+                  tree={DEMO_FILE_TREE.slice(0, filesVisible >= 2 ? 2 : 1)}
+                  selectedPath={null}
+                  onSelectFile={noopSelect}
+                />
+              )}
+            </div>
+          </div>
+
+          <div
+            data-tour="ai-run"
+            className="shrink-0 px-3 py-2.5 border-t border-border/50 space-y-2"
+          >
+            {!buildDone && (
+              <div className="flex items-center gap-1.5 px-2 py-1.5 rounded-md text-[11px] bg-muted/60 border border-border/50 text-muted-foreground">
+                <CircleAlert className="size-3 shrink-0" />
+                <span>
+                  {t("evolution.chatTune.runHintNeedBuild", {
+                    defaultValue: "Submit run after the AI build completes",
+                  })}
+                </span>
+              </div>
+            )}
+            <button
+              type="button"
+              onClick={handleRun}
+              disabled={!buildDone}
+              className={cn(
+                "w-full inline-flex items-center justify-center gap-1.5 h-9 px-4 rounded-md text-sm font-medium transition-all",
+                buildDone
+                  ? "bg-primary text-primary-foreground shadow-md hover:shadow-lg"
+                  : "bg-primary/30 text-primary-foreground/60 cursor-not-allowed",
+              )}
+            >
+              <Play className="size-3.5" />
+              {t("evolution.confirmStep.submitRun", {
+                defaultValue: "Submit & Run",
+              })}
+            </button>
+          </div>
+        </div>
+
+        {/* Chat column */}
+        <div
+          data-tour="ai-chat-panel"
+          className="min-h-0 flex flex-col rounded-xl border border-border/60 bg-card/70 overflow-hidden"
+        >
+          <div className="flex-1 min-h-0 overflow-y-auto p-4 space-y-3">
+            {visibleMessages.map((msg, idx) => {
+              if (msg.role === "system") {
+                return (
+                  <div
+                    // biome-ignore lint/suspicious/noArrayIndexKey: chat is append-only and immutable
+                    key={idx}
+                    className="flex gap-2 animate-in fade-in slide-in-from-bottom-1 duration-200"
+                  >
+                    <div className="shrink-0 flex items-center justify-center size-7 rounded-lg bg-muted border border-border/50">
+                      <Monitor className="size-3.5 text-muted-foreground" />
+                    </div>
+                    <div className="min-w-0 flex-1">
+                      <div className="rounded-2xl rounded-tl-sm border border-dashed border-muted-foreground/30 bg-muted/40 px-3.5 py-2 text-sm leading-relaxed text-muted-foreground whitespace-pre-wrap">
+                        {msg.text}
+                      </div>
+                    </div>
+                  </div>
+                )
+              }
+              const isUser = msg.role === "user"
+              return (
+                <div
+                  // biome-ignore lint/suspicious/noArrayIndexKey: chat is append-only and immutable
+                  key={idx}
+                  className="flex gap-2 animate-in fade-in slide-in-from-bottom-1 duration-200"
+                >
+                  <div
+                    className={cn(
+                      "shrink-0 size-7 rounded-lg",
+                      isUser && "invisible",
+                    )}
+                  >
+                    {!isUser && (
+                      <div className="size-full flex items-center justify-center bg-primary/10 border border-primary/20 rounded-lg">
+                        <Bot className="size-3.5 text-primary" />
+                      </div>
+                    )}
+                  </div>
+                  <div className="min-w-0 flex-1 flex flex-col gap-2">
+                    <div
+                      className={cn(
+                        "rounded-2xl px-3.5 py-2 text-sm leading-relaxed shadow-sm min-w-0 [overflow-wrap:anywhere]",
+                        isUser
+                          ? "bg-primary text-primary-foreground rounded-tr-sm whitespace-pre-wrap self-end max-w-[85%]"
+                          : "bg-gradient-to-br from-muted to-muted/60 border border-border/50 text-foreground rounded-tl-sm whitespace-pre-wrap min-h-[44px] flex flex-col justify-center max-w-[90%]",
+                      )}
+                    >
+                      {msg.text}
+                    </div>
+                  </div>
+                </div>
+              )
+            })}
+            {chatBusy && (
+              <div className="flex gap-2 animate-in fade-in slide-in-from-bottom-1 duration-200">
+                <div className="shrink-0 size-7 rounded-lg flex items-center justify-center bg-primary/10 border border-primary/20">
+                  <Bot className="size-3.5 text-primary" />
+                </div>
+                <div className="rounded-2xl rounded-tl-sm bg-gradient-to-br from-muted to-muted/60 border border-border/50 px-3.5 py-2.5">
+                  <span className="inline-flex gap-1">
+                    <span className="size-1.5 rounded-full bg-current animate-bounce" />
+                    <span
+                      className="size-1.5 rounded-full bg-current animate-bounce"
+                      style={{ animationDelay: "0.15s" }}
+                    />
+                    <span
+                      className="size-1.5 rounded-full bg-current animate-bounce"
+                      style={{ animationDelay: "0.3s" }}
+                    />
+                  </span>
+                </div>
+              </div>
+            )}
+            <div ref={messagesEndRef} />
+          </div>
+
+          {/* Composer */}
+          <div className="shrink-0 px-3 pb-3 pt-2">
+            <div
+              data-tour="ai-composer"
+              className={cn(
+                "relative rounded-2xl border-2 backdrop-blur-md transition-all duration-200",
+                isConfiguring && !chatBusy
+                  ? "shadow-lg shadow-primary/8 border-primary/20 bg-card/95"
+                  : "border-border/20 bg-card/80 opacity-60",
+              )}
+            >
+              <div className="px-4 pt-3 pb-1">
+                <textarea
+                  value={typewriter.text}
+                  readOnly
+                  onClick={typewriter.skip}
+                  placeholder={
+                    chatBusy
+                      ? t("evolution.chatTune.composerGenerating", {
+                          defaultValue: "AI is generating a response...",
+                        })
+                      : t("evolution.chatTune.composerActive", {
+                          defaultValue:
+                            "Tell AI your needs through conversation...",
+                        })
+                  }
+                  className="w-full resize-none border-0 bg-transparent text-sm leading-relaxed placeholder:text-muted-foreground/60 focus:outline-none min-h-[40px] cursor-default"
+                  disabled={!isConfiguring || chatBusy}
+                />
+              </div>
+              <div className="flex items-center justify-between px-3 pb-2.5">
+                <div className="flex items-center gap-1.5">
+                  <button
+                    type="button"
+                    disabled
+                    className="size-7 flex items-center justify-center rounded-lg text-muted-foreground/50 cursor-not-allowed"
+                  >
+                    <ChevronsUpDown className="size-3.5" />
+                  </button>
+                </div>
+                <button
+                  type="button"
+                  data-tour="ai-send"
+                  onClick={handleSend}
+                  disabled={
+                    !isConfiguring ||
+                    chatBusy ||
+                    typewriter.isTyping ||
+                    !typewriter.text.trim()
+                  }
+                  className={cn(
+                    "inline-flex items-center gap-1.5 h-8 px-4 rounded-xl text-xs font-medium transition-all duration-200",
+                    isConfiguring &&
+                      !chatBusy &&
+                      !typewriter.isTyping &&
+                      typewriter.text.trim()
+                      ? "bg-primary text-primary-foreground shadow-md shadow-primary/25 hover:shadow-lg"
+                      : "bg-primary/10 text-primary/40 cursor-not-allowed",
+                  )}
+                >
+                  <Send className="size-3.5" />
+                  <span>
+                    {t("evolution.chatTune.send", { defaultValue: "Send" })}
+                  </span>
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/frontend/src/components/Demo/DemoResultShell.tsx
+++ b/src/frontend/src/components/Demo/DemoResultShell.tsx
@@ -1,0 +1,39 @@
+import { useTranslation } from "react-i18next"
+
+import InitializedView from "@/components/Evolution/TaskDetail/InitializedView"
+import { buildDemoTask } from "@/data/demoFixtures"
+import type { DemoPhase } from "@/hooks/useDemoMode"
+import { useDemoState } from "@/hooks/useDemoMode"
+
+/**
+ * Center pane during the result phases (running → completed).
+ *
+ * Reuses the production `InitializedView` directly. That component reads
+ * everything it needs from `EvolutionContext` — node graph, log entries,
+ * active tab, selected nodes — and the demo route's layout already feeds
+ * those slots with fixture-driven values via the existing demo
+ * short-circuits in `useEvolutionNodes` and `useTaskLogs`.
+ *
+ * The IDE tab inside `InitializedView` already detects demo task ids and
+ * swaps its iframe for a static code block, so no extra branching is
+ * needed here.
+ */
+export default function DemoResultShell() {
+  const { t } = useTranslation()
+  const demoState = useDemoState()
+
+  if (demoState.phase === "uninitialized") {
+    return (
+      <div className="h-full w-full flex flex-col items-center justify-center text-muted-foreground">
+        <p className="text-sm">
+          {t("demo.result.notReady", {
+            defaultValue: "Waiting for the build to start...",
+          })}
+        </p>
+      </div>
+    )
+  }
+
+  const task = buildDemoTask(demoState.phase as DemoPhase)
+  return <InitializedView task={task} />
+}

--- a/src/frontend/src/components/Demo/DemoRightPanel.tsx
+++ b/src/frontend/src/components/Demo/DemoRightPanel.tsx
@@ -1,0 +1,183 @@
+import { useTranslation } from "react-i18next"
+
+import { buildDemoTask } from "@/data/demoFixtures"
+import type { DemoPhase } from "@/hooks/useDemoMode"
+import { useDemoState } from "@/hooks/useDemoMode"
+
+/**
+ * Read-only right-side panel for the demo route.
+ *
+ * Mirrors the visual rhythm of the real `EvolutionRightPanel` (compact
+ * status badge, key/value rows, parameter list) but exposes ZERO
+ * interactive controls — no Run / Stop / Adjust params / View params /
+ * AI Build History buttons. Per leadership feedback the demo's right
+ * column should be informational only, so the user never gets stuck on
+ * a button that would silently no-op.
+ *
+ * The component derives its task state from the live `demoState.phase`
+ * via `buildDemoTask(phase)` so the panel reflects whatever step of the
+ * walkthrough the user is on (uninitialized → configuring → … → done).
+ */
+export default function DemoRightPanel() {
+  const { t } = useTranslation()
+  const demoState = useDemoState()
+
+  if (demoState.phase === "uninitialized") {
+    return (
+      <div className="flex flex-col h-full">
+        <div className="px-4 py-3 border-b border-border/50">
+          <span className="text-xs font-semibold uppercase tracking-wider text-muted-foreground/80">
+            {t("demo.rightPanel.title", { defaultValue: "Task Info" })}
+          </span>
+        </div>
+        <div className="flex-1 flex items-center justify-center text-center px-4">
+          <p className="text-xs text-muted-foreground/70">
+            {t("demo.rightPanel.empty", {
+              defaultValue: "Create a task to see its status and parameters.",
+            })}
+          </p>
+        </div>
+      </div>
+    )
+  }
+
+  const task = buildDemoTask(demoState.phase as DemoPhase)
+  const statusInfo = getStatusInfo(t, task.status)
+  const args = (task.input_args ?? {}) as Record<string, unknown>
+
+  return (
+    <div className="flex flex-col h-full">
+      <div className="shrink-0 px-4 py-3 border-b border-border/50 flex items-center justify-between">
+        <span className="text-xs font-semibold uppercase tracking-wider text-muted-foreground/80">
+          {t("demo.rightPanel.title", { defaultValue: "Task Info" })}
+        </span>
+        <span
+          className="inline-flex items-center gap-1.5 px-2 py-0.5 rounded-md text-[10px] font-medium uppercase tracking-wider border"
+          style={{
+            color: statusInfo.color,
+            borderColor: `${statusInfo.color}55`,
+            backgroundColor: `${statusInfo.color}15`,
+          }}
+        >
+          <span
+            className="size-1.5 rounded-full"
+            style={{ backgroundColor: statusInfo.color }}
+          />
+          {statusInfo.label}
+        </span>
+      </div>
+
+      <div className="flex-1 min-h-0 overflow-y-auto px-4 py-3 space-y-4">
+        <div>
+          <div className="text-[10px] uppercase tracking-wider text-muted-foreground/60 mb-1">
+            {t("demo.rightPanel.name", { defaultValue: "Name" })}
+          </div>
+          <div className="text-sm text-foreground break-words">{task.name}</div>
+        </div>
+
+        {task.description && (
+          <div>
+            <div className="text-[10px] uppercase tracking-wider text-muted-foreground/60 mb-1">
+              {t("demo.rightPanel.description", {
+                defaultValue: "Description",
+              })}
+            </div>
+            <div className="text-xs text-muted-foreground break-words leading-relaxed">
+              {task.description}
+            </div>
+          </div>
+        )}
+
+        <div>
+          <div className="text-[10px] uppercase tracking-wider text-muted-foreground/60 mb-1">
+            {t("demo.rightPanel.parameters", {
+              defaultValue: "Parameters",
+            })}
+          </div>
+          <div className="space-y-1">
+            {Object.entries(args).length === 0 ? (
+              <span className="text-xs text-muted-foreground/60 italic">
+                {t("demo.rightPanel.noParameters", { defaultValue: "—" })}
+              </span>
+            ) : (
+              Object.entries(args).map(([key, value]) => (
+                <div
+                  key={key}
+                  className="flex items-center justify-between gap-2 text-xs"
+                >
+                  <span className="text-muted-foreground font-mono truncate">
+                    {key}
+                  </span>
+                  <span className="text-foreground font-mono tabular-nums">
+                    {String(value)}
+                  </span>
+                </div>
+              ))
+            )}
+          </div>
+        </div>
+
+        <div>
+          <div className="text-[10px] uppercase tracking-wider text-muted-foreground/60 mb-1">
+            {t("demo.rightPanel.flags", { defaultValue: "Build Mode" })}
+          </div>
+          <div className="text-xs text-foreground">
+            {task.ai_built
+              ? t("demo.rightPanel.aiBuilt", { defaultValue: "AI Build" })
+              : t("demo.rightPanel.manualBuilt", {
+                  defaultValue: "Manual Build",
+                })}
+          </div>
+        </div>
+      </div>
+
+      <div className="shrink-0 px-4 py-2.5 border-t border-border/50">
+        <p className="text-[10px] text-muted-foreground/60 italic leading-relaxed">
+          {t("demo.rightPanel.readOnlyHint", {
+            defaultValue:
+              "Read-only — interactive controls are disabled in the demo.",
+          })}
+        </p>
+      </div>
+    </div>
+  )
+}
+
+function getStatusInfo(
+  t: (key: string, opts?: { defaultValue?: string }) => string,
+  status: string,
+): { label: string; color: string } {
+  switch (status) {
+    case "uninitialized":
+      return {
+        label: t("evolution.taskStatus.uninitialized", {
+          defaultValue: "Uninitialized",
+        }),
+        color: "#6b7280",
+      }
+    case "pending":
+      return {
+        label: t("evolution.taskStatus.pending", { defaultValue: "Pending" }),
+        color: "#f59e0b",
+      }
+    case "running":
+      return {
+        label: t("evolution.taskStatus.running", { defaultValue: "Running" }),
+        color: "#00d4ff",
+      }
+    case "completed":
+      return {
+        label: t("evolution.taskStatus.completed", {
+          defaultValue: "Completed",
+        }),
+        color: "#10b981",
+      }
+    case "failed":
+      return {
+        label: t("evolution.taskStatus.failed", { defaultValue: "Failed" }),
+        color: "#ef4444",
+      }
+    default:
+      return { label: status, color: "#6b7280" }
+  }
+}

--- a/src/frontend/src/components/Demo/DemoTaskList.tsx
+++ b/src/frontend/src/components/Demo/DemoTaskList.tsx
@@ -1,0 +1,407 @@
+import { useState } from "react"
+import { useForm } from "react-hook-form"
+import { useTranslation } from "react-i18next"
+
+import {
+  AlertTriangle,
+  Bot,
+  CheckCircle2,
+  Circle,
+  Clock,
+  FolderOpen,
+  Loader2,
+  Plus,
+  Settings2,
+} from "lucide-react"
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog"
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form"
+import { Input } from "@/components/ui/input"
+import { LoadingButton } from "@/components/ui/loading-button"
+import { Button } from "@/components/ui/button"
+import { buildDemoTask, DEMO_TASK_ID } from "@/data/demoFixtures"
+import { setDemoPhase, useDemoState } from "@/hooks/useDemoMode"
+import { useEvolution } from "@/hooks/useEvolution"
+import { formatDateTime } from "@/lib/utils"
+import { cn } from "@/lib/utils"
+
+/**
+ * Demo task list — visual twin of `EvolutionTaskList`.
+ *
+ * Same header (title + "+" icon trigger), same task-row layout (status
+ * icon + name + status badge + timestamp), same "no tasks yet" empty
+ * state. The only differences are:
+ *   - the row never renders the rename/delete/copy hover actions
+ *   - the create dialog locks to AI Build mode (manual is shown but
+ *     non-clickable, mirroring real visual but disabled per leadership)
+ *   - submitting the dialog flips the demo phase instead of calling the
+ *     real createTask API
+ */
+function getStatusConfig(t: (key: string) => string) {
+  return {
+    uninitialized: {
+      icon: Circle,
+      color: "#6b7280",
+      label: t("evolution.taskStatus.uninitialized"),
+      bg: "rgba(107,114,128,0.12)",
+    },
+    pending: {
+      icon: Clock,
+      color: "#f59e0b",
+      label: t("evolution.taskStatus.pending"),
+      bg: "rgba(245,158,11,0.12)",
+    },
+    running: {
+      icon: Loader2,
+      color: "#00d4ff",
+      label: t("evolution.taskStatus.running"),
+      bg: "rgba(0,212,255,0.12)",
+    },
+    completed: {
+      icon: CheckCircle2,
+      color: "#10b981",
+      label: t("evolution.taskStatus.completed"),
+      bg: "rgba(16,185,129,0.12)",
+    },
+    failed: {
+      icon: AlertTriangle,
+      color: "#f87171",
+      label: t("evolution.taskStatus.failed"),
+      bg: "rgba(248,113,113,0.12)",
+    },
+  } as Record<
+    string,
+    { icon: typeof Circle; color: string; label: string; bg: string }
+  >
+}
+
+interface NameFormData {
+  name: string
+}
+
+export default function DemoTaskList() {
+  const { t } = useTranslation()
+  const demoState = useDemoState()
+  const { selectedTask, setSelectedTask, effectiveStatus } = useEvolution()
+  const [dialogOpen, setDialogOpen] = useState(false)
+  const statusConfig = getStatusConfig(t)
+  const taskExists = demoState.phase !== "uninitialized"
+
+  return (
+    <div className="flex flex-col h-full min-h-0">
+      {/* Header — mirrors EvolutionTaskList */}
+      <div className="flex items-center justify-between px-4 py-3 border-b border-border/60">
+        <h3 className="text-sm font-semibold text-primary tracking-wider uppercase">
+          {t("evolution.taskList", { defaultValue: "Task List" })}
+        </h3>
+        <DemoCreateTaskDialog
+          open={dialogOpen}
+          onOpenChange={setDialogOpen}
+          onCreated={(task) => {
+            setSelectedTask(task)
+          }}
+        />
+      </div>
+
+      {/* Task list body */}
+      <div className="flex-1 min-h-0 overflow-y-auto p-2 space-y-1 scrollbar-thin">
+        {!taskExists ? (
+          <div className="flex flex-col items-center justify-center gap-3 py-12 text-center">
+            <FolderOpen className="size-10 text-muted-foreground/40" />
+            <p className="text-xs text-muted-foreground">
+              {t("evolution.emptyTaskList", {
+                defaultValue: "No tasks yet",
+              })}
+            </p>
+          </div>
+        ) : (
+          <DemoTaskRow
+            isActive={selectedTask?.id === DEMO_TASK_ID}
+            displayStatus={effectiveStatus}
+            statusConfig={statusConfig}
+            onSelect={() => setSelectedTask(buildDemoTask(demoState.phase))}
+          />
+        )}
+      </div>
+    </div>
+  )
+}
+
+function DemoTaskRow({
+  isActive,
+  displayStatus,
+  statusConfig,
+  onSelect,
+}: {
+  isActive: boolean
+  displayStatus: string
+  statusConfig: ReturnType<typeof getStatusConfig>
+  onSelect: () => void
+}) {
+  const { t } = useTranslation()
+  const status = statusConfig[displayStatus] ?? statusConfig.uninitialized
+  const StatusIcon = status.icon
+
+  // Date so the demo row's "created at" time isn't suspiciously fresh.
+  const createdAt = "2026-06-17T10:00:00Z"
+
+  return (
+    <div
+      data-tour="demo-task-row"
+      className={cn(
+        "group flex flex-col gap-1 px-3 py-2.5 rounded-md cursor-pointer transition-all duration-200 border",
+        isActive
+          ? "bg-primary/10 border-primary/40 shadow-[0_0_12px] shadow-primary/15"
+          : "border-transparent hover:bg-accent/60 hover:border-border/40",
+      )}
+      onClick={onSelect}
+    >
+      <div className="flex items-center gap-2.5">
+        <StatusIcon
+          className={cn(
+            "size-3.5 shrink-0",
+            displayStatus === "running" && "animate-spin",
+          )}
+          style={{ color: status.color }}
+        />
+        <span
+          className={cn(
+            "text-sm truncate flex-1",
+            isActive ? "text-primary" : "text-muted-foreground",
+          )}
+        >
+          {t("demo.taskList.taskName", {
+            defaultValue: "Demo · Greedy + Local Search",
+          })}
+        </span>
+        <span
+          className="text-[10px] shrink-0 px-1.5 py-0.5 rounded"
+          style={{ color: status.color, background: status.bg }}
+        >
+          {status.label}
+        </span>
+      </div>
+      <div className="flex items-center pl-6">
+        <span className="text-[10px] text-muted-foreground/60">
+          {formatDateTime(createdAt)}
+        </span>
+      </div>
+    </div>
+  )
+}
+
+/**
+ * Demo's clone of `CreateTaskDialog` — same DialogTrigger ("+" icon
+ * button in the panel header) and same body (task name + side-by-side
+ * Manual/AI mode cards). The only divergences:
+ *   - manual card is visually rendered but non-clickable (icon dimmed,
+ *     `cursor-not-allowed`, no onClick)
+ *   - submission skips createTask and flips the demo phase instead
+ */
+function DemoCreateTaskDialog({
+  open,
+  onOpenChange,
+  onCreated,
+}: {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  onCreated: (task: ReturnType<typeof buildDemoTask>) => void
+}) {
+  const { t } = useTranslation()
+
+  const form = useForm<NameFormData>({
+    mode: "onBlur",
+    defaultValues: {
+      name: "TSP Heuristic",
+    },
+  })
+
+  const handleSubmit = (data: NameFormData) => {
+    if (!data.name.trim()) return
+    onOpenChange(false)
+    setDemoPhase("configuring")
+    const task = buildDemoTask("configuring")
+    onCreated({ ...task, name: data.name.trim() })
+  }
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        onOpenChange(next)
+        if (!next) form.reset({ name: "TSP Heuristic" })
+      }}
+    >
+      <DialogTrigger asChild>
+        <button
+          type="button"
+          data-tour="new-task-btn"
+          className="flex items-center gap-1.5 px-3 py-1.5 text-xs rounded
+            border border-primary/30 text-primary hover:bg-primary/10
+            transition-colors"
+        >
+          <Plus className="size-3.5" />
+          {t("evolution.createTask", { defaultValue: "New Task" })}
+        </button>
+      </DialogTrigger>
+      <DialogContent
+        data-tour="create-task-dialog"
+        className="sm:max-w-lg"
+      >
+        <DialogHeader>
+          <DialogTitle>
+            {t("evolution.createTaskTitle", {
+              defaultValue: "Create a new task",
+            })}
+          </DialogTitle>
+          <DialogDescription>
+            {t("demo.taskList.dialogDescription", {
+              defaultValue:
+                "AI Build is pre-selected for the walkthrough. Click Create to continue.",
+            })}
+          </DialogDescription>
+        </DialogHeader>
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(handleSubmit)}>
+            <div className="grid gap-4 py-4">
+              <FormField
+                control={form.control}
+                name="name"
+                rules={{
+                  required: t("validation.taskNameRequired", {
+                    defaultValue: "Task name is required",
+                  }),
+                  maxLength: 255,
+                }}
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>
+                      {t("evolution.taskName", { defaultValue: "Task name" })}{" "}
+                      <span className="text-destructive">*</span>
+                    </FormLabel>
+                    <FormControl>
+                      <Input
+                        placeholder={t("evolution.taskNamePlaceholder", {
+                          defaultValue: "Enter a task name",
+                        })}
+                        {...field}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              {/* Build mode selector — manual rendered but locked to AI */}
+              <div className="space-y-2">
+                <label className="text-sm font-medium leading-none">
+                  {t("evolution.buildModeLabel", {
+                    defaultValue: "Build mode",
+                  })}
+                </label>
+                <div className="grid grid-cols-2 gap-3">
+                  {/* Manual card — visible but non-interactive in demo */}
+                  <div
+                    aria-disabled="true"
+                    className="relative flex flex-col items-start gap-1.5 rounded-lg border-2 p-3 text-left
+                      border-border/60 opacity-60 cursor-not-allowed"
+                    title={t("demo.taskList.manualDisabled", {
+                      defaultValue:
+                        "Manual mode is disabled in the walkthrough",
+                    })}
+                  >
+                    <div className="flex items-center gap-2">
+                      <div className="flex items-center justify-center size-6 rounded-md bg-muted text-muted-foreground">
+                        <Settings2 className="size-3.5" />
+                      </div>
+                      <span className="text-sm font-medium text-foreground">
+                        {t("evolution.buildModeManual", {
+                          defaultValue: "Manual",
+                        })}
+                      </span>
+                    </div>
+                    <p className="text-[11px] text-muted-foreground leading-relaxed">
+                      {t("evolution.buildModeManualDesc", {
+                        defaultValue:
+                          "Fill in every parameter step by step.",
+                      })}
+                    </p>
+                  </div>
+
+                  {/* AI card — selected, primary styling */}
+                  <div
+                    aria-selected="true"
+                    className="relative flex flex-col items-start gap-1.5 rounded-lg border-2 p-3 text-left
+                      border-primary bg-primary/5 shadow-sm shadow-primary/10"
+                  >
+                    <div className="flex items-center gap-2">
+                      <div className="flex items-center justify-center size-6 rounded-md bg-primary/15 text-primary">
+                        <Bot className="size-3.5" />
+                      </div>
+                      <span className="text-sm font-medium text-primary">
+                        {t("evolution.buildModeAi", {
+                          defaultValue: "AI Build",
+                        })}
+                      </span>
+                    </div>
+                    <p className="text-[11px] text-muted-foreground leading-relaxed">
+                      {t("evolution.buildModeAiDesc", {
+                        defaultValue:
+                          "Configure through conversation with the AI.",
+                      })}
+                    </p>
+                    <div className="absolute top-2 right-2 size-4 rounded-full bg-primary flex items-center justify-center">
+                      <CheckCircle2 className="size-3 text-primary-foreground" />
+                    </div>
+                  </div>
+                </div>
+              </div>
+
+              <div className="flex items-center gap-2 rounded-md border border-primary/20 bg-primary/5 px-3 py-2.5">
+                <Bot className="size-4 text-primary shrink-0" />
+                <p className="text-xs text-muted-foreground leading-relaxed">
+                  {t("evolution.buildModeAiTemplateHint", {
+                    defaultValue:
+                      "AI Build doesn't need a template — the agent will guide you through every choice.",
+                  })}
+                </p>
+              </div>
+            </div>
+
+            <DialogFooter>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => onOpenChange(false)}
+              >
+                {t("common.cancel", { defaultValue: "Cancel" })}
+              </Button>
+              <LoadingButton
+                type="submit"
+                data-tour="create-task-submit"
+                loading={false}
+              >
+                {t("common.create", { defaultValue: "Create" })}
+              </LoadingButton>
+            </DialogFooter>
+          </form>
+        </Form>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/frontend/src/components/Demo/useTypewriter.ts
+++ b/src/frontend/src/components/Demo/useTypewriter.ts
@@ -1,0 +1,87 @@
+import { useCallback, useEffect, useRef, useState } from "react"
+
+interface UseTypewriterOptions {
+  /** Milliseconds between each character. Default 30ms. */
+  speed?: number
+  /** Fired once the full target string has been typed out. */
+  onDone?: () => void
+  /** Skip the animation entirely and resolve to the full text immediately. */
+  skipImmediately?: boolean
+}
+
+interface UseTypewriterResult {
+  /** The portion of `target` typed out so far. */
+  text: string
+  /** True until every character is in place. */
+  isTyping: boolean
+  /** Snap to the full `target`. Safe to call mid-animation. */
+  skip: () => void
+}
+
+/**
+ * Char-by-char typewriter for the demo composer.
+ *
+ * Resets and replays whenever `target` changes, so each pre-filled turn in
+ * the gather script gets its own animation. Uses `setTimeout` (not rAF) so
+ * the effect still advances when the tab is backgrounded — important for
+ * the "user clicked away during demo, comes back, finds composer half-typed"
+ * edge case.
+ *
+ * Usage in DemoBuildShell:
+ *   const { text, isTyping, skip } = useTypewriter(prefillForCurrentTurn)
+ *   <textarea value={text} readOnly onClick={skip} />
+ *   <button disabled={isTyping || !text.trim()}>Send</button>
+ */
+export function useTypewriter(
+  target: string,
+  opts: UseTypewriterOptions = {},
+): UseTypewriterResult {
+  const { speed = 30, onDone, skipImmediately = false } = opts
+  const [text, setText] = useState(skipImmediately ? target : "")
+  const timerRef = useRef<number | null>(null)
+  const onDoneRef = useRef(onDone)
+  onDoneRef.current = onDone
+
+  const clearTimer = () => {
+    if (timerRef.current != null) {
+      window.clearTimeout(timerRef.current)
+      timerRef.current = null
+    }
+  }
+
+  // Run / re-run whenever target changes. Each run schedules itself one char
+  // at a time; we track progress in a closure-local index so React state
+  // updates only happen at character boundaries (no extra renders).
+  useEffect(() => {
+    clearTimer()
+    if (skipImmediately || !target) {
+      setText(target ?? "")
+      onDoneRef.current?.()
+      return
+    }
+    setText("")
+    let i = 0
+    const tick = () => {
+      i += 1
+      setText(target.slice(0, i))
+      if (i >= target.length) {
+        timerRef.current = null
+        onDoneRef.current?.()
+        return
+      }
+      timerRef.current = window.setTimeout(tick, speed)
+    }
+    timerRef.current = window.setTimeout(tick, speed)
+    return clearTimer
+  }, [target, speed, skipImmediately])
+
+  const skip = useCallback(() => {
+    clearTimer()
+    setText(target)
+    onDoneRef.current?.()
+  }, [target])
+
+  const isTyping = text.length < target.length
+
+  return { text, isTyping, skip }
+}

--- a/src/frontend/src/components/Onboarding/DemoTour.tsx
+++ b/src/frontend/src/components/Onboarding/DemoTour.tsx
@@ -1,0 +1,829 @@
+import { useNavigate } from "@tanstack/react-router"
+import { useEffect, useMemo, useRef, useState } from "react"
+import { createPortal } from "react-dom"
+import { useTranslation } from "react-i18next"
+
+import type { DemoPhase } from "@/hooks/useDemoMode"
+import { setDemoPhase, useDemoState } from "@/hooks/useDemoMode"
+import { useEvolution } from "@/hooks/useEvolution"
+
+/**
+ * Phase-driven walkthrough overlay for `/demo`.
+ *
+ * Three-layer overlay structure addresses leadership feedback #2 and #3:
+ *
+ *   z-9998: four invisible click-blocker rectangles surrounding the
+ *           spotlight cutout. They absorb every click outside the
+ *           highlighted region with `pointer-events: auto` and no
+ *           background, so the user is forced to hit the highlighted
+ *           target (or the in-tooltip Exit button).
+ *   z-9999: a single full-screen SVG with a `<mask>` punching a hole
+ *           where the spotlight is. Renders the dimming ring/glow without
+ *           any seams between sibling divs and is `pointer-events: none`.
+ *   z-10000: tooltip + inner pulse ring. Lives above everything and
+ *           catches clicks on the in-tooltip controls (Got it / Back /
+ *           Exit demo).
+ *
+ * Spotlight rect coords are quantized to device pixels via
+ * `Math.round(value * dpr) / dpr` so the cutout aligns crisply on any
+ * `devicePixelRatio` (HiDPI displays, OS scaling, browser zoom). A
+ * `ResizeObserver` on the anchor element keeps the rect synced as
+ * downstream layouts settle.
+ */
+
+interface Step {
+  selector: string
+  phase: DemoPhase
+  titleKey: string
+  contentKey: string
+  titleFallback: string
+  contentFallback: string
+  placement?: "top" | "bottom" | "left" | "right"
+  manualNext?: boolean
+  manualNextPhase?: DemoPhase
+  /** Inner pulse ring on the actionable button inside a wide spotlight. */
+  pulseSelector?: string
+  /** If true, advance to this step the moment its anchor mounts. */
+  autoAdvanceOnAnchor?: boolean
+  /** Hide the Back button on this step (e.g. a sub-step that mustn't be undone). */
+  hideBack?: boolean
+}
+
+const PHASE_ORDER: DemoPhase[] = [
+  "uninitialized",
+  "configuring",
+  "building",
+  "running",
+  "completed",
+]
+
+const STEPS: Step[] = [
+  {
+    phase: "uninitialized",
+    selector: '[data-tour="new-task-btn"]',
+    titleKey: "demoTour.create.title",
+    contentKey: "demoTour.create.content",
+    titleFallback: "Step 1 · Create a task",
+    contentFallback:
+      'Click "New task" to follow the full guided experience.',
+    placement: "right",
+  },
+  {
+    phase: "uninitialized",
+    selector: '[data-tour="create-task-dialog"]',
+    titleKey: "demoTour.createSubmit.title",
+    contentKey: "demoTour.createSubmit.content",
+    titleFallback: "Step 1b · Pick a build mode",
+    contentFallback:
+      'AI Build is selected, name pre-filled — click "Create" to continue.',
+    placement: "right",
+    autoAdvanceOnAnchor: true,
+    pulseSelector: '[data-tour="create-task-submit"]',
+    // Going back to step 1 would have to close the dialog the user just
+    // opened — not worth supporting.
+    hideBack: true,
+  },
+  {
+    phase: "configuring",
+    selector: '[data-tour="demo-task-row"]',
+    titleKey: "demoTour.taskRow.title",
+    contentKey: "demoTour.taskRow.content",
+    titleFallback: "Step 2 · Your task appears in the sidebar",
+    contentFallback:
+      "The task you just created shows up in the left task list. In real projects you'll see every task here — click any row to switch between them.",
+    placement: "right",
+    manualNext: true,
+  },
+  {
+    phase: "configuring",
+    selector: '[data-tour="ai-chat-panel"]',
+    titleKey: "demoTour.send.title",
+    contentKey: "demoTour.send.content",
+    titleFallback: "Step 3 · Chat with the AI",
+    contentFallback:
+      'Click "Send" to step through the conversation. The AI gathers your requirements then asks whether to start building.',
+    placement: "left",
+    pulseSelector: '[data-tour="ai-send"]',
+  },
+  {
+    phase: "building",
+    selector: '[data-tour="ai-preview-body"]',
+    titleKey: "demoTour.building.title",
+    contentKey: "demoTour.building.content",
+    titleFallback: "Step 4 · Wait while the build runs",
+    contentFallback:
+      "The progress bar fills as the agent moves through Gathering → Build → Review. Generated files appear below.",
+    placement: "right",
+    manualNext: true,
+  },
+  {
+    phase: "building",
+    selector: '[data-tour="ai-run"]',
+    titleKey: "demoTour.run.title",
+    contentKey: "demoTour.run.content",
+    titleFallback: "Step 5 · Submit and start the auto-design loop",
+    contentFallback:
+      'Click "Submit & Run" to kick off evolution — candidates appear generation by generation.',
+    placement: "right",
+  },
+  {
+    phase: "running",
+    selector: '[data-tour="result-canvas"]',
+    titleKey: "demoTour.canvas.title",
+    contentKey: "demoTour.canvas.content",
+    titleFallback: "Step 6 · Watch the design process unfold",
+    contentFallback:
+      "Inspect the evolution graph — every node is one algorithm the system designed. Logs stream in alongside.",
+    placement: "right",
+    manualNext: true,
+    manualNextPhase: "completed",
+  },
+  {
+    phase: "completed",
+    selector: '[data-tour="demo-best-summary"]',
+    titleKey: "demoTour.ide.title",
+    contentKey: "demoTour.ide.content",
+    titleFallback: "Step 7 · Read the final algorithm",
+    contentFallback:
+      "Click the IDE tab to read the algorithm LLM4AD_Next evolved.",
+    placement: "bottom",
+  },
+  {
+    phase: "completed",
+    selector: '[data-tour="demo-ide-code"]',
+    titleKey: "demoTour.ideCode.title",
+    contentKey: "demoTour.ideCode.content",
+    titleFallback: "Step 8 · Skim the generated code",
+    contentFallback:
+      "This is the algorithm — greedy nearest-neighbor with 2-opt refinement. Skim through it, then click Got it to wrap up.",
+    placement: "left",
+    manualNext: true,
+  },
+  {
+    phase: "completed",
+    // Final step — no anchor, tooltip lands centered. The exit affordance
+    // lives in the tooltip itself per leadership #9.
+    selector: "",
+    titleKey: "demoTour.exit.title",
+    contentKey: "demoTour.exit.content",
+    titleFallback: "You're ready",
+    contentFallback:
+      "Head back to the project list, configure an LLM provider, and create your first real project.",
+    placement: "bottom",
+    manualNext: true,
+  },
+]
+
+interface Rect {
+  top: number
+  left: number
+  width: number
+  height: number
+}
+
+const CUTOUT_PADDING = 6
+const TOOLTIP_WIDTH = 360
+const TOOLTIP_GAP = 14
+const VIEWPORT_MARGIN = 12
+
+function quantizeToDevicePixels(value: number, dpr: number): number {
+  if (!Number.isFinite(dpr) || dpr <= 0) return Math.round(value)
+  return Math.round(value * dpr) / dpr
+}
+
+function getRect(el: Element): Rect {
+  const r = el.getBoundingClientRect()
+  const dpr = typeof window !== "undefined" ? window.devicePixelRatio : 1
+  return {
+    top: quantizeToDevicePixels(r.top, dpr),
+    left: quantizeToDevicePixels(r.left, dpr),
+    width: quantizeToDevicePixels(r.width, dpr),
+    height: quantizeToDevicePixels(r.height, dpr),
+  }
+}
+
+function placeTooltip(
+  rect: Rect | null,
+  preferred: Step["placement"],
+  tooltipHeight: number,
+): { top: number; left: number } {
+  const vw = window.innerWidth
+  const vh = window.innerHeight
+  if (!rect) {
+    // Centered fallback for the final step (no anchor).
+    return {
+      top: Math.max(VIEWPORT_MARGIN, (vh - tooltipHeight) / 2),
+      left: Math.max(VIEWPORT_MARGIN, (vw - TOOLTIP_WIDTH) / 2),
+    }
+  }
+  let top = 0
+  let left = 0
+  switch (preferred ?? "bottom") {
+    case "top":
+      top = rect.top - TOOLTIP_GAP - tooltipHeight
+      left = rect.left + rect.width / 2 - TOOLTIP_WIDTH / 2
+      break
+    case "bottom":
+      top = rect.top + rect.height + TOOLTIP_GAP
+      left = rect.left + rect.width / 2 - TOOLTIP_WIDTH / 2
+      break
+    case "left":
+      top = rect.top + rect.height / 2 - tooltipHeight / 2
+      left = rect.left - TOOLTIP_GAP - TOOLTIP_WIDTH
+      break
+    case "right":
+      top = rect.top + rect.height / 2 - tooltipHeight / 2
+      left = rect.left + rect.width + TOOLTIP_GAP
+      break
+  }
+  left = Math.max(
+    VIEWPORT_MARGIN,
+    Math.min(left, vw - TOOLTIP_WIDTH - VIEWPORT_MARGIN),
+  )
+  top = Math.max(
+    VIEWPORT_MARGIN,
+    Math.min(top, vh - tooltipHeight - VIEWPORT_MARGIN),
+  )
+  return { top, left }
+}
+
+export default function DemoTour() {
+  const { t } = useTranslation()
+  const navigate = useNavigate()
+  const demoState = useDemoState()
+  const { activeTab } = useEvolution()
+  const [subStepIdx, setSubStepIdx] = useState(0)
+  const [rect, setRect] = useState<Rect | null>(null)
+  const [pulseRect, setPulseRect] = useState<Rect | null>(null)
+  const [tooltipHeight, setTooltipHeight] = useState(200)
+  const [tooltipPos, setTooltipPos] = useState<{ top: number; left: number }>({
+    top: 0,
+    left: 0,
+  })
+  const tooltipRef = useRef<HTMLDivElement | null>(null)
+
+  // Reset sub-step when phase changes; clear stale rects so the overlay
+  // doesn't paint against an unmounted target while the new anchor is
+  // still settling.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: only re-fire on phase change
+  useEffect(() => {
+    setSubStepIdx(0)
+    setRect(null)
+    setPulseRect(null)
+  }, [demoState.phase])
+
+  // IDE tab listener: completed-phase step 7 advances to step 8 the moment
+  // the user actually opens the IDE tab. Tracks previous activeTab so
+  // hitting Back to step 7 doesn't immediately bounce forward again.
+  const prevTabRef = useRef<string | null>(null)
+  useEffect(() => {
+    const prev = prevTabRef.current
+    prevTabRef.current = activeTab
+    if (demoState.phase !== "completed") return
+    if (subStepIdx !== 0) return
+    if (prev !== "ide" && activeTab === "ide") {
+      setSubStepIdx(1)
+    }
+  }, [demoState.phase, subStepIdx, activeTab])
+
+  const currentStep = useMemo(() => {
+    const matching = STEPS.filter((s) => s.phase === demoState.phase)
+    const idx = Math.min(subStepIdx, matching.length - 1)
+    return matching[idx] ?? null
+  }, [demoState.phase, subStepIdx])
+
+  // Locate the current spotlight target. Uses ResizeObserver on the anchor
+  // for tight sync as layouts settle, plus resize/scroll fallbacks. Also
+  // re-measures at 150 / 350 / 650ms after first hit to catch the final
+  // bounds of elements mounting inside an animating container (Radix
+  // Dialog's zoom-in transform was the symptom that exposed this).
+  useEffect(() => {
+    if (!currentStep) return
+    setRect(null)
+    if (!currentStep.selector) {
+      // Final step has no anchor.
+      return
+    }
+    let cancelled = false
+    let attempts = 0
+    let observer: ResizeObserver | null = null
+    let observedEl: Element | null = null
+    const settleTimers: number[] = []
+
+    const measure = (el: Element) => {
+      const r = getRect(el)
+      if (r.width > 0 && r.height > 0 && !cancelled) {
+        setRect(r)
+      }
+    }
+    const scheduleSettle = (el: Element) => {
+      for (const delay of [150, 350, 650]) {
+        settleTimers.push(
+          window.setTimeout(() => {
+            if (!cancelled && document.contains(el)) measure(el)
+          }, delay),
+        )
+      }
+    }
+    const tick = () => {
+      if (cancelled) return
+      const el = document.querySelector(currentStep.selector)
+      if (el) {
+        measure(el)
+        scheduleSettle(el)
+        if (observer == null) {
+          observer = new ResizeObserver(() => {
+            if (observedEl) measure(observedEl)
+          })
+          observedEl = el
+          observer.observe(el)
+        }
+        return
+      }
+      attempts += 1
+      if (attempts < 40) window.setTimeout(tick, 100)
+    }
+    tick()
+
+    const onUpdate = () => {
+      const el = document.querySelector(currentStep.selector)
+      if (el) measure(el)
+      else if (!cancelled) setRect(null)
+    }
+    window.addEventListener("resize", onUpdate)
+    window.addEventListener("scroll", onUpdate, true)
+    return () => {
+      cancelled = true
+      for (const id of settleTimers) window.clearTimeout(id)
+      observer?.disconnect()
+      window.removeEventListener("resize", onUpdate)
+      window.removeEventListener("scroll", onUpdate, true)
+    }
+  }, [currentStep])
+
+  // Track the optional inner pulse target.
+  //
+  // Re-measure on a short schedule (150 / 350 / 650ms) after the first hit
+  // so we catch the final position of elements that mount inside an
+  // animating container (e.g. Radix Dialog's `data-[state=open]:zoom-in-95`
+  // transform — getBoundingClientRect at frame 0 returns the pre-animation
+  // bounds, which is what made the 1b pulse ring land off-target).
+  useEffect(() => {
+    setPulseRect(null)
+    if (!currentStep?.pulseSelector) return
+    const sel = currentStep.pulseSelector
+    let cancelled = false
+    let attempts = 0
+    let observer: ResizeObserver | null = null
+    let observedEl: Element | null = null
+    const settleTimers: number[] = []
+
+    const measure = (el: Element) => {
+      const r = getRect(el)
+      if (r.width > 0 && r.height > 0 && !cancelled) setPulseRect(r)
+    }
+    const scheduleSettle = (el: Element) => {
+      for (const delay of [150, 350, 650]) {
+        settleTimers.push(
+          window.setTimeout(() => {
+            if (!cancelled && document.contains(el)) measure(el)
+          }, delay),
+        )
+      }
+    }
+    const tick = () => {
+      if (cancelled) return
+      const el = document.querySelector(sel)
+      if (el) {
+        measure(el)
+        scheduleSettle(el)
+        if (observer == null) {
+          observer = new ResizeObserver(() => {
+            if (observedEl) measure(observedEl)
+          })
+          observedEl = el
+          observer.observe(el)
+        }
+        return
+      }
+      attempts += 1
+      if (attempts < 40) window.setTimeout(tick, 100)
+    }
+    tick()
+
+    const onUpdate = () => {
+      const el = document.querySelector(sel)
+      if (el) measure(el)
+      else if (!cancelled) setPulseRect(null)
+    }
+    window.addEventListener("resize", onUpdate)
+    window.addEventListener("scroll", onUpdate, true)
+    return () => {
+      cancelled = true
+      for (const id of settleTimers) window.clearTimeout(id)
+      observer?.disconnect()
+      window.removeEventListener("resize", onUpdate)
+      window.removeEventListener("scroll", onUpdate, true)
+    }
+  }, [currentStep])
+
+  // Auto-advance to the next sub-step when its anchor appears in the DOM.
+  useEffect(() => {
+    const matching = STEPS.filter((s) => s.phase === demoState.phase)
+    const next = matching[subStepIdx + 1]
+    if (!next?.autoAdvanceOnAnchor) return
+    let cancelled = false
+    const tick = () => {
+      if (cancelled) return
+      const el = document.querySelector(next.selector) as HTMLElement | null
+      if (el) {
+        const r = el.getBoundingClientRect()
+        if (r.width > 0 && r.height > 0) {
+          setSubStepIdx((i) => i + 1)
+          return
+        }
+      }
+      window.setTimeout(tick, 200)
+    }
+    const id = window.setTimeout(tick, 200)
+    return () => {
+      cancelled = true
+      window.clearTimeout(id)
+    }
+  }, [demoState.phase, subStepIdx])
+
+  // Reposition the tooltip whenever the spotlight or the tooltip itself
+  // changes size.
+  useEffect(() => {
+    if (!currentStep) return
+    setTooltipPos(placeTooltip(rect, currentStep.placement, tooltipHeight))
+  }, [rect, currentStep, tooltipHeight])
+
+  // Measure tooltip height after render so the clamp keeps it on-screen.
+  useEffect(() => {
+    if (!tooltipRef.current) return
+    const h = tooltipRef.current.getBoundingClientRect().height
+    if (h > 0 && Math.abs(h - tooltipHeight) > 1) setTooltipHeight(h)
+  })
+
+  if (!currentStep) return null
+  // For anchored steps without a settled rect, suspend rendering so we
+  // never paint against an unmounted target. The final step has no anchor
+  // and renders even with `rect === null`.
+  if (currentStep.selector && !rect) return null
+
+  const phaseIdx = PHASE_ORDER.indexOf(demoState.phase)
+  const matching = STEPS.filter((s) => s.phase === demoState.phase)
+  const isLastStepInPhase = subStepIdx >= matching.length - 1
+  // Total step number for the "{n} / {total}" badge — count steps across
+  // all phases so the user sees overall progress, not per-phase.
+  const totalSteps = STEPS.length
+  const stepNumber = STEPS.indexOf(currentStep) + 1
+  const isFinalStep = stepNumber === totalSteps
+
+  const canGoBack =
+    !currentStep.hideBack &&
+    (subStepIdx > 0 || phaseIdx > 0)
+
+  const handleAdvance = () => {
+    if (isLastStepInPhase) {
+      if (currentStep.manualNextPhase) {
+        setDemoPhase(currentStep.manualNextPhase)
+        return
+      }
+      // Final step — exit on the manualNext button.
+      if (isFinalStep) {
+        navigate({ to: "/projects" })
+        return
+      }
+    }
+    setSubStepIdx((i) => i + 1)
+  }
+
+  const handleBack = () => {
+    if (subStepIdx > 0) {
+      setSubStepIdx((i) => i - 1)
+      return
+    }
+    if (phaseIdx <= 0) return
+    const prevPhase = PHASE_ORDER[phaseIdx - 1]
+    const prevSteps = STEPS.filter((s) => s.phase === prevPhase)
+    // Find the last "user-facing" step in the previous phase. autoAdvance
+    // steps (e.g. step 1b which only mounts when its anchor dialog appears)
+    // would immediately advance again or sit on a missing anchor — skip them.
+    let targetIdx = prevSteps.length - 1
+    while (targetIdx > 0 && prevSteps[targetIdx]?.autoAdvanceOnAnchor) {
+      targetIdx -= 1
+    }
+    setDemoPhase(prevPhase)
+    const finalIdx = targetIdx
+    window.setTimeout(() => setSubStepIdx(finalIdx), 0)
+  }
+
+  const handleExit = () => {
+    navigate({ to: "/projects" })
+  }
+
+  const isDark =
+    typeof document !== "undefined" &&
+    document.documentElement.classList.contains("dark")
+  const overlayBg = "rgba(0, 8, 24, 0.55)"
+  const ringColor = isDark
+    ? "rgba(0, 212, 255, 0.85)"
+    : "rgba(37, 99, 235, 0.9)"
+  const ringGlow = isDark
+    ? "rgba(0, 212, 255, 0.45)"
+    : "rgba(37, 99, 235, 0.35)"
+  const tooltipBorder = isDark
+    ? "rgba(0, 212, 255, 0.35)"
+    : "rgba(37, 99, 235, 0.25)"
+
+  // The cutout rectangle (with padding) — used by both the SVG mask
+  // visual and the four invisible click-blocker rectangles.
+  const cutout = rect
+    ? {
+        top: rect.top - CUTOUT_PADDING,
+        left: rect.left - CUTOUT_PADDING,
+        width: rect.width + CUTOUT_PADDING * 2,
+        height: rect.height + CUTOUT_PADDING * 2,
+      }
+    : null
+
+  const vw = typeof window !== "undefined" ? window.innerWidth : 1920
+  const vh = typeof window !== "undefined" ? window.innerHeight : 1080
+
+  return createPortal(
+    <div
+      style={{
+        position: "fixed",
+        inset: 0,
+        zIndex: 9998,
+        pointerEvents: "none",
+      }}
+    >
+      {/* z-9998: invisible click-blocker rectangles surrounding the cutout.
+          Pure event sinks — no background, no visual. They sit underneath
+          the visual mask so the dimmed area looks seamless. When there is
+          no cutout (final step), a single full-screen blocker is rendered. */}
+      {cutout ? (
+        <>
+          <div
+            style={{
+              position: "fixed",
+              top: 0,
+              left: 0,
+              right: 0,
+              height: Math.max(0, cutout.top),
+              pointerEvents: "auto",
+            }}
+            onClickCapture={(e) => e.stopPropagation()}
+            onMouseDownCapture={(e) => e.stopPropagation()}
+            aria-hidden="true"
+          />
+          <div
+            style={{
+              position: "fixed",
+              top: cutout.top + cutout.height,
+              left: 0,
+              right: 0,
+              bottom: 0,
+              pointerEvents: "auto",
+            }}
+            onClickCapture={(e) => e.stopPropagation()}
+            onMouseDownCapture={(e) => e.stopPropagation()}
+            aria-hidden="true"
+          />
+          <div
+            style={{
+              position: "fixed",
+              top: cutout.top,
+              left: 0,
+              width: Math.max(0, cutout.left),
+              height: cutout.height,
+              pointerEvents: "auto",
+            }}
+            onClickCapture={(e) => e.stopPropagation()}
+            onMouseDownCapture={(e) => e.stopPropagation()}
+            aria-hidden="true"
+          />
+          <div
+            style={{
+              position: "fixed",
+              top: cutout.top,
+              left: cutout.left + cutout.width,
+              right: 0,
+              height: cutout.height,
+              pointerEvents: "auto",
+            }}
+            onClickCapture={(e) => e.stopPropagation()}
+            onMouseDownCapture={(e) => e.stopPropagation()}
+            aria-hidden="true"
+          />
+        </>
+      ) : (
+        <div
+          style={{
+            position: "fixed",
+            inset: 0,
+            pointerEvents: "auto",
+          }}
+          onClickCapture={(e) => e.stopPropagation()}
+          onMouseDownCapture={(e) => e.stopPropagation()}
+          aria-hidden="true"
+        />
+      )}
+
+      {/* z-9999: SVG-mask visual. One element, one path — no sub-pixel seams. */}
+      <svg
+        style={{
+          position: "fixed",
+          inset: 0,
+          width: vw,
+          height: vh,
+          zIndex: 1,
+          pointerEvents: "none",
+        }}
+        aria-hidden="true"
+      >
+        <title>Demo tour overlay</title>
+        <defs>
+          <mask id="demo-tour-mask">
+            <rect width="100%" height="100%" fill="white" />
+            {cutout && (
+              <rect
+                x={cutout.left}
+                y={cutout.top}
+                width={cutout.width}
+                height={cutout.height}
+                rx={8}
+                ry={8}
+                fill="black"
+              />
+            )}
+          </mask>
+        </defs>
+        <rect
+          width="100%"
+          height="100%"
+          fill={overlayBg}
+          mask="url(#demo-tour-mask)"
+        />
+        {cutout && (
+          <rect
+            x={cutout.left}
+            y={cutout.top}
+            width={cutout.width}
+            height={cutout.height}
+            rx={8}
+            ry={8}
+            fill="none"
+            stroke={ringColor}
+            strokeWidth={2}
+            style={{
+              filter: `drop-shadow(0 0 12px ${ringGlow})`,
+            }}
+          />
+        )}
+      </svg>
+
+      {/* Inner pulse ring (purely decorative, no pointer events). */}
+      {pulseRect && (
+        <div
+          style={{
+            position: "fixed",
+            top: pulseRect.top - 4,
+            left: pulseRect.left - 4,
+            width: pulseRect.width + 8,
+            height: pulseRect.height + 8,
+            borderRadius: 10,
+            border: `2px solid ${ringColor}`,
+            boxShadow: `0 0 0 4px ${ringGlow}, 0 0 18px 6px ${ringGlow}`,
+            pointerEvents: "none",
+            animation: "demoPulseRing 1.4s ease-in-out infinite",
+            zIndex: 2,
+          }}
+        />
+      )}
+
+      {/* z-10000: tooltip card. Lives above everything.
+
+          stopPropagation on pointer events is critical when the spotlight
+          target is a Radix dialog: without it, clicking anywhere on the
+          tooltip would trigger the dialog's onPointerDownOutside handler
+          and close the dialog mid-walkthrough. */}
+      <div
+        ref={tooltipRef}
+        role="dialog"
+        aria-modal="false"
+        onPointerDown={(e) => e.stopPropagation()}
+        onMouseDown={(e) => e.stopPropagation()}
+        onClick={(e) => e.stopPropagation()}
+        style={{
+          position: "fixed",
+          top: tooltipPos.top,
+          left: tooltipPos.left,
+          width: TOOLTIP_WIDTH,
+          background: "var(--popover)",
+          color: "var(--popover-foreground)",
+          border: `1px solid ${tooltipBorder}`,
+          borderRadius: 10,
+          padding: 16,
+          boxShadow: isDark
+            ? "0 12px 32px rgba(0, 0, 0, 0.45), 0 0 16px rgba(0, 212, 255, 0.15)"
+            : "0 12px 32px rgba(15, 23, 42, 0.18), 0 0 16px rgba(37, 99, 235, 0.08)",
+          pointerEvents: "auto",
+          fontSize: 13,
+          lineHeight: 1.55,
+          zIndex: 10,
+        }}
+      >
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+            marginBottom: 6,
+          }}
+        >
+          <div style={{ fontSize: 14, fontWeight: 600 }}>
+            {t(currentStep.titleKey, { defaultValue: currentStep.titleFallback })}
+          </div>
+          <div style={{ fontSize: 11, opacity: 0.6 }}>
+            {stepNumber} / {totalSteps}
+          </div>
+        </div>
+        <div style={{ marginBottom: 14, opacity: 0.92, whiteSpace: "pre-wrap" }}>
+          {t(currentStep.contentKey, {
+            defaultValue: currentStep.contentFallback,
+          })}
+        </div>
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+            gap: 8,
+          }}
+        >
+          <div style={{ display: "flex", alignItems: "center", gap: 12 }}>
+            {canGoBack && (
+              <button
+                type="button"
+                onClick={handleBack}
+                style={{
+                  fontSize: 12,
+                  padding: "5px 12px",
+                  borderRadius: 6,
+                  border: "1px solid var(--border)",
+                  background: "transparent",
+                  color: "var(--foreground)",
+                  cursor: "pointer",
+                }}
+              >
+                {t("demoTour.back", { defaultValue: "Back" })}
+              </button>
+            )}
+          </div>
+          <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+            <button
+              type="button"
+              onClick={handleExit}
+              style={{
+                fontSize: 11,
+                color: "var(--muted-foreground)",
+                background: "transparent",
+                border: "none",
+                cursor: "pointer",
+                padding: "5px 8px",
+                textDecoration: "underline",
+              }}
+            >
+              {t("demoTour.exitDemo", { defaultValue: "Exit demo" })}
+            </button>
+            {currentStep.manualNext && (
+              <button
+                type="button"
+                onClick={handleAdvance}
+                style={{
+                  fontSize: 12,
+                  padding: "5px 14px",
+                  borderRadius: 6,
+                  border: "1px solid var(--primary)",
+                  background: "var(--primary)",
+                  color: "var(--primary-foreground)",
+                  cursor: "pointer",
+                  fontWeight: 500,
+                }}
+              >
+                {isFinalStep
+                  ? t("demoTour.finishExit", { defaultValue: "Exit demo" })
+                  : t("demoTour.gotIt", { defaultValue: "Got it" })}
+              </button>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>,
+    document.body,
+  )
+}

--- a/src/frontend/src/components/Projects/DemoProjectCard.tsx
+++ b/src/frontend/src/components/Projects/DemoProjectCard.tsx
@@ -10,7 +10,6 @@ import {
   CardTitle,
 } from "@/components/ui/card"
 import { DEMO_PROJECT } from "@/data/demoFixtures"
-import { enterDemo } from "@/hooks/useDemoMode"
 import { getProjectIcon } from "./ProjectIcons"
 
 export default function DemoProjectCard() {
@@ -19,8 +18,9 @@ export default function DemoProjectCard() {
   const Icon = getProjectIcon(DEMO_PROJECT.icon)
 
   const handleEnter = () => {
-    enterDemo("uninitialized")
-    navigate({ to: "/evolution", search: { projectId: DEMO_PROJECT.id } })
+    // The dedicated /demo route owns the demo session lifecycle now —
+    // _layout_demo calls enterDemo on mount.
+    navigate({ to: "/demo" })
   }
 
   return (

--- a/src/frontend/src/data/demoFixtures/index.ts
+++ b/src/frontend/src/data/demoFixtures/index.ts
@@ -199,3 +199,6 @@ export const DEMO_AI_BUILD_FILES = [
   { name: "evaluator.py", language: "python" },
   { name: "task.py", language: "python" },
 ]
+
+export { DEMO_FILE_TREE } from "./mockFileTree"
+export { DEMO_LOG_ENTRIES, visibleLogCount } from "./mockLogs"

--- a/src/frontend/src/data/demoFixtures/mockFileTree.ts
+++ b/src/frontend/src/data/demoFixtures/mockFileTree.ts
@@ -1,0 +1,49 @@
+import type { FileTreeNode } from "@/client"
+
+/**
+ * Mock file tree shown in the demo's AI Build preview panel.
+ *
+ * Two-level structure: an `algorithm` folder with the evaluator/task code and
+ * a `config` folder with config files. Mirrors the artifact layout the AI
+ * build pipeline actually produces, so the demo's `FileTreeView` looks
+ * indistinguishable from a real run.
+ *
+ * Wired through `<FileTreeView tree={DEMO_FILE_TREE} />` in DemoBuildShell —
+ * the real `FileTreeView` component is reused as-is, no internal changes.
+ */
+export const DEMO_FILE_TREE: FileTreeNode[] = [
+  {
+    name: "algorithm",
+    path: "algorithm",
+    type: "directory",
+    children: [
+      {
+        name: "evaluator.py",
+        path: "algorithm/evaluator.py",
+        type: "file",
+      },
+      {
+        name: "task.py",
+        path: "algorithm/task.py",
+        type: "file",
+      },
+    ],
+  },
+  {
+    name: "config",
+    path: "config",
+    type: "directory",
+    children: [
+      {
+        name: "config.yaml",
+        path: "config/config.yaml",
+        type: "file",
+      },
+      {
+        name: "params.json",
+        path: "config/params.json",
+        type: "file",
+      },
+    ],
+  },
+]

--- a/src/frontend/src/data/demoFixtures/mockLogs.ts
+++ b/src/frontend/src/data/demoFixtures/mockLogs.ts
@@ -1,0 +1,141 @@
+import type { LogEntry } from "@/hooks/useTaskLogs"
+
+/**
+ * Mock log entries surfaced through the demo's `LogsPanel`.
+ *
+ * Shape mirrors what the real backend streams via SSE — log-renderers.tsx
+ * reads `level / message / timestamp / module / function / line` directly off
+ * each entry, so feeding fixtures with the same fields makes the demo logs
+ * look pixel-identical to a real run.
+ *
+ * Story arc: load dataset → init islands → step through generations → done.
+ *
+ * Wired via the demo short-circuit inside `useTaskLogs` — the hook returns a
+ * slice of this array based on the current demo phase, so the panel "fills
+ * up" as the user advances the walkthrough.
+ */
+export const DEMO_LOG_ENTRIES: LogEntry[] = [
+  {
+    _kind: "log",
+    type: "log",
+    timestamp: "2026-06-17T11:18:09.035000+00:00",
+    level: "DEBUG",
+    message: "Global settings file not found at /root/.llm4ad/settings.yaml",
+    module: "llm4ad.config.settings",
+    function: "load_global_settings",
+    line: 98,
+  },
+  {
+    _kind: "log",
+    type: "log",
+    timestamp: "2026-06-17T11:18:09.214000+00:00",
+    level: "INFO",
+    message: "Loading dataset: tsp_50.json (50 cities, Euclidean distance)",
+    module: "llm4ad.evaluator.dataset",
+    function: "load_dataset",
+    line: 142,
+  },
+  {
+    _kind: "log",
+    type: "log",
+    timestamp: "2026-06-17T11:18:09.531000+00:00",
+    level: "INFO",
+    message: "Initializing 2 islands with population 8 each",
+    module: "llm4ad.evolution.islands",
+    function: "initialize",
+    line: 67,
+  },
+  {
+    _kind: "log",
+    type: "log",
+    timestamp: "2026-06-17T11:18:10.812000+00:00",
+    level: "INFO",
+    message:
+      "Generation 1: best score 0.31, mean score 0.18 (16 candidates evaluated)",
+    module: "llm4ad.evolution.runner",
+    function: "step_generation",
+    line: 215,
+  },
+  {
+    _kind: "log",
+    type: "log",
+    timestamp: "2026-06-17T11:18:14.226000+00:00",
+    level: "INFO",
+    message:
+      "Generation 4: best score 0.58 (+0.27 over baseline) — 2-opt swap accepted",
+    module: "llm4ad.evolution.runner",
+    function: "step_generation",
+    line: 215,
+  },
+  {
+    _kind: "log",
+    type: "log",
+    timestamp: "2026-06-17T11:18:18.094000+00:00",
+    level: "DEBUG",
+    message: "Cross-island migration: best individual A-7 → island B",
+    module: "llm4ad.evolution.islands",
+    function: "migrate",
+    line: 188,
+  },
+  {
+    _kind: "log",
+    type: "log",
+    timestamp: "2026-06-17T11:18:21.473000+00:00",
+    level: "INFO",
+    message: "Generation 8: best score 0.81, convergence detected on island A",
+    module: "llm4ad.evolution.runner",
+    function: "step_generation",
+    line: 215,
+  },
+  {
+    _kind: "log",
+    type: "log",
+    timestamp: "2026-06-17T11:18:25.117000+00:00",
+    level: "INFO",
+    message: "Generation 12: best score 0.93 — convergence reached",
+    module: "llm4ad.evolution.runner",
+    function: "step_generation",
+    line: 215,
+  },
+  {
+    _kind: "log",
+    type: "log",
+    timestamp: "2026-06-17T11:18:25.341000+00:00",
+    level: "INFO",
+    message: "Run finished. Best individual: gen12_A (score 0.93)",
+    module: "llm4ad.evolution.runner",
+    function: "finalize",
+    line: 312,
+  },
+  {
+    _kind: "log",
+    type: "log",
+    timestamp: "2026-06-17T11:18:25.404000+00:00",
+    level: "INFO",
+    message: "Total wall time: 00:01:24, total candidates evaluated: 192",
+    module: "llm4ad.evolution.runner",
+    function: "finalize",
+    line: 318,
+  },
+]
+
+/**
+ * How many entries to expose for a given demo phase. Drives the "logs fill
+ * up as the run progresses" effect inside `useTaskLogs`.
+ */
+export function visibleLogCount(phase: string): number {
+  switch (phase) {
+    case "completed":
+      return DEMO_LOG_ENTRIES.length
+    case "running":
+      // Show everything up to and including the "Generation 12 done" line so
+      // the user perceives the animation as following the live progress.
+      return Math.min(DEMO_LOG_ENTRIES.length, 8)
+    case "building":
+      return 3
+    case "configuring":
+      return 1
+    default:
+      return 0
+  }
+}

--- a/src/frontend/src/hooks/useTaskLogs.ts
+++ b/src/frontend/src/hooks/useTaskLogs.ts
@@ -4,7 +4,11 @@ import { useTranslation } from "react-i18next"
 import type { TaskStatus } from "@/client"
 import { Llm4AdTasksService } from "@/client"
 import type { LogLevel } from "@/components/Evolution/TaskDetail/log-renderers"
-import { DEMO_LOG_LINES, isDemoTaskId } from "@/data/demoFixtures"
+import {
+  DEMO_LOG_ENTRIES,
+  isDemoTaskId,
+  visibleLogCount,
+} from "@/data/demoFixtures"
 import { useDemoState } from "@/hooks/useDemoMode"
 import { taskKeys } from "@/lib/task-queries"
 import { authFetch } from "@/utils/auth"
@@ -277,28 +281,12 @@ export function useTaskLogs(
 
   // ---------- Return ----------
   if (isDemo) {
-    // Walk through the canned log lines as the demo phase advances so the
-    // logs panel feels alive while the user clicks through the tour.
-    const phase = demoState.phase
-    const visibleCount =
-      phase === "completed"
-        ? DEMO_LOG_LINES.length
-        : phase === "running"
-          ? Math.min(DEMO_LOG_LINES.length, 5)
-          : phase === "building"
-            ? 2
-            : 0
-    const entries: LogEntry[] = DEMO_LOG_LINES.slice(0, visibleCount).map(
-      (line, idx) => ({
-        _kind: "log",
-        type: "log",
-        level: "info",
-        message: line,
-        timestamp: new Date(
-          Date.now() - (visibleCount - idx) * 1000,
-        ).toISOString(),
-      }),
-    )
+    // Slice the demo fixture by phase so the logs "fill up" as the user
+    // clicks through the walkthrough. Each entry already carries the full
+    // {level, module, function, line, ...} shape that log-renderers expects,
+    // so the panel renders identically to a real run.
+    const visibleCount = visibleLogCount(demoState.phase)
+    const entries = DEMO_LOG_ENTRIES.slice(0, visibleCount)
     return { entries, isLoading: false, error: null }
   }
   if (isActive) {
@@ -336,6 +324,7 @@ export function useTaskLogsList(opts: {
 }): UseTaskLogsListResult {
   const { taskId, searchQuery, levelFilter, enabled } = opts
   const levelArr = useMemo(() => [...levelFilter], [levelFilter])
+  const isDemo = isDemoTaskId(taskId)
 
   const query = useInfiniteQuery({
     queryKey: taskKeys.logsList(taskId ?? "", "log", searchQuery, levelArr),
@@ -351,7 +340,9 @@ export function useTaskLogsList(opts: {
     initialPageParam: "" as string,
     getNextPageParam: (lastPage) =>
       lastPage.has_more ? (lastPage.next_cursor ?? undefined) : undefined,
-    enabled: enabled && !!taskId,
+    // Demo short-circuit: never hit the live REST endpoint for the demo
+    // task — its history comes from the fixture via `useTaskLogs` already.
+    enabled: enabled && !!taskId && !isDemo,
     staleTime: 5 * 60_000,
   })
 
@@ -363,6 +354,18 @@ export function useTaskLogsList(opts: {
       normalizeLogEntries((p.entries ?? []) as Record<string, unknown>[]),
     )
   }, [query.data])
+
+  if (isDemo) {
+    // Demo task: return the fixture slice directly, never report loading
+    // or "more pages available".
+    return {
+      entries: DEMO_LOG_ENTRIES,
+      isLoading: false,
+      isFetchingMore: false,
+      hasMore: false,
+      loadMore: () => {},
+    }
+  }
 
   const lastPage = query.data?.pages[query.data.pages.length - 1]
 

--- a/src/frontend/src/i18n/locales/en.json
+++ b/src/frontend/src/i18n/locales/en.json
@@ -1223,7 +1223,40 @@
     "readOnly": "Read-only · No LLM calls",
     "startTour": "Start guided tour",
     "banner": "Demo",
-    "exitTitle": "Exit demo"
+    "exitTitle": "Exit demo",
+    "taskList": {
+      "title": "Task List",
+      "empty": "No tasks yet. Click below to create one.",
+      "create": "New task",
+      "dialogTitle": "Create a task",
+      "dialogDescription": "AI Build mode is pre-selected for the walkthrough. Click Create to continue.",
+      "nameLabel": "Task name",
+      "modeLabel": "Build mode",
+      "aiBuild": "AI Build",
+      "manualBuild": "Manual",
+      "manualDisabled": "Manual mode is disabled in the walkthrough",
+      "createSubmit": "Create",
+      "taskName": "Demo · Greedy + Local Search"
+    },
+    "rightPanel": {
+      "title": "Task Info",
+      "empty": "Create a task to see its status and parameters.",
+      "name": "Name",
+      "description": "Description",
+      "parameters": "Parameters",
+      "noParameters": "—",
+      "flags": "Build Mode",
+      "aiBuilt": "AI Build",
+      "manualBuilt": "Manual Build",
+      "readOnlyHint": "Read-only — interactive controls are disabled in the demo."
+    },
+    "center": {
+      "emptyTitle": "No task selected",
+      "emptyHint": "Click the New task button on the left to start the walkthrough. The tour will guide you through every step."
+    },
+    "result": {
+      "notReady": "Waiting for the build to start..."
+    }
   },
   "demoTour": {
     "create": {
@@ -1269,7 +1302,8 @@
     "exitDemo": "Exit demo",
     "skipAhead": "Skip ahead",
     "gotIt": "Got it",
-    "back": "Back"
+    "back": "Back",
+    "finishExit": "Finish & exit"
   },
   "demoBuild": {
     "chatTitle": "AI Build · Chat",

--- a/src/frontend/src/i18n/locales/zh.json
+++ b/src/frontend/src/i18n/locales/zh.json
@@ -1224,7 +1224,40 @@
     "readOnly": "只读 · 不调用任何 LLM",
     "startTour": "开始体验",
     "banner": "示例",
-    "exitTitle": "退出示例"
+    "exitTitle": "退出示例",
+    "taskList": {
+      "title": "演化任务列表",
+      "empty": "暂无任务，点击下方按钮创建。",
+      "create": "新建任务",
+      "dialogTitle": "创建任务",
+      "dialogDescription": "示例已经替你选好「AI 构建」。点击「创建」继续。",
+      "nameLabel": "任务名称",
+      "modeLabel": "构建方式",
+      "aiBuild": "AI 构建",
+      "manualBuild": "手动配置",
+      "manualDisabled": "示例中只演示 AI 构建路径",
+      "createSubmit": "创建",
+      "taskName": "Demo · 贪心 + 局部搜索"
+    },
+    "rightPanel": {
+      "title": "任务信息",
+      "empty": "创建任务后，这里会显示状态与参数。",
+      "name": "名称",
+      "description": "描述",
+      "parameters": "参数",
+      "noParameters": "—",
+      "flags": "构建方式",
+      "aiBuilt": "AI 构建",
+      "manualBuilt": "手动配置",
+      "readOnlyHint": "只读 — 示例中所有交互按钮已禁用。"
+    },
+    "center": {
+      "emptyTitle": "尚未选择任务",
+      "emptyHint": "点击左侧的「新建任务」按钮开始走查。引导会逐步带你完成每一步。"
+    },
+    "result": {
+      "notReady": "等待构建启动..."
+    }
   },
   "demoTour": {
     "create": {
@@ -1270,7 +1303,8 @@
     "exitDemo": "退出示例",
     "skipAhead": "跳到下一步",
     "gotIt": "了解",
-    "back": "上一步"
+    "back": "上一步",
+    "finishExit": "结束示例"
   },
   "demoBuild": {
     "chatTitle": "AI 构建 · 对话",

--- a/src/frontend/src/routeTree.gen.ts
+++ b/src/frontend/src/routeTree.gen.ts
@@ -15,9 +15,11 @@ import { Route as ResetPasswordRouteImport } from './routes/reset-password'
 import { Route as RecoverPasswordRouteImport } from './routes/recover-password'
 import { Route as LoginRouteImport } from './routes/login'
 import { Route as Layout_evolutionRouteImport } from './routes/_layout_evolution'
+import { Route as Layout_demoRouteImport } from './routes/_layout_demo'
 import { Route as LayoutRouteImport } from './routes/_layout'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as Layout_evolutionEvolutionRouteImport } from './routes/_layout_evolution/evolution'
+import { Route as Layout_demoDemoRouteImport } from './routes/_layout_demo/demo'
 import { Route as LayoutSettingsRouteImport } from './routes/_layout/settings'
 import { Route as LayoutProjectsRouteImport } from './routes/_layout/projects'
 import { Route as LayoutLlm_roviderRouteImport } from './routes/_layout/llm_rovider'
@@ -57,6 +59,10 @@ const Layout_evolutionRoute = Layout_evolutionRouteImport.update({
   id: '/_layout_evolution',
   getParentRoute: () => rootRouteImport,
 } as any)
+const Layout_demoRoute = Layout_demoRouteImport.update({
+  id: '/_layout_demo',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const LayoutRoute = LayoutRouteImport.update({
   id: '/_layout',
   getParentRoute: () => rootRouteImport,
@@ -72,6 +78,11 @@ const Layout_evolutionEvolutionRoute =
     path: '/evolution',
     getParentRoute: () => Layout_evolutionRoute,
   } as any)
+const Layout_demoDemoRoute = Layout_demoDemoRouteImport.update({
+  id: '/demo',
+  path: '/demo',
+  getParentRoute: () => Layout_demoRoute,
+} as any)
 const LayoutSettingsRoute = LayoutSettingsRouteImport.update({
   id: '/settings',
   path: '/settings',
@@ -134,6 +145,7 @@ export interface FileRoutesByFullPath {
   '/llm_rovider': typeof LayoutLlm_roviderRoute
   '/projects': typeof LayoutProjectsRoute
   '/settings': typeof LayoutSettingsRoute
+  '/demo': typeof Layout_demoDemoRoute
   '/evolution': typeof Layout_evolutionEvolutionRoute
 }
 export interface FileRoutesByTo {
@@ -152,12 +164,14 @@ export interface FileRoutesByTo {
   '/llm_rovider': typeof LayoutLlm_roviderRoute
   '/projects': typeof LayoutProjectsRoute
   '/settings': typeof LayoutSettingsRoute
+  '/demo': typeof Layout_demoDemoRoute
   '/evolution': typeof Layout_evolutionEvolutionRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
   '/_layout': typeof LayoutRouteWithChildren
+  '/_layout_demo': typeof Layout_demoRouteWithChildren
   '/_layout_evolution': typeof Layout_evolutionRouteWithChildren
   '/login': typeof LoginRoute
   '/recover-password': typeof RecoverPasswordRoute
@@ -173,6 +187,7 @@ export interface FileRoutesById {
   '/_layout/llm_rovider': typeof LayoutLlm_roviderRoute
   '/_layout/projects': typeof LayoutProjectsRoute
   '/_layout/settings': typeof LayoutSettingsRoute
+  '/_layout_demo/demo': typeof Layout_demoDemoRoute
   '/_layout_evolution/evolution': typeof Layout_evolutionEvolutionRoute
 }
 export interface FileRouteTypes {
@@ -193,6 +208,7 @@ export interface FileRouteTypes {
     | '/llm_rovider'
     | '/projects'
     | '/settings'
+    | '/demo'
     | '/evolution'
   fileRoutesByTo: FileRoutesByTo
   to:
@@ -211,11 +227,13 @@ export interface FileRouteTypes {
     | '/llm_rovider'
     | '/projects'
     | '/settings'
+    | '/demo'
     | '/evolution'
   id:
     | '__root__'
     | '/'
     | '/_layout'
+    | '/_layout_demo'
     | '/_layout_evolution'
     | '/login'
     | '/recover-password'
@@ -231,12 +249,14 @@ export interface FileRouteTypes {
     | '/_layout/llm_rovider'
     | '/_layout/projects'
     | '/_layout/settings'
+    | '/_layout_demo/demo'
     | '/_layout_evolution/evolution'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   LayoutRoute: typeof LayoutRouteWithChildren
+  Layout_demoRoute: typeof Layout_demoRouteWithChildren
   Layout_evolutionRoute: typeof Layout_evolutionRouteWithChildren
   LoginRoute: typeof LoginRoute
   RecoverPasswordRoute: typeof RecoverPasswordRoute
@@ -289,6 +309,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof Layout_evolutionRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/_layout_demo': {
+      id: '/_layout_demo'
+      path: ''
+      fullPath: '/'
+      preLoaderRoute: typeof Layout_demoRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/_layout': {
       id: '/_layout'
       path: ''
@@ -309,6 +336,13 @@ declare module '@tanstack/react-router' {
       fullPath: '/evolution'
       preLoaderRoute: typeof Layout_evolutionEvolutionRouteImport
       parentRoute: typeof Layout_evolutionRoute
+    }
+    '/_layout_demo/demo': {
+      id: '/_layout_demo/demo'
+      path: '/demo'
+      fullPath: '/demo'
+      preLoaderRoute: typeof Layout_demoDemoRouteImport
+      parentRoute: typeof Layout_demoRoute
     }
     '/_layout/settings': {
       id: '/_layout/settings'
@@ -403,6 +437,18 @@ const LayoutRouteChildren: LayoutRouteChildren = {
 const LayoutRouteWithChildren =
   LayoutRoute._addFileChildren(LayoutRouteChildren)
 
+interface Layout_demoRouteChildren {
+  Layout_demoDemoRoute: typeof Layout_demoDemoRoute
+}
+
+const Layout_demoRouteChildren: Layout_demoRouteChildren = {
+  Layout_demoDemoRoute: Layout_demoDemoRoute,
+}
+
+const Layout_demoRouteWithChildren = Layout_demoRoute._addFileChildren(
+  Layout_demoRouteChildren,
+)
+
 interface Layout_evolutionRouteChildren {
   Layout_evolutionEvolutionRoute: typeof Layout_evolutionEvolutionRoute
 }
@@ -417,6 +463,7 @@ const Layout_evolutionRouteWithChildren =
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   LayoutRoute: LayoutRouteWithChildren,
+  Layout_demoRoute: Layout_demoRouteWithChildren,
   Layout_evolutionRoute: Layout_evolutionRouteWithChildren,
   LoginRoute: LoginRoute,
   RecoverPasswordRoute: RecoverPasswordRoute,

--- a/src/frontend/src/routes/_layout_demo.tsx
+++ b/src/frontend/src/routes/_layout_demo.tsx
@@ -1,0 +1,450 @@
+import { useQueryClient } from "@tanstack/react-query"
+import {
+  createFileRoute,
+  Link,
+  Outlet,
+  redirect,
+  useNavigate,
+} from "@tanstack/react-router"
+import { LogOut, Settings } from "lucide-react"
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
+import { useTranslation } from "react-i18next"
+
+import type { ReportType, TaskResponse, TaskStatus } from "@/client"
+import LanguageToggle from "@/components/Common/LanguageToggle"
+import ThemeToggle from "@/components/Common/ThemeToggle"
+import DemoRightPanel from "@/components/Demo/DemoRightPanel"
+import DemoTaskList from "@/components/Demo/DemoTaskList"
+import TechBackground from "@/components/Evolution/TechBackground"
+import TechCorner from "@/components/Evolution/TechCorner"
+import TechPanel from "@/components/Evolution/TechPanel"
+import DemoTour from "@/components/Onboarding/DemoTour"
+import { getProjectIcon } from "@/components/Projects/ProjectIcons"
+import { Avatar, AvatarFallback } from "@/components/ui/avatar"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
+import {
+  buildDemoTask,
+  DEMO_PROJECT,
+  DEMO_TASK,
+  DEMO_TASK_ID,
+  demoPhaseToStatus,
+} from "@/data/demoFixtures"
+import useAuth, { isLoggedIn } from "@/hooks/useAuth"
+import {
+  enterDemo,
+  exitDemo,
+  setDemoGeneration,
+  useDemoState,
+} from "@/hooks/useDemoMode"
+import type { SelectedNodeInfo } from "@/hooks/useEvolution"
+import { EvolutionContext } from "@/hooks/useEvolution"
+import { useEvolutionNodes } from "@/hooks/useEvolutionNodes"
+import { useTaskLogs } from "@/hooks/useTaskLogs"
+import { taskKeys } from "@/lib/task-queries"
+import { getInitials } from "@/utils"
+import icon from "/assets/images/logo.svg"
+
+/**
+ * Top-level layout for the read-only demo walkthrough.
+ *
+ * Sits at `/demo` and is fully separate from `_layout_evolution`. The split
+ * keeps demo logic (mocked task lifecycle, scripted AI conversation, fake
+ * generation animation) out of the production evolution route, so changes
+ * here can never regress real algorithm-design tasks.
+ *
+ * The layout owns:
+ *   - the demo session lifecycle (enterDemo on mount, exitDemo on unmount)
+ *   - the running-phase generation animation that streams nodes onto the canvas
+ *   - the EvolutionContext.Provider so child surfaces can pull nodes/logs/
+ *     selection state through the same hooks the real route uses
+ */
+export const Route = createFileRoute("/_layout_demo")({
+  component: DemoLayout,
+  beforeLoad: async ({ location }) => {
+    if (!isLoggedIn()) {
+      throw redirect({
+        to: "/login",
+        search: { redirect: location.pathname + (location.searchStr || "") },
+      })
+    }
+  },
+})
+
+function DemoUserAvatarMenu() {
+  const { t } = useTranslation()
+  const { user, logout } = useAuth()
+  const navigate = useNavigate()
+
+  if (!user) return null
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <button
+          type="button"
+          className="flex items-center gap-2 px-2 py-1 rounded-md
+            hover:bg-accent/60 transition-colors border border-transparent
+            hover:border-border/40 focus:outline-none"
+        >
+          <Avatar className="size-7">
+            <AvatarFallback className="text-xs font-medium bg-primary/10 text-primary border border-primary/30">
+              {getInitials(user.full_name || "U")}
+            </AvatarFallback>
+          </Avatar>
+          <span className="text-xs text-muted-foreground max-w-[80px] truncate hidden sm:inline">
+            {user.full_name}
+          </span>
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" sideOffset={8} className="w-48">
+        <DropdownMenuLabel className="font-normal px-3 py-2">
+          <p className="text-sm font-medium">{user.full_name}</p>
+          <p className="text-xs text-muted-foreground">{user.email}</p>
+        </DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem
+          className="cursor-pointer"
+          onClick={() => navigate({ to: "/settings" })}
+        >
+          <Settings className="size-4 mr-2" />
+          {t("layout.accountSettings")}
+        </DropdownMenuItem>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem
+          className="text-destructive focus:bg-destructive/15 focus:text-destructive cursor-pointer"
+          onClick={logout}
+        >
+          <LogOut className="size-4 mr-2" />
+          {t("layout.logout")}
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}
+
+function DemoLayout() {
+  const { t } = useTranslation()
+  const queryClient = useQueryClient()
+  const demoState = useDemoState()
+
+  // Activate demo session on mount, clear it on unmount. This is the single
+  // source of truth: any consumer of `useDemoState()` sees `active=true` while
+  // we sit on `/demo`, and never anywhere else.
+  useEffect(() => {
+    enterDemo("uninitialized")
+    return () => exitDemo()
+  }, [])
+
+  // Selected task tracks the simulated DEMO_TASK once the user clicks
+  // "create" in DemoTaskList. Before that, the left panel renders the
+  // "no tasks yet" empty state.
+  const [selectedTask, setSelectedTaskRaw] = useState<TaskResponse | null>(null)
+  const [selectedChildTaskId, setSelectedChildTaskId] = useState<string | null>(
+    null,
+  )
+
+  useEffect(() => {
+    if (demoState.phase === "uninitialized") {
+      setSelectedTaskRaw(null)
+      return
+    }
+    setSelectedTaskRaw(buildDemoTask(demoState.phase))
+    // Bust the demo task detail cache so any consumer reading via React Query
+    // re-renders with the new phase-derived status.
+    queryClient.invalidateQueries({ queryKey: taskKeys.detail(DEMO_TASK_ID) })
+    queryClient.invalidateQueries({ queryKey: ["getTask", DEMO_TASK_ID] })
+  }, [demoState.phase, queryClient])
+
+  // Running-phase animation: stream the demo's pre-baked generations one at a
+  // time so the user sees the canvas come alive instead of jumping straight to
+  // the final state. Stops at the last generation and waits for the user to
+  // advance the tour into `completed`.
+  useEffect(() => {
+    if (demoState.phase !== "running") return
+    const TOTAL_GENS = 12
+    const STEP_MS = 220
+    let gen = 0
+    const id = window.setInterval(() => {
+      gen += 1
+      if (gen > TOTAL_GENS) {
+        window.clearInterval(id)
+        return
+      }
+      setDemoGeneration(gen)
+    }, STEP_MS)
+    return () => window.clearInterval(id)
+  }, [demoState.phase])
+
+  // Evolution viz state — driven by the demo phase via existing demo
+  // short-circuits inside the hooks.
+  const [currentGeneration, setCurrentGeneration] = useState(0)
+  const [isPlaying, setIsPlaying] = useState(false)
+  const [selectedNodes, setSelectedNodes] = useState<SelectedNodeInfo[]>([])
+  const [activeTab, setActiveTab] = useState("overview")
+  const [isConfiguring, setIsConfiguring] = useState(false)
+  const [isViewingParams, setIsViewingParams] = useState(false)
+  const [isViewingAiBuildHistory, setIsViewingAiBuildHistory] = useState(false)
+  const [forceManualConfigTaskId, setForceManualConfigTaskId] = useState<
+    string | null
+  >(null)
+  const [insightActiveType, setInsightActiveType] = useState<ReportType | null>(
+    null,
+  )
+  const [insightSelectedNodeIds, setInsightSelectedNodeIds] = useState<
+    string[] | null
+  >(null)
+  const [insightSelectedBestNodeId, setInsightSelectedBestNodeId] = useState<
+    string | null
+  >(null)
+  const [focusNodeRequest, setFocusNodeRequest] = useState<{
+    id: string
+    nonce: number
+    select: boolean
+  } | null>(null)
+  const requestFocusNode = useCallback((id: string, select = true) => {
+    if (!id) return
+    setFocusNodeRequest({ id, nonce: Date.now(), select })
+  }, [])
+  const toggleSelectedNode = useCallback((node: SelectedNodeInfo) => {
+    setSelectedNodes((prev) => {
+      const exists = prev.some((n) => n.id === node.id)
+      return exists ? prev.filter((n) => n.id !== node.id) : [...prev, node]
+    })
+  }, [])
+
+  // Wrap setSelectedTask: clearing the child override in the same render
+  // batch on root-task switch matches the production behavior in
+  // `_layout_evolution`.
+  const selectedTaskRef = useRef<TaskResponse | null>(null)
+  selectedTaskRef.current = selectedTask
+  const setSelectedTask = useCallback((task: TaskResponse | null) => {
+    const prev = selectedTaskRef.current
+    const prevRoot = prev ? prev.group_id || prev.id : null
+    const nextRoot = task ? task.group_id || task.id : null
+    setSelectedTaskRaw(task)
+    if (prevRoot !== nextRoot) setSelectedChildTaskId(null)
+  }, [])
+
+  // Effective task / status feeds the visualisation hooks. In demo mode the
+  // "effective task" is always DEMO_TASK once the user has clicked create;
+  // before that, no task is selected so the empty state shows.
+  const effectiveTaskId = selectedTask ? DEMO_TASK_ID : null
+  const effectiveStatus: TaskStatus = demoPhaseToStatus(demoState.phase)
+
+  // Real hooks — they short-circuit on `isDemoTaskId` internally and return
+  // fixture-derived data without touching the network.
+  const { data: evolutionData, feedGenerated } = useEvolutionNodes(
+    effectiveTaskId ?? undefined,
+    effectiveStatus,
+    !!effectiveTaskId,
+  )
+  const {
+    entries: logEntries,
+    isLoading: logLoading,
+    error: logError,
+  } = useTaskLogs(effectiveTaskId ?? "", effectiveStatus, !!effectiveTaskId)
+  const maxGeneration = evolutionData.maxGeneration
+
+  // Keep the playback head pinned to the latest available generation so the
+  // canvas auto-follows the streaming animation.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: intentional auto-follow on stream
+  useEffect(() => {
+    setCurrentGeneration(maxGeneration)
+  }, [maxGeneration])
+
+  const setMaxGeneration = useCallback((_max: number) => {
+    // No-op — maxGeneration is derived from evolution data.
+  }, [])
+  const resetTaskData = useCallback(() => {
+    setCurrentGeneration(0)
+    setIsPlaying(false)
+    setSelectedNodes([])
+  }, [])
+  const updateTaskStatus = useCallback((_status: string) => {
+    // No-op — demo status is derived from the phase, not pushed externally.
+  }, [])
+
+  // _feedGenerated: hooks expose this for SSE-driven tasks to push nodes
+  // back. Demo mode never streams via SSE, so reference it once to silence
+  // unused-binding lint and keep the hook contract intact.
+  void feedGenerated
+
+  const contextValue = useMemo(
+    () => ({
+      projectId: DEMO_PROJECT.id,
+      projectValid: true,
+      selectedTask,
+      setSelectedTask,
+      selectedChildTaskId,
+      setSelectedChildTaskId,
+      effectiveTaskId,
+      effectiveStatus,
+      currentGeneration,
+      maxGeneration,
+      setCurrentGeneration,
+      setMaxGeneration,
+      isPlaying,
+      setIsPlaying,
+      selectedNodes,
+      setSelectedNodes,
+      toggleSelectedNode,
+      evolutionData,
+      logEntries,
+      logLoading,
+      logError,
+      activeTab,
+      setActiveTab,
+      isConfiguring,
+      setIsConfiguring,
+      isViewingParams,
+      setIsViewingParams,
+      isViewingAiBuildHistory,
+      setIsViewingAiBuildHistory,
+      forceManualConfigTaskId,
+      setForceManualConfigTaskId,
+      insightActiveType,
+      setInsightActiveType,
+      insightSelectedNodeIds,
+      setInsightSelectedNodeIds,
+      insightSelectedBestNodeId,
+      setInsightSelectedBestNodeId,
+      focusNodeRequest,
+      requestFocusNode,
+      // Left panel never collapses in the demo — the walkthrough relies on
+      // the side-by-side layout.
+      leftCollapsed: false,
+      setLeftCollapsed: () => {},
+      resetTaskData,
+      updateTaskStatus,
+    }),
+    [
+      selectedTask,
+      setSelectedTask,
+      selectedChildTaskId,
+      effectiveTaskId,
+      effectiveStatus,
+      currentGeneration,
+      maxGeneration,
+      setMaxGeneration,
+      isPlaying,
+      selectedNodes,
+      toggleSelectedNode,
+      evolutionData,
+      logEntries,
+      logLoading,
+      logError,
+      activeTab,
+      isConfiguring,
+      isViewingParams,
+      isViewingAiBuildHistory,
+      forceManualConfigTaskId,
+      insightActiveType,
+      insightSelectedNodeIds,
+      insightSelectedBestNodeId,
+      focusNodeRequest,
+      requestFocusNode,
+      resetTaskData,
+      updateTaskStatus,
+    ],
+  )
+
+  // Quiet lints for fixture re-exports we keep available to children.
+  void DEMO_TASK
+
+  return (
+    <EvolutionContext.Provider value={contextValue}>
+      <div className="flex flex-col h-screen overflow-hidden bg-background text-foreground">
+        {activeTab !== "ide" && <TechBackground />}
+
+        {/* Header — three-column grid keeps project name absolutely centered */}
+        <header className="relative z-10 grid grid-cols-[1fr_auto_1fr] items-center gap-2 sm:gap-4 px-3 sm:px-6 py-3 shrink-0 bg-background/95 backdrop-blur border-b border-border shadow-sm">
+          <div className="flex items-center gap-2 sm:gap-4 min-w-0">
+            <Link
+              to="/projects"
+              className="flex items-center gap-2.5 group hover:opacity-80 transition-opacity min-w-0"
+            >
+              <div className="relative shrink-0">
+                <img
+                  src={icon}
+                  alt="LLM4AD_Next"
+                  className="h-8 w-auto landing-spin-periodic"
+                />
+                <div className="absolute inset-0 rounded-full bg-primary/20 blur-md opacity-0 group-hover:opacity-100 transition-opacity duration-500" />
+              </div>
+              <span className="text-base font-bold tracking-wider landing-gradient-animated shrink-0">
+                LLM4AD_Next
+              </span>
+              <span className="hidden lg:inline-block text-[10px] font-medium px-1.5 py-0.5 rounded bg-primary/10 text-primary border border-primary/20 shrink-0">
+                {t("evolution.simulationTitle", { defaultValue: "Simulation" })}
+              </span>
+            </Link>
+          </div>
+
+          <div className="flex items-center justify-center min-w-0">
+            {(() => {
+              const ProjectIcon = getProjectIcon(DEMO_PROJECT.icon)
+              return (
+                <div
+                  className="flex items-center gap-2 min-w-0 max-w-[min(38vw,440px)]"
+                  title={DEMO_PROJECT.name}
+                >
+                  <ProjectIcon className="size-5 shrink-0 text-primary glow-primary" />
+                  <span className="text-base tracking-wide truncate text-primary glow-primary">
+                    {t("demo.projectName", {
+                      defaultValue: DEMO_PROJECT.name,
+                    })}
+                  </span>
+                </div>
+              )
+            })()}
+          </div>
+
+          <div className="flex items-center justify-end gap-3 text-xs text-muted-foreground min-w-0">
+            <div className="hidden sm:flex items-center gap-3">
+              <LanguageToggle />
+              <ThemeToggle />
+              <div className="w-px h-5 bg-border/40" />
+            </div>
+            <DemoUserAvatarMenu />
+          </div>
+        </header>
+
+        {/* Three-pane body. Left/right panels are mounted by sub-components
+            via the same EvolutionContext the real evolution layout uses;
+            the center pane swaps based on `demoState.phase`. */}
+        <div className="flex flex-1 min-h-0 relative z-10">
+          <aside className="shrink-0 flex flex-col overflow-hidden bg-background/95 w-64">
+            <TechPanel className="h-full flex flex-col w-64">
+              <DemoTaskList />
+            </TechPanel>
+          </aside>
+
+          <main className="flex-1 min-w-0 relative overflow-hidden flex flex-col">
+            <TechCorner position="top-left" size={20} />
+            <TechCorner position="top-right" size={20} />
+            <TechCorner position="bottom-left" size={20} />
+            <TechCorner position="bottom-right" size={20} />
+            <div className="flex-1 min-h-0 overflow-hidden p-4">
+              <Outlet />
+            </div>
+          </main>
+
+          <aside className="relative shrink-0 flex flex-col overflow-hidden bg-background/95 w-[300px]">
+            <TechPanel className="h-full flex flex-col">
+              <DemoRightPanel />
+            </TechPanel>
+          </aside>
+        </div>
+
+        <DemoTour />
+      </div>
+    </EvolutionContext.Provider>
+  )
+}

--- a/src/frontend/src/routes/_layout_demo/demo.tsx
+++ b/src/frontend/src/routes/_layout_demo/demo.tsx
@@ -1,0 +1,66 @@
+import { createFileRoute } from "@tanstack/react-router"
+import { Plus } from "lucide-react"
+import { useTranslation } from "react-i18next"
+
+import DemoBuildShell from "@/components/Demo/DemoBuildShell"
+import DemoResultShell from "@/components/Demo/DemoResultShell"
+import { useDemoState } from "@/hooks/useDemoMode"
+
+/**
+ * Center pane for `/demo`. Phase-driven switch:
+ *
+ *   uninitialized          → Empty CTA prompt
+ *   configuring / building → DemoBuildShell (chat + preview + run footer)
+ *   running / completed    → DemoResultShell (real InitializedView)
+ *
+ * The empty state intentionally tells the user where to look (left panel)
+ * rather than offering its own CTA — the only New-Task button lives in the
+ * task list per the walkthrough's flow, and surfacing a duplicate here
+ * would give the user a target the tour overlay isn't aware of.
+ */
+export const Route = createFileRoute("/_layout_demo/demo")({
+  component: DemoIndex,
+  head: () => ({
+    meta: [
+      {
+        title: "Demo · LLM4AD_Next",
+      },
+    ],
+  }),
+})
+
+function DemoIndex() {
+  const { t } = useTranslation()
+  const demoState = useDemoState()
+
+  if (
+    demoState.phase === "configuring" ||
+    demoState.phase === "building"
+  ) {
+    return <DemoBuildShell />
+  }
+
+  if (demoState.phase === "running" || demoState.phase === "completed") {
+    return <DemoResultShell />
+  }
+
+  // uninitialized — point the user at the left panel.
+  return (
+    <div className="h-full w-full flex flex-col items-center justify-center text-center px-6 gap-4">
+      <div className="size-16 rounded-full bg-primary/10 border border-primary/20 flex items-center justify-center">
+        <Plus className="size-7 text-primary" />
+      </div>
+      <p className="text-base font-medium text-foreground">
+        {t("demo.center.emptyTitle", {
+          defaultValue: "No task selected",
+        })}
+      </p>
+      <p className="text-sm text-muted-foreground max-w-md leading-relaxed">
+        {t("demo.center.emptyHint", {
+          defaultValue:
+            "Click the New task button on the left to start the walkthrough. The tour will guide you through every step.",
+        })}
+      </p>
+    </div>
+  )
+}


### PR DESCRIPTION
1. Add /demo as a top-level route (`_layout_demo` + `_layout_demo/demo`) so the demo lifecycle is fully isolated from `/evolution`. Real evolution tasks no longer carry any demo branches in the layout.
2. Mirror the production `EvolutionTaskList` layout for the demo task list and Create-task dialog — same header, same row visuals, same two-card mode picker — with manual mode locked out and submit wired to a phase flip instead of `createTask`.
3. Add `DemoBuildShell` (chat + reused real `FileTreeView` + Run footer), `DemoResultShell` (reuses real `InitializedView` so logs / IDE / canvas all run through production components), and `DemoRightPanel` (read-only task info, no Run/Stop/Adjust buttons).
4. Replace the four-div spotlight with an SVG `<mask>` overlay plus four invisible click-blocker rects: visually seamless at any DPR / zoom and clicks outside the highlight are blocked. Pointer events on the tooltip stop propagation so Radix Dialog's outside-click detector can't dismiss the create-task dialog mid-step.
5. Quantize spotlight + pulse rects to device pixels, observe anchors with `ResizeObserver`, and re-measure at 150 / 350 / 650ms after first hit to land on the post-animation bounds (Radix dialog's `zoom-in-95` was the symptom that exposed this).
6. Tour fixes: hide Back on step 1b, skip auto-advance steps when Back crosses phases (so step 2 -> Back lands on step 1 instead of 1b), step 6 tooltip placement = right, final step routes to /projects on the in-tooltip Exit button.
7. Pre-fill the composer one turn at a time via a new `useTypewriter` hook (30ms / char, click-to-skip), feed `LogsPanel` mock entries shaped like real backend logs (with module / function / line), and short-circuit `useTaskLogsList` for demo tasks so the panel never hits the live REST endpoint.

The legacy `/evolution?projectId=__demo_project__` path and its supporting branches inside `_layout_evolution.tsx` / `DemoBuildView.tsx` / `DemoEvolutionTour.tsx` are intentionally left untouched — they act as a safety net for this PR and will be removed in a follow-up once the dedicated route is verified.