### PR TITLE
Feat/ai build agent beta

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -235,3 +235,4 @@ docs/slides/
 
 # External repositories
 openevolve-main/
+refefence_superpowers/

--- a/docs/ai-build-beta-handoff.md
+++ b/docs/ai-build-beta-handoff.md
@@ -1,0 +1,370 @@
+# AI 构建 (Beta) — AgentScope 单 Agent 构建：实现交接文档
+
+> 本文件是给**接手的 AI 模型**看的完整交接说明。读者看不到此前的对话历史，
+> 因此本文档力求自包含：包含背景、设计决策及其理由、已完成的全部改动（逐文件、
+> 逐函数）、当前状态、剩余工作、安全分析、以及待用户拍板的开放问题。
+> 编写日期：2026-06-29。所有改动均在 `src/backend/` 内，**未触碰前端**。
+
+---
+
+## 1. 背景与目标
+
+### 1.1 项目是什么
+LLM4AD_Next 是一个"用 LLM 做自动算法设计 (LLM4AD)"的平台。核心玩法：用户描述一个
+优化问题，平台用进化算法 + LLM 不断改写一段被 `# EVOLVE_START` / `# EVOLVE_END`
+标记包裹的代码，由一个自定义"评估器 (evaluator)"打分，迭代出更优算法。
+
+平台有一个 Web UI 栈（FastAPI 后端 + Celery worker + 前端 + Postgres/Redis/RustFS/
+nginx），通过 `docker/` 下的 compose 编排。其中"AI 构建"功能对应后端的 **chat_tune**
+模块：用户通过对话，让系统自动生成一个可运行的 LLM4AD 任务包（评估器、带 EVOLVE 标记
+的算法、config.yaml、调试脚本、样本数据等）。
+
+### 1.2 用户的诉求（为什么做这个）
+用户认为现有的 AI 构建**太死板**，希望用"**真正的 Agent**"来构建项目包，并能根据
+用户需求灵活做事。经过多轮讨论，确定了以下关键约束和决策（**这些是用户拍板的，不是
+我自行决定的**）：
+
+1. **保留原有 AI 构建不动**，新增一个并行的 **"AI 构建 (Beta)"** 入口/模式。
+2. **Agent 框架用 AgentScope**（阿里通义实验室开源，用户同事推荐）。
+   - 关键原因：用户的用户群**不只用 Anthropic 模型**（还有 DeepSeek/通义/OpenAI 等）。
+     Claude Agent SDK 绑死 Anthropic 协议，非 Anthropic 模型需要协议翻译网关（脆弱）；
+     AgentScope 原生多 provider，且能走现有透明 LLM proxy **零改动**。
+3. **改造范围 = 大改**：用一个 AgentScope agent 统一承接"对话 + 构建 + 评审"，
+   取代原三阶段状态机。但作为 beta 与旧逻辑**并存**（特性开关控制）。
+4. **构建核心走"混合"路线**（用户在被问及"对话死板还是代码生成死板"时选的）：
+   - **BuildOrchestrator 生成**（复用现有稳妥引擎，config 程序化生成、自带 validation 闸），
+   - **agent 用 `run_python` 验证**（跑 `debug_run.py`/`test_evaluator.py` 看报错），
+   - 跑不通就调 BuildOrchestrator 的 `rebuild_evaluator` 重试。
+5. **config.yaml 由程序化生成**（不让 agent 凭空写 10 段 schema）。混合路线下这天然成立——
+   BuildOrchestrator 内部就是程序化生成 config 的。
+6. **验证两层就够**（用户原话"两层就够了"）：
+   - 第 1 层 = agent 自验（`run_python`）；
+   - 第 2 层 = BuildOrchestrator 自带的确定性 validation 闸。
+   - **不叠第三层**（不再在 agent 之外额外加一道独立 validator）。
+7. **凭据走 LLM proxy + 一次性 token**（用户选的）：真实 key 不进容器。
+8. **网络隔离沿用现有 chat_tune 容器级别**（用户让我按现有水平判断）：
+   一次性容器、不挂 docker.sock、`no-new-privileges`、内存/CPU 限制、用完即销。
+   不为 beta 单独搭内网出口代理（列为可选后续加固）。
+9. **安全是头等约束**：agent 不能编辑其根目录 (`/task/data`) 之外的任何东西，
+   防止线上服务被攻破。
+
+### 1.3 为什么是"混合"而不是其它
+讨论中澄清过两种极端：
+- **纯复用 BuildOrchestrator**（agent 只聊需求）：只解决"对话死板"，代码生成仍是单次
+  生成，且与现状差别不大。
+- **agent 完全自己写代码**（write_file + run_python 自纠错）：最彻底解决"代码生成死板"，
+  但与"config 程序化"决策有摩擦，需要一座桥（scaffold + 重建 blueprint），最复杂。
+
+用户选了**混合**：引擎生成（稳） + agent 验证重试（智能）。这是当前实现的路线。
+> 注：实现早期我一度写过 `write_file` 工具和一个 `agent_build_support.py`（scaffold/
+> 重建/validate 桥接模块），那是"agent 自己写代码"路线的产物。选定混合路线后**已删除**
+> `agent_build_support.py`，并把 `write_file` 从工具集移除。若在 git 历史里看到它们，
+> 属于已废弃的早期尝试。
+
+---
+
+## 2. 关键技术事实（已核实，非猜测）
+
+这些事实是动手前通过"读 AgentScope 2.0.3 已安装源码 + 读本仓库源码 + web 检索"逐一
+核实的，接手时可直接信任，但若要改动相关处建议复核：
+
+### 2.1 AgentScope 2.0.3
+- **只用核心包 `agentscope`，绝不装 `agentscope-runtime`**。后者的 sandbox 会自己起
+  Docker 容器（硬依赖 `docker>=7.1.0`），我们已在容器里跑，装它=容器套容器。
+- 已通过 `uv lock` 加入 `src/backend/pyproject.toml`，解析为 `agentscope==2.0.3`，
+  无版本冲突（含 OpenTelemetry 1.43 等传递依赖）。
+- 要求 Python ≥3.11。backend 是 3.12，满足；**故 agentscope 放 backend 依赖，不进
+  根 `llm4ad`**（根项目受 3.10 约束，CLAUDE.md 要求 `ruff` 用 3.10 跑）。
+- 真实 API（v2.0.3，与网上部分 v1 教程不同）：
+  - `from agentscope.agent import Agent, ReActConfig`（v2 把 ReActAgent 合并进统一 `Agent`）。
+  - `Agent(name, system_prompt, model, toolkit=None, react_config=None, ...)`。
+  - `agent.reply_stream(inputs)` → async 生成器，产出**事件对象**（不是字符串）。
+  - 事件类型来自 `agentscope.event`：`TextBlockDeltaEvent(.delta)`、
+    `ToolCallStartEvent(.tool_call_name)`、`ToolResultEndEvent`、等。
+  - `from agentscope.model import OpenAIChatModel, AnthropicChatModel`；
+    `from agentscope.credential import OpenAICredential, AnthropicCredential`。
+    `OpenAIChatModel(credential=OpenAICredential(api_key=, base_url=), model=, stream=True)`。
+    Anthropic 额外可经 `client_kwargs={"auth_token": ...}` 传 bearer。
+  - `from agentscope.tool import Toolkit, FunctionTool`。
+    `Toolkit(tools=[FunctionTool(fn), ...])`；`FunctionTool(fn, is_read_only=True)` 从
+    函数签名+docstring 自动抽 JSON schema。
+  - **权限坑**：`FunctionTool.check_permissions` 默认返回 `ASK`，容器内无人应答会卡。
+    必须 `agent.state.permission_context.mode = PermissionMode.BYPASS`
+    （`from agentscope.permission import PermissionMode`）。真正的安全保证不在这个弹窗，
+    而在工具实现里的路径围栏。
+  - **Msg 坑**：`Msg(content="字符串")` 会 pydantic 校验失败（`content` 必须是
+    `list[ContentBlock]`，且只有 after-validator 做断言、没有 before-validator 做转换）。
+    必须用工厂函数 `from agentscope.message import UserMsg`，`UserMsg(name=, content="str")`
+    会自动把字符串包成 `TextBlock`。
+  - **Windows 本地导入极慢**：`import agentscope` 在本机（Windows + 杀软）首次导入会被
+    逐文件扫描拖到分钟级甚至超时。这是**本机现象，不是代码问题**（Linux 容器里正常）。
+    所以本机别反复 spawn python 去 import agentscope 验证；改读源码或在容器里验证。
+
+### 2.2 现有 LLM proxy（关键：零改动即可用）
+- `src/backend/app/api/llm4ad/llm_proxy.py` 是**透明中继**：原样转发请求体、只替换鉴权头，
+  天然兼容 OpenAI / openai_compatible / Anthropic 协议，支持流式 + 工具调用。
+- 挂载在 `/api/v1/llm4ad/llmproxy`。
+- `credential_broker.issue_token(...)` 发一次性 token（Fernet 加密存 Redis，带 TTL，
+  按 task_id 归集）；容器持 token，proxy 用真实 key 转发上游。
+- **复用模式**见 `src/backend/app/services/task_service/execution.py:311` 的 `_swap`：
+  发 token → 改写 provider_cfg 的 `api_key`=token、`base_url`=proxy_base、`auth_token`=""。
+
+### 2.3 chat_tune 容器与契约
+- 容器入口 `src/backend/app/tasks/chat_tune_runner.py`，是一个 FastAPI SSE 应用，
+  跑在复用的 `TASK_RUNNER_IMAGE` 里。原有端点 `/run`(needs)、`/build`、`/review`、`/health`。
+- 容器隔离（`src/backend/app/services/container_service.py:346` `start_chat_tune_container`）：
+  只挂载 `/task/data`、不挂 docker.sock、`no-new-privileges`、mem/cpu 限制、用完即销、
+  端口不发布（仅 docker 网络内按容器名 DNS 可达）。
+- **路径围栏** `_resolve_within_sandbox(base, path)`（chat_tune_runner.py:68）：把任意
+  用户/LLM 传入路径钉死在 `/task/data` 内，`..`/越界绝对路径一律拒绝返回 None。
+  **本次新工具全部复用这个函数**——已用 8 个用例本地测过拦截有效（见 §6）。
+- SSE 事件协议（后端 `_run_*` 协程与前端都依赖，**必须保持不变**）：
+  `{"type":"chunk","content":...}`、`{"type":"build_result","blueprint_data":{...}}`、
+  `{"type":"done"}`、`{"type":"error","error":...}`。
+- 后端编排协程 `_run_ai_build`（chat_tune_service.py:869 起，本次改动后行号下移）：
+  prepare workdir → start 容器 → 连 SSE → 落库 → 上传产物到对象存储 + 回填
+  `task.input_args`。**新协程 `_run_agent_build` 严格照搬此结构**。
+- DB 模型 `ChatTuneSession` / `ChatTuneMessage`，枚举 `ChatTuneGenerationKind`
+  （retry 时按它分发）、`ChatTuneStageStatus`、`ChatTuneActiveStage`。
+- `generation_id`（Redis）用于取消：协程轮询若发现 id 变了就退出。
+- `start_turn` 分发器（chat_tune_service.py:~380）按 target_stage/状态机决定
+  generation_kind；`retry_turn`（~700）按存储的 generation_kind 重新分发。
+
+### 2.4 BuildOrchestrator / NeedsProfile（混合路线的生成引擎）
+- `src/llm4ad/consultant/build_orchestrator.py`：
+  - `BuildOrchestrator(provider, console=None, max_repair_attempts=10)`。
+    `console=None` 在容器里安全（它内部用 rich，但传 None 会自建，非 TTY 下 transient 进度
+    无害）。
+  - `async build(needs: NeedsProfile) -> TaskBlueprint`：跑 Analyze→Create→Validate→
+    Requirements→Configure（config 程序化），内部已含 validation 闸，不通过会抛 `BuildError`。
+  - `async rebuild_evaluator(blueprint, modification_request, needs) -> TaskBlueprint`。
+- `src/llm4ad/consultant/needs.py`：`NeedsProfile` 是 dataclass，主字段 `description`，
+  其它可选：`project_name`、`metrics_hints: list[str]`、`evaluation_hints`、`data_path`、
+  `code_path`、`language` 等。有 `to_dict`/`from_dict`。
+- `src/llm4ad/builder/writer.py`：`write_task_directory(blueprint, output_dir)` 把
+  blueprint 写成 `output_dir/{project_name}/` 下的文件。
+- `provider` 这里指 **llm4ad 的 `BaseProvider`**（`BaseProvider.create(type, config=cfg)`），
+  与 AgentScope 的 model 是两套东西：AgentScope model 驱动 agent 的推理循环，
+  llm4ad BaseProvider 驱动 BuildOrchestrator 内部的生成调用。两者用**同一份 provider_config**。
+
+---
+
+## 3. 架构总览（混合路线，最终形态）
+
+```
+用户(UI 配置自己的任意 provider 凭据，加密入库)
+        │  beta=true 且后端 ENABLE_AI_AGENT_BUILD 开启
+后端 start_turn → generation_kind = AI_AGENT → _run_agent_build 协程
+        │ _maybe_proxy_provider_config: 若 LLM_PROXY_ENABLE,
+        │   发一次性 token(TTL 2h) → provider_config.api_key=token, base_url=proxy
+        ▼
+一次性隔离容器(chat_tune_runner 的 FastAPI app, POST /agent)
+   AgentScope 单 agent (provider_config → OpenAI/Anthropic model)
+   工具(全部沙箱在 /task/data):
+     read_file / list_dir         —— 只读，看用户已有代码/数据做需求分析
+     run_python                    —— 跑脚本自验(debug_run/test_evaluator)
+     build_task                    —— 调 BuildOrchestrator.build() 生成+validation闸
+     rebuild_evaluator             —— 调 BuildOrchestrator.rebuild_evaluator() 修
+   流程: 聊需求 → build_task → run_python 验证 → 跑不通 rebuild → 再验证
+   agent 推理 → 调模型 → (proxy 时)经后端 proxy → 上游(真实 key 留后端)
+        │ reply_stream 事件 → 映射成 chunk/build_result/done/error (SSE)
+        ▼
+后端 _run_agent_build: 落库 + 上传产物到对象存储 + 回填 task.input_args
+   (完全复用 _run_ai_build 的同款逻辑)
+```
+
+**两层验证**：(1) agent 用 `run_python` 自验；(2) `build_task` 内 BuildOrchestrator 自带
+的确定性 validation 闸。无第三层。
+
+**安全分层**：① 容器隔离(沿用现状) ② 工具路径围栏(硬保证，不能越出 `/task/data`)
+③ 无通用 Bash(消除 shell 逃逸面) ④ 真实 key 经 proxy 不进容器 ⑤ 权限引擎 BYPASS
+(因为只有上述被围栏的工具，且无人值守)。
+
+---
+
+## 4. 已完成的改动（逐文件）
+
+> 全部在 `src/backend/`。所有文件已通过 `uv run --python 3.10 --with ruff ruff check`（All checks passed）。
+
+### 4.1 `src/backend/pyproject.toml`（改）
+- dependencies 末尾新增 `"agentscope>=2.0,<3.0"`，附注释说明只用核心包、绝不用
+  agentscope-runtime。已 `uv lock` 成功。
+
+### 4.2 `src/backend/app/tasks/agent_build_runner.py`（新，核心引擎）
+容器内跑的模块。要点：
+- `AgentBuildRequest`：`POST /agent` 请求体（`provider_config`、`gathering_context`、
+  `user_content`、`max_iters=40`）。
+- `build_model(provider_config)`：按 `type` 映射 AgentScope model。`anthropic`→
+  `AnthropicChatModel`，其余→`OpenAIChatModel`。`base_url`/`api_key` 直透（指向 proxy 即可）。
+- `_build_llm_provider(provider_config)`：建 llm4ad `BaseProvider`（给 BuildOrchestrator 用）。
+- `_BuildState`：持有当前 `blueprint`/`needs`/`project_name`，供 rebuild 工具跨调用使用。
+- `make_tools(base_dir, provider_config, state)`：返回 5 个 `FunctionTool`：
+  - `read_file(path)` / `list_dir(path)`：只读，路径过 `_resolve_within_sandbox`。
+  - `run_python(path, args)`：`subprocess.run` 跑沙箱内 .py，超时 600s，输出截断。
+  - `build_task(description, project_name, metrics_hints, evaluation_hints, data_path,
+    code_path, language)`：构造 `NeedsProfile` → `BuildOrchestrator.build()` →
+    `write_task_directory` 写入 → 存入 state → 返回产物清单。`BuildError` 时返回闸错误字符串。
+  - `rebuild_evaluator(modification_request)`：用 state 里的 blueprint/needs 调
+    `BuildOrchestrator.rebuild_evaluator()` → 重写 → 更新 state。
+- `run_agent_build(req)`：async 生成器。建 model+toolkit+Agent，设
+  `permission_context.mode = BYPASS`，用 `UserMsg`（**不是 `Msg`**）构造输入，
+  `agent.reply_stream` 事件 → 映射 `chunk`/工具进度行/`✓` → 末尾
+  `build_result`(含 `_blueprint_data(state)`，带 `built` 标志) + `done`；异常 → `error`。
+- `router = APIRouter()`，`POST /agent` → SSE。
+
+### 4.3 `src/backend/app/tasks/agent_build_skill.py`（新，领域知识）
+- `build_system_prompt(workspace_dir)`：系统提示词。讲清"你不自己写文件，用 build_task
+  让引擎生成，再用 run_python 验证、rebuild_evaluator 修"，工具用法，工作流，完成判据
+  （build_task 成功 + test_evaluator.py 能加载 + debug_run.py 跑通），并提示"路径越界=
+  你试图离开工作区"。要求用用户语言回答。
+- `build_task_message(gathering_context, user_content)`：把 needs_profile/description/
+  本轮 user_content 拼成给 agent 的任务消息。
+
+### 4.4 `src/backend/app/tasks/chat_tune_runner.py`（改，挂载路由）
+- 文件末尾（`main()` 前）新增：
+  ```python
+  from app.tasks.agent_build_runner import router as _agent_router  # noqa: E402
+  app.include_router(_agent_router)
+  ```
+  放末尾是为了解开循环导入（agent_build_runner 顶部从本模块 import `DATA_DIR`/
+  `_resolve_within_sandbox`/`_sse`）。
+
+### 4.5 `src/backend/app/models/chat_tune.py`（改）
+- `ChatTuneGenerationKind` 枚举新增 `AI_AGENT = "ai_agent"`。
+
+### 4.6 `src/backend/app/schemas/chat_tune.py`（改）
+- `ChatTuneTurnStartRequest` 新增字段 `beta: bool = False`（仅当后端
+  `ENABLE_AI_AGENT_BUILD` 开启时生效）。
+
+### 4.7 `src/backend/app/core/config.py`（改）
+- `Settings` 新增 `ENABLE_AI_AGENT_BUILD: bool = False`（在 CHAT_TUNE 容器配置段附近）。
+
+### 4.8 `src/backend/app/services/chat_tune_service.py`（改，编排）
+- 模块常量新增 `_AGENT_BUILD_TOKEN_TTL = 2 * 3600`（agent 构建代理 token 的短 TTL）。
+- `start_turn` 分发器：在原 generation_kind 判定后追加——
+  `if request.beta and settings.ENABLE_AI_AGENT_BUILD: generation_kind = AI_AGENT`
+  （覆盖阶段判定，因为 agent 一轮内承接全部）。
+- `start_turn` 调度分支：新增 `elif generation_kind is AI_AGENT:` →
+  `asyncio.create_task(_run_agent_build(..., user_id=current_user.id,
+  user_content=llm_user_content, ...))`。
+- `retry_turn` 调度分支：新增 `elif kind == AI_AGENT.value:` → 同上（用 `user_msg.content`）。
+- 新增 `_maybe_proxy_provider_config(provider_config, user_id, task_id)`：
+  LLM_PROXY 开启时发一次性 token（TTL=`_AGENT_BUILD_TOKEN_TTL`）并改写 provider_config
+  （api_key=token, base_url=proxy, auth_token="");关闭/mock 时原样返回。
+- 新增 `_run_agent_build(...)` 协程：照搬 `_run_ai_build` 结构，区别：
+  - 先调 `_maybe_proxy_provider_config` 得到 `container_provider_config`；
+  - POST 到 `{base_url}/agent`，body 含 `provider_config`(已脱敏)、`gathering_context`、
+    `user_content`；
+  - `build_result` 仅当 `blueprint_data.get("built")` 为真才上传产物；
+  - `finally` **不调** `revoke_task_tokens`（见 §5 bug 2），靠短 TTL 兜底。
+
+---
+
+## 5. 复查中发现并已修复的两个真 bug（重要）
+
+接手时请知悉这两个坑，改相关代码时别回退：
+
+### Bug 1：`Msg(content="字符串")` 会崩
+AgentScope 的 `Msg` 只有 after-validator 断言 content 是 block 列表，没有 before-validator
+做 str→block 转换；`_to_blocks` 只在 `UserMsg`/`AssistantMsg` 工厂里调用。
+**修复**：`run_agent_build` 用 `from agentscope.message import UserMsg` +
+`UserMsg(name="user", content=task_text)`。
+
+### Bug 2：`revoke_task_tokens(task_id)` 会误杀演化任务的 token
+`revoke_task_tokens` 删的是该 task_id 下**所有** token，而 `evolution.py` 为**同一个**
+task_id 也签发任务级 token。我最初在 `_run_agent_build` 的 `finally` 里调它，会把并发/
+后续演化任务的 proxy token 一并删掉。且原 `_run_ai_build` 本就**不** revoke（靠 TTL）。
+**修复**：移除 `finally` 里的 revoke，改为发 token 时用短 TTL（`_AGENT_BUILD_TOKEN_TTL=2h`）
+自然过期。
+
+---
+
+## 6. 已验证 / 未验证
+
+### 已验证
+- `ruff check`：全部新增/修改文件通过（All checks passed）。
+- `py_compile`：三个新/改文件语法 OK。
+- **沙箱路径围栏**：用 8 个用例本地测 `_resolve_within_sandbox`（runner 工具复用的同款
+  函数）——`proj/ok.py`/`./proj/ok.py`/内部不存在路径=放行；`../escape.py`/
+  `../../etc/passwd`/`proj/../../../etc/x`/`/etc/passwd`=拒绝。8/8 通过。
+- AgentScope API：直接读 v2.0.3 已安装源码核实了所有签名、事件类、权限模式、Msg 工厂。
+
+### 未验证（需要真实环境，见 §7）
+- **AgentScope 端到端**：agent 真的跑起来、事件映射正确、工具被正确调用、产出能过闸、
+  rebuild 循环有效——需要 ① 可用 provider 的 key+base_url ② 重建镜像 ③ Linux 容器里跑
+  （本机 Windows 因杀软导致 agentscope 导入超时，不适合在 host 上验证）。
+
+---
+
+## 7. 剩余工作（按优先级）
+
+1. **重建镜像 + 容器内端到端验证**（最高优先，最早暴露真实问题）：
+   - `agentscope` 是新依赖，**backend 与 task-runner 两个镜像都要重建**（task-runner
+     复用 backend 依赖；它跑 `chat_tune_runner` 进程，agent 就在这里）。
+   - 重建坑：见 §9 —— `./dev.sh full` 默认带 `--build`，task-runner 的 `Dockerfile.task`
+     `apt-get` 会连不上 `deb.debian.org`。要么配 `APT_MIRROR`，要么只重建 backend
+     的 uv 依赖层（task-runner 镜像本地已有，但需要它带上 agentscope —— 故 task-runner
+     也要重建其依赖层）。
+   - 验证：开 `ENABLE_AI_AGENT_BUILD=true`（+ 建议 `LLM_PROXY_ENABLE=true` 配好
+     `LLM_PROXY_BASE_URL`），配一个 OpenAI 兼容 provider（如 DeepSeek）和一个 Anthropic
+     provider 各跑一次 beta 构建；确认产出能过 BuildOrchestrator 闸 + agent 自验通过；
+     构造一个诱导 agent 写/读越界路径的需求，确认工具返回拒绝。
+2. **前端 Beta 入口**（用户明确说**暂不做**，本次未碰）：
+   - 在 `src/frontend` 的 ChatTuneView 加一个 "AI 构建 (Beta)" 入口，发 `startTurn` 时带
+     `beta: true`。需重新生成前端 API client（schema 加了 `beta` 字段）。
+   - 仅当后端开关开启时显示（需要后端暴露该 flag 给前端，或前端配置）。
+3. **可选后续加固**：为 beta 容器搭专用 internal 网络、只放行到 proxy 出口
+   （当前沿用 chat_tune 共享网络级别，与现状一致）。
+
+---
+
+## 8. 待用户拍板的开放问题
+
+1. **`_AGENT_BUILD_TOKEN_TTL = 2h` 是否合适**：我自行定的（一轮构建分钟级，2h 给多轮
+   debug 留足余量）。若用户认为该更短/更长，改 `chat_tune_service.py` 的常量即可。
+2. **`run_python` 超时 600s、`max_iters=40`**：经验值，未与用户确认。多轮 rebuild + 跑
+   完整 `debug_run.py`（会真实调 LLM 进化）可能不够或过长。
+3. **`build_task` 是否暴露 `multimodal` 入口**：当前没暴露（NeedsProfile 支持 multimodal，
+   但 beta 工具签名未加），多模态任务走 beta 暂不支持。
+4. **完成判据的"严格度"**：当前靠系统提示词要求 agent 跑通两个自验脚本 + 引擎闸。
+   没有在后端再做强制 gate（符合"两层就够"）。若线上发现弱模型 agent 谎报完成，
+   可能要加一道后端 gate（但这违反"两层"的决策，需用户重新确认）。
+
+---
+
+## 9. 部署/环境备忘（来自本会话踩的坑）
+
+- 项目可本地 Docker 部署。`docker/.env` 仓库只有示例（`.env.develop.local.example`）。
+  本会话已创建过 `docker/.env`（全 Docker 模式：端点用 compose 服务名 db/redis/rustfs/
+  mailcatcher/backend；密钥已生成；`HOST_PROJECT_HOME` 指向 `docker/app-data/project_home`）。
+- 启动：`docker compose -f compose.yml -f compose.deploy.debug.yml --profile debug up -d`。
+  前端 `localhost:18041`，后端 `localhost:8000`/`/docs`，超管 `admin@example.com`/`Admin12345`。
+- **CRLF 坑**：`src/backend/scripts/*.sh` 曾被 Windows git autocrlf 转成 CRLF，导致
+  `prestart` 容器（迁移+建超管）`\r` 报错。已 `sed -i 's/\r$//'` 修复并重建 backend 镜像。
+  若重建镜像后 prestart 又挂，先查这个。
+- **task-runner 构建坑**：`./dev.sh full` 带 `--build` 时 `Dockerfile.task` 的 apt
+  连不上 deb.debian.org，整批构建 CANCELED。本会话当时用不带 `--build` 的 `up -d` 复用
+  既有镜像绕过。**但本次加了 agentscope 依赖，必须重建**——届时需配 `APT_MIRROR`
+  （如 `mirrors.aliyun.com`）或确保容器联网，否则 task-runner 镜像重建会失败。
+- ruff 在本仓库要用 `uv run --python 3.10 --with ruff ruff check src/...`
+  （ruff 不是默认依赖，要 `--with ruff`；CLAUDE.md 要求用 3.10 跑）。
+
+---
+
+## 10. 改动文件清单（速查）
+
+| 文件 | 类型 | 说明 |
+|---|---|---|
+| `src/backend/pyproject.toml` | 改 | 加 agentscope 依赖 |
+| `src/backend/app/tasks/agent_build_runner.py` | 新 | 容器内 agent 引擎(model映射/工具/循环/SSE) |
+| `src/backend/app/tasks/agent_build_skill.py` | 新 | agent 系统提示词 + 任务消息构造 |
+| `src/backend/app/tasks/chat_tune_runner.py` | 改 | 末尾 include `/agent` 路由 |
+| `src/backend/app/models/chat_tune.py` | 改 | 枚举加 `AI_AGENT` |
+| `src/backend/app/schemas/chat_tune.py` | 改 | 请求加 `beta` 字段 |
+| `src/backend/app/core/config.py` | 改 | 加 `ENABLE_AI_AGENT_BUILD` 开关 |
+| `src/backend/app/services/chat_tune_service.py` | 改 | `_AGENT_BUILD_TOKEN_TTL`/`_maybe_proxy_provider_config`/`_run_agent_build`/分发器+retry 分支 |
+| `src/backend/app/tasks/agent_build_support.py` | 已删 | 早期"agent自写代码"路线的桥接，选混合后废弃 |
+
+> 提示：未做 DB 迁移。`generation_kind` 是 `ChatTuneMessage` 上的 varchar 字段，加枚举值
+> `ai_agent` 不需要 schema 迁移（值是字符串）。若有疑虑可核对 `models/chat_tune.py` 该字段
+> 定义（max_length 20，"ai_agent" 长度 8，安全）。

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,6 +96,14 @@ docs = [
     "mkdocs-minify-plugin>=0.8.0",
     "mkdocstrings[python]>=0.24.0",
 ]
+# AI build (beta) agent. agentscope requires Python >=3.11, while llm4ad core
+# targets >=3.10; the env marker makes this extra empty on 3.10 (so the universal
+# lockfile still resolves) and pulls agentscope only on 3.11+. Imports are lazy so
+# the rest of llm4ad works on 3.10 without it. Used by `llm4ad chatv2` and the
+# backend /agent path.
+agent = [
+    "agentscope>=2.0,<3.0; python_version >= '3.11'",
+]
 all = [
     "llm4ad[infra,providers,eval,dev,docs,tsp,lunarlander,dyca,meoh]"
 ]

--- a/skills/llm4ad-task-builder/README.md
+++ b/skills/llm4ad-task-builder/README.md
@@ -1,0 +1,46 @@
+# llm4ad-task-builder — a portable Agent Skill
+
+A single, agent-agnostic Skill that teaches any capable coding agent how to build a
+runnable **LLM4AD_Next task package** (evaluator + algorithm with EVOLVE markers +
+config.yaml + test scripts + sample data) and how the package is used on the
+LLM4AD platform.
+
+It follows the open [Agent Skills](https://agentskills.io) `SKILL.md` format
+(YAML frontmatter + Markdown body + reference files), which works across Claude
+Code, Qwen Code, and other agents.
+
+## Contents
+
+```
+llm4ad-task-builder/
+├── SKILL.md                       # the skill: package knowledge + how to use the platform
+├── reference/
+│   ├── config-template.yaml       # annotated 10-section config.yaml skeleton
+│   └── example-tsp.md             # pointer to the full working example in this repo
+└── README.md                      # this file
+```
+
+## Install / use
+
+**Claude Code** — copy or symlink this directory into your skills folder:
+```bash
+cp -r skills/llm4ad-task-builder ~/.claude/skills/       # user scope
+# or project scope: <repo>/.claude/skills/llm4ad-task-builder
+```
+Claude auto-discovers it by the `name`/`description` frontmatter and loads the body
+when a task matches.
+
+**Qwen Code** — place it under Qwen Code's skills directory (see Qwen Code's Skills
+docs); the same `SKILL.md` format is supported.
+
+**This platform (AgentScope agent)** — the platform's beta build agent loads
+`SKILL.md`'s body into its system prompt at runtime, so the same knowledge drives
+the in-platform agent as well. (Maintained as one source; see
+`src/llm4ad/agent/`.)
+
+## Scope
+
+This skill is **domain knowledge** (what a package is, its contracts, how to run it),
+not a tool implementation. It assumes the host agent already has file read/write and
+command execution. The platform's interactive UX (step-by-step option cards, the
+plan/confirm/lock flow) lives in the platform agent, not in this portable skill.

--- a/skills/llm4ad-task-builder/SKILL.md
+++ b/skills/llm4ad-task-builder/SKILL.md
@@ -1,0 +1,148 @@
+---
+name: llm4ad-task-builder
+description: "Use when a user wants to build an LLM4AD_Next task package — a runnable directory that lets the LLM4AD platform evolve an algorithm for their problem. Covers what files a task package contains, each file's contract, and how the package is run on the LLM4AD platform."
+---
+
+# Building an LLM4AD_Next Task Package
+
+## What LLM4AD_Next is
+
+LLM4AD_Next is an automated algorithm-design platform: it combines an LLM with
+evolutionary optimization to discover and improve algorithms automatically. The
+user describes a problem (e.g. "evolve a solver for the Traveling Salesman
+Problem"), marks the code region to evolve with `# EVOLVE_START` / `# EVOLVE_END`,
+and the platform repeatedly asks an LLM to propose better code inside that region,
+scores each candidate with a custom evaluator, and keeps the best across
+generations. Better algorithms emerge through guided search rather than manual
+trial and error.
+
+Your job with this skill: turn a user's problem into a **complete, runnable task
+package**, then verify it actually runs before handing it over.
+
+## What a task package is
+
+A task package is a self-contained directory with everything the platform needs to
+evolve algorithms for one problem:
+
+| File | Purpose |
+|---|---|
+| `config.yaml` | Master config for the whole pipeline (evolution params, providers, evaluator, dataset). This is what gets run. |
+| `<name>_evaluator.py` | A `BaseEvaluator` subclass that runs a candidate algorithm on test data and returns a score + metrics. Defines what "better" means. |
+| `<algo_dir>/<algo>.py` | The algorithm, with the function to evolve wrapped in `# EVOLVE_START` / `# EVOLVE_END`. Reads input as a JSON CLI arg, prints a JSON result. |
+| `debug_run.py` | Runs the full pipeline once (`LLM4AD("config.yaml").run()`) — a smoke test. |
+| `test_evaluator.py` | Loads the evaluator via the dispatcher to confirm it imports and is wired correctly. |
+| `data/sample/*.json` | 2-3 small test instances the evaluator scores algorithms against. |
+
+## The contracts each file must satisfy
+
+**Algorithm file** (`<algo_dir>/<algo>.py`):
+- The algorithm directory is the one named in `version_control.local_path`; the
+  platform copies it into a git worktree for each candidate and edits only the code
+  between the markers.
+- The function to evolve is wrapped exactly in `# EVOLVE_START` and `# EVOLVE_END`
+  comment markers (the platform only edits code between them).
+- It reads its input as a single JSON string from `sys.argv[1]`, and prints a JSON
+  result to stdout — so the evaluator can run it as a subprocess.
+- The file name must match the name the evaluator looks for (see below). In the TSP
+  example both sides use `solve.py`.
+
+**Evaluator** (`<name>_evaluator.py`):
+- Subclasses `BaseEvaluator`, decorated `@BaseEvaluator.register("<name>")`, with a
+  no-argument `__init__(self)` (the base `__init__` takes no config).
+- Implements `metrics` (list of `Metric(name, type=MINIMIZE|MAXIMIZE, weight, description)`),
+  `name`, and `async def evaluate(self, cfg: EvalContext) -> EvaluationResult`.
+- `cfg: EvalContext` carries `cfg.project_root` (the candidate's worktree dir),
+  `cfg.data_path` (the current data file), and `cfg.timeout` (seconds per instance).
+- `evaluate` locates the algorithm file **by hardcoded name** under
+  `cfg.project_root` (e.g. `Path(cfg.project_root) / "solve.py"`), runs it as a
+  subprocess on `cfg.data_path`, parses its JSON output, validates it, and returns
+  `EvaluationResult(score, metrics, success, ...)` (negative cost for a minimization
+  objective). That hardcoded name **must** equal the algorithm file's actual name —
+  this is the most common wiring mistake.
+
+**config.yaml** (10 sections — generated programmatically, not hand-written):
+- `providers` use `${LLM_BASE_URL}` / `${LLM_API_KEY}` / `${LLM_MODEL}` env
+  placeholders (the platform fills them in).
+- The evaluator `module` reference (`<file>.py:<ClassName>`), the `metrics` list,
+  the `dataset` path (`data/sample`), and the coder `prompt_template`'s EVOLVE block
+  must all be consistent with the other files.
+
+**debug_run.py** / **test_evaluator.py**: standard boilerplate that runs
+`config.yaml` end-to-end and loads the evaluator, respectively.
+
+See `reference/config-template.yaml` for the config shape and `reference/example-tsp.md`
+for a pointer to a complete, known-good package in this repo to adapt.
+
+## The information to gather before building
+
+A correct package needs these decided (ask the user; let the agent fill sensible
+defaults where the user has no preference):
+
+1. **Problem description** — what is being optimized. (Required — ask.)
+2. **Function/algorithm to evolve + input/output format** — ask if the user has any
+   constraints; if not, the agent designs it.
+3. **Evaluation metric(s)** — what to minimize/maximize. (Required — ask clearly.)
+4. **Reuse existing code/evaluator?** — user provides existing code, or generate from
+   scratch. (Ask.)
+5. **Data source** — user provides data, or generate sample instances. (Ask.)
+6. **Programming language** — default Python. (Offer as a choice.)
+7. **Project name** — the agent proposes one from the description; confirm with user.
+
+## Build workflow
+
+1. Understand the problem and the 7 items above (inspect any user-provided code/data).
+2. Write the algorithm file first; verify it runs standalone and prints valid JSON.
+3. Write 2-3 sample data files under `data/sample/`.
+4. Write the evaluator; keep its metrics consistent with `config.yaml`.
+5. Write `config.yaml`, `debug_run.py`, `test_evaluator.py`.
+6. **Self-test (required):** run `test_evaluator.py` (evaluator loads — no LLM, no
+   network, cheap and always runnable). Then run `debug_run.py`, which executes the
+   full pipeline and **does call the LLM**: it needs the `LLM_BASE_URL` /
+   `LLM_API_KEY` / `LLM_MODEL` env vars set (the config uses these placeholders) and
+   consumes tokens over the network. Read every error, fix the relevant file,
+   re-run. Not done until both run cleanly. If no provider credentials are available,
+   say so — a missing-credential failure of `debug_run.py` is not a package defect.
+
+<!-- PLATFORM-USAGE-DRAFT: 以下"如何在平台上使用"为草稿，待产品同学修订 -->
+## How the package is used on the LLM4AD platform
+
+Once the package exists, the user runs it to evolve their algorithm. Two paths:
+
+**CLI:**
+```bash
+llm4ad run path/to/config.yaml
+# resume an interrupted run: pass a real checkpoint file written under
+# ./runs/<project>/<run_id>/checkpoints/ (Island GA names them
+# iga_checkpoint_gen_<N>_<hash>.json; MEoH names them meoh_<N>.json).
+llm4ad run config.yaml --resume ./runs/<project>/<run_id>/checkpoints/iga_checkpoint_gen_5_a1b2c3d4.json
+```
+It launches the evolution pipeline and prints per-generation progress (best score
+each generation).
+
+**Web platform (this project's Web UI):**
+1. Create or open a task (the package's `config.yaml` + files back it).
+2. Configure an LLM provider (the user's own key/model — OpenAI-compatible or
+   Anthropic). The package's `config.yaml` references providers by the platform's
+   env placeholders; the platform injects the real credentials at run time.
+3. Start the evolution run; monitor progress in the browser — current generation,
+   best individual's score, metrics, and logs — in real time.
+4. When it finishes, inspect the best evolved algorithm and its score.
+
+**Tuning after generation (optional):** users often adjust `config.yaml` evolution
+parameters to trade cost vs. quality — e.g. `max_generations`, `num_islands`,
+`island_population_size`, `mutation_rate` / `crossover_rate`, `early_stop_patience`,
+the provider `model`, and `evaluator.timeout`.
+
+**Where results go:** each run writes to `./runs/{project}/{run_id}/`:
+- `best/code/` — the evolved algorithm source (the main deliverable)
+- `best/metadata.json`, `best/summary.txt` — score, generation, metrics
+- `state/evolution_state.json` — full generation history (drives the Web UI dashboards)
+- `logs/llm4ad.log` — full execution log for troubleshooting
+- `checkpoints/` — snapshots to resume from
+<!-- END PLATFORM-USAGE-DRAFT -->
+
+## Completion criteria
+
+The package is done only when `test_evaluator.py` loads the evaluator AND
+`debug_run.py` runs without raising. Then summarize what was built (files + the
+7 decisions) and the verification result.

--- a/skills/llm4ad-task-builder/reference/config-template.yaml
+++ b/skills/llm4ad-task-builder/reference/config-template.yaml
@@ -1,0 +1,96 @@
+# config.yaml — LLM4AD_Next task package configuration (reference template).
+#
+# 10 sections. Adapt project_name / paths / metrics / the coder prompt_template to
+# the task. Keep providers using the ${LLM_BASE_URL}/${LLM_API_KEY}/${LLM_MODEL}
+# env placeholders — the platform fills these in at run time. The evaluator `module`
+# reference, the `metrics` list, the dataset `path`, and the coder prompt_template's
+# EVOLVE_START/EVOLVE_END block must stay consistent with the other package files.
+
+# 1. General
+project_name: "example_task"
+description_en: "One-line English description for platform display."
+description_zh: "用于平台展示的一句话中文描述。"
+background: |
+  A short paragraph describing the problem, passed to the LLM for context.
+random_seed: 42
+base_dir: "./runs"
+
+# 2. Workspace
+workspace:
+  auto_create: true
+  subdirs: {output: "output", logs: "logs", checkpoints: "checkpoints",
+            generated: "generated", cache: "cache", temp: "temp"}
+
+# 3. Providers (env placeholders — do not hardcode real keys)
+providers:
+  - name: "default"
+    type: "openai_compatible"
+    base_url: ${LLM_BASE_URL}
+    api_key: ${LLM_API_KEY}
+    model: ${LLM_MODEL}
+    temperature: 0.7
+    max_tokens: 8192
+    timeout: 120.0
+
+# 4. Coder (materializes LLM proposals into code)
+coder:
+  type: "custom"
+  provider: "default"
+  timeout: 180.0
+  max_retries: 2
+  default_extension: "py"
+  prompt_template: |
+    Implement the function to evolve. Provide the function body between
+    EVOLVE_START and EVOLVE_END markers.
+
+# 5. Planner (proposes algorithm ideas)
+planner:
+  type: "llm_evolution"
+  provider: "default"
+  selection_strategy: "weighted"
+  parent_selection_strategy: "tournament"
+  build: {script: {}}
+  samplers:
+    - {name: "init_sampler"}
+    - {name: "mutation_sampler"}
+    - {name: "crossover_sampler"}
+
+# 6. Evaluator (module ref + metrics must match the evaluator .py file)
+evaluator:
+  type: "custom"
+  module: "example_evaluator.py:ExampleEvaluator"
+  timeout: 120.0
+  max_retries: 2
+  parallel: true
+  batch_size: 6
+  dataset: {mode: "directory", path: "data/sample", recursive: false}
+  metrics: ["objective", "valid"]
+
+# 7. Evolution (the params users most often tune after generation)
+evolution:
+  type: "island_ga"
+  max_generations: 5
+  num_islands: 2
+  island_population_size: 2
+  mutation_rate: 0.3
+  crossover_rate: 0.5
+  tournament_size: 3
+  early_stop_patience: 10
+
+# 8. Multimodal
+multimodal: {enabled: false}
+
+# 9. Logging
+logging: {level: "INFO", console: true}
+
+# 10. Version control + repo analyzer
+version_control:
+  enabled: true
+  type: "git_worktree"
+  local_path: "example_algorithm"
+  auto_initialize: true
+  default_branch: "main"
+repo_analyzer:
+  type: "evolve_detector"
+  include: ["*.py"]
+  exclude: [".git/**", "__pycache__/**"]

--- a/skills/llm4ad-task-builder/reference/example-tsp.md
+++ b/skills/llm4ad-task-builder/reference/example-tsp.md
@@ -1,0 +1,28 @@
+# Reference: a complete, known-good task package
+
+For a full, runnable example of an LLM4AD_Next task package, see the TSP benchmark
+in this repository:
+
+    examples/applications/tsp_benchmark_python/
+
+It contains every piece a package needs, and is the best concrete reference to
+adapt:
+
+- `config.yaml` — the 10-section pipeline config (see `../config-template.yaml`
+  here for an annotated skeleton).
+- `tsp_evaluator.py` — a `BaseEvaluator` subclass (`PythonTSPEvaluator`): runs the
+  algorithm as a subprocess, validates the tour, returns score + metrics.
+- `tsp_algorithm/solve.py` — the algorithm with `# EVOLVE_START` / `# EVOLVE_END`
+  around the function to evolve; reads a JSON CLI arg, prints a JSON result.
+- `debug_run.py` — runs the full pipeline once (smoke test).
+- `test_evaluator.py` — loads the evaluator via the dispatcher.
+- `data/` — sample instances the evaluator scores against.
+
+When building a new package, mirror this structure and the file contracts described
+in `../../SKILL.md`, adapting names, the algorithm, the metrics, and the dataset to
+the user's problem.
+
+Note: on the platform (Web UI / backend), the package is generated programmatically
+by the build engine and the same structure is produced automatically — this
+reference is the shape that engine targets and that any coding agent should
+reproduce.

--- a/src/backend/app/api/base_routes/utils.py
+++ b/src/backend/app/api/base_routes/utils.py
@@ -5,13 +5,21 @@
 """
 
 from fastapi import APIRouter, Depends
+from pydantic import BaseModel
 from pydantic.networks import EmailStr
 
 from app.api.deps import get_current_active_superuser
+from app.core.config import settings
 from app.models import Message
 from app.utils.email import generate_test_email, send_email
 
 router = APIRouter(prefix="/utils", tags=["utils"])
+
+
+class FeatureFlags(BaseModel):
+    """Public feature flags the frontend uses to show/hide optional UI."""
+
+    enable_ai_agent_build: bool
 
 
 @router.post(
@@ -49,3 +57,16 @@ async def health_check() -> bool:
         bool: 始终为 ``True``。
     """
     return True
+
+
+@router.get("/features/")
+async def feature_flags() -> FeatureFlags:
+    """返回前端可见的特性开关。
+
+    前端据此决定是否展示可选 UI（如 "AI 构建 (Beta)" 入口）。无需鉴权——
+    仅暴露布尔开关，不含任何敏感信息。
+
+    Returns:
+        FeatureFlags: 当前生效的特性开关集合。
+    """
+    return FeatureFlags(enable_ai_agent_build=settings.ENABLE_AI_AGENT_BUILD)

--- a/src/backend/app/core/config.py
+++ b/src/backend/app/core/config.py
@@ -239,6 +239,12 @@ class Settings(BaseSettings):
     CHAT_TUNE_CONTAINER_READY_TIMEOUT: float = 30.0   # 等待容器 SSE 服务就绪的超时（秒）
     CHAT_TUNE_CONTAINER_NETWORK: bool = True           # True=通过 Docker 网络连接容器; False=发布端口到宿主机用 localhost 连接
 
+    # ---- AI 构建 (beta)：AgentScope 单 agent 构建 ----
+    # 开启后前端显示 "AI 构建 (Beta)" 入口，beta 轮次走 AgentScope agent
+    # （混合：BuildOrchestrator 生成 + agent 用 run_python 验证/重试），
+    # 与现有 AI 构建并存。关闭时 beta 入口隐藏、beta 请求回退到旧 AI 构建。
+    ENABLE_AI_AGENT_BUILD: bool = False
+
     # ---- Celery 任务超时 ----
     # 单一来源：Celery 配置与 LLM 代理 token TTL 均由此派生，避免多处魔法数字漂移。
     TASK_TIME_LIMIT: int = 7 * 24 * 3600        # 任务硬超时（秒），默认 7 天

--- a/src/backend/app/models/chat_tune.py
+++ b/src/backend/app/models/chat_tune.py
@@ -53,6 +53,7 @@ class ChatTuneGenerationKind(StrEnum):
 
     CHAT_TUNE = "chat_tune"
     AI_BUILD = "ai_build"
+    AI_AGENT = "ai_agent"
     REVIEW = "review"
 
 

--- a/src/backend/app/schemas/chat_tune.py
+++ b/src/backend/app/schemas/chat_tune.py
@@ -57,6 +57,13 @@ class ChatTuneTurnStartRequest(BaseModel):
         default="zh",
         description="本轮对话使用的语言（zh/en），驱动 LLM 回答语言",
     )
+    beta: bool = Field(
+        default=False,
+        description=(
+            "是否走 AI 构建 (Beta)：用 AgentScope 单 agent 构建。仅当后端 "
+            "ENABLE_AI_AGENT_BUILD 开启时生效，否则忽略并回退到默认分发。"
+        ),
+    )
 
     @model_validator(mode="after")
     def _validate_inputs(self) -> "ChatTuneTurnStartRequest":

--- a/src/backend/app/services/chat_tune_service.py
+++ b/src/backend/app/services/chat_tune_service.py
@@ -195,6 +195,12 @@ def get_turn_stream_context(
 _DEFAULT_PAGE_LIMIT = 50
 _MAX_PAGE_LIMIT = 100
 
+# Proxy token TTL for an AI-agent build turn (seconds). One turn lives minutes;
+# 2h covers long multi-round debug builds with margin. Bounded and self-expiring
+# because the token is NOT explicitly revoked (it is task-scoped and an evolution
+# run for the same task issues its own token).
+_AGENT_BUILD_TOKEN_TTL = 2 * 3600
+
 
 def get_session_detail(
         db: Session,
@@ -404,6 +410,40 @@ def start_turn(
     else:
         generation_kind = ChatTuneGenerationKind.CHAT_TUNE
 
+    # AI 构建 (Beta)：前端 beta 标志在后端开关开启时，覆盖为 AgentScope agent
+    # 路径。该 agent 在一轮内承接对话+构建+验证，不依赖三阶段状态机，故无视上面
+    # 的阶段判定。开关关闭时忽略 beta，沿用上面的默认分发。
+    if request.beta and settings.ENABLE_AI_AGENT_BUILD:
+        generation_kind = ChatTuneGenerationKind.AI_AGENT
+
+    # 稳健路由：若本轮是在回复一条 ai_agent 生成的消息（如确认卡片），无论前端是否
+    # 仍带 beta 标志（刷新后可能丢失），都继续走 agent 路径。
+    replying_to_agent = (
+        locked_message is not None
+        and locked_message.generation_kind == ChatTuneGenerationKind.AI_AGENT.value
+    )
+    if replying_to_agent and settings.ENABLE_AI_AGENT_BUILD:
+        generation_kind = ChatTuneGenerationKind.AI_AGENT
+
+    # agent 的 build 阶段闸：进入 build 阶段（拥有 build/edit 工具）的条件——
+    #   (a) 用户在 confirm_build 卡片上点了“确认构建”，或
+    #   (b) 本会话已经构建过（build_status 完成 / 已有 blueprint_data），此时后续
+    #       轮次都应带 build/edit 工具，以便 agent 帮用户调 config、改代码、改评估器。
+    _already_built = (
+        session.build_status == ChatTuneStageStatus.COMPLETED.value
+        or bool((session.gathering_context or {}).get("blueprint_data"))
+    )
+    agent_allow_build = generation_kind is ChatTuneGenerationKind.AI_AGENT and (
+        (
+            replying_to_agent
+            and isinstance(locked_message.payload, dict)
+            and locked_message.payload.get("stage") == "confirm_build"
+            and isinstance(request.submission, dict)
+            and request.submission.get("value") == _CONFIRM_BUILD_VALUE
+        )
+        or _already_built
+    )
+
     # 取消上一轮：直接覆写 generation_id 让旧协程感知到
     if session.active_turn_id is not None:
         _cancel_turn_inplace(session.id, session.active_turn_id)
@@ -497,6 +537,27 @@ def start_turn(
                     provider_config=provider_config,
                     gathering_context=_ctx_with_language(),
                     input_data_path=task.input_data_path,
+                )
+            )
+        elif generation_kind is ChatTuneGenerationKind.AI_AGENT:
+            asyncio.create_task(
+                _run_agent_build(
+                    session_id=session.id,
+                    turn_id=turn_id,
+                    assistant_message_id=assistant_message.id,
+                    generation_id=generation_id,
+                    task_id=task.id,
+                    user_id=current_user.id,
+                    provider_config=provider_config,
+                    user_content=llm_user_content,
+                    gathering_context=_ctx_with_language(),
+                    input_data_path=task.input_data_path,
+                    allow_build=agent_allow_build,
+                    proposed=(
+                        (session.gathering_context or {}).get("proposed")
+                        if agent_allow_build
+                        else None
+                    ),
                 )
             )
         else:
@@ -736,6 +797,21 @@ def retry_turn(
                     generation_id=generation_id,
                     task_id=task.id,
                     provider_config=provider_config,
+                    gathering_context=gathering_ctx,
+                    input_data_path=task.input_data_path,
+                )
+            )
+        elif kind == ChatTuneGenerationKind.AI_AGENT.value:
+            asyncio.create_task(
+                _run_agent_build(
+                    session_id=session.id,
+                    turn_id=turn_id,
+                    assistant_message_id=assistant_msg.id,
+                    generation_id=generation_id,
+                    task_id=task.id,
+                    user_id=current_user.id,
+                    provider_config=provider_config,
+                    user_content=user_msg.content,
                     gathering_context=gathering_ctx,
                     input_data_path=task.input_data_path,
                 )
@@ -1063,6 +1139,357 @@ async def _run_ai_build(
         push_chat_tune_chunk(session_id, turn_id, {"type": "error", "error": error_msg})
 
     finally:
+        if client is not None:
+            await client.aclose()
+        if container_id is not None:
+            await asyncio.to_thread(
+                container_service.cleanup_chat_tune_container, container_id
+            )
+        if docker_workdir is not None:
+            await asyncio.to_thread(
+                container_service.cleanup_chat_tune_workdir, docker_workdir
+            )
+
+
+def _maybe_proxy_provider_config(
+    provider_config: dict[str, Any],
+    user_id: uuid.UUID,
+    task_id: uuid.UUID,
+) -> dict[str, Any]:
+    """Return a provider config safe to send into the agent container.
+
+    When the LLM proxy is enabled, swap the real credentials for a one-time
+    ``credential_broker`` token and point ``base_url`` at the in-cluster proxy,
+    so the real api_key never enters the container running agent-driven code
+    (which can execute generated code). When the proxy is disabled, return the
+    config unchanged (matches the existing chat-tune behavior).
+
+    Args:
+        provider_config: The resolved provider config (contains the real key).
+        user_id: Owner, for token auditing.
+        task_id: Task the token is scoped to.
+
+    Returns:
+        A new provider config dict to send to the container.
+    """
+    if not settings.LLM_PROXY_ENABLE:
+        return provider_config
+    if provider_config.get("type") == "mock":
+        return provider_config
+    if not settings.LLM_PROXY_BASE_URL:
+        raise RuntimeError(
+            "LLM_PROXY_ENABLE is on but LLM_PROXY_BASE_URL is unset; refusing to "
+            "send plaintext credentials into the agent container."
+        )
+    from app.services import credential_broker
+
+    proxied = dict(provider_config)
+    # Short bounded TTL: one build turn lives minutes, not the 7-day task TTL.
+    # We deliberately do NOT revoke on completion (tokens are task-scoped and an
+    # evolution run for the same task issues its own), so the TTL is the bound.
+    token = credential_broker.issue_token(
+        user_id=user_id,
+        task_id=task_id,
+        ttl=_AGENT_BUILD_TOKEN_TTL,
+        provider_type=provider_config.get("type", "openai_compatible"),
+        base_url=provider_config.get("base_url") or "",
+        api_key=provider_config.get("api_key") or "",
+        auth_token=provider_config.get("auth_token") or "",
+        model=provider_config.get("model", ""),
+        timeout=provider_config.get("timeout") or 60.0,
+    )
+    proxied["api_key"] = token
+    proxied["auth_token"] = ""
+    proxied["base_url"] = settings.LLM_PROXY_BASE_URL.rstrip("/")
+    return proxied
+
+
+async def _run_agent_build(
+        session_id: uuid.UUID,
+        turn_id: uuid.UUID,
+        assistant_message_id: uuid.UUID,
+        generation_id: str,
+        task_id: uuid.UUID,
+        user_id: uuid.UUID,
+        provider_config: dict[str, Any],
+        user_content: str = "",
+        gathering_context: dict[str, Any] | None = None,
+        input_data_path: str | None = None,
+        allow_build: bool = False,
+        proposed: dict[str, Any] | None = None,
+) -> None:
+    """Background coroutine: AI build (beta) via the AgentScope agent container.
+
+    Two-phase (gather / build) with cross-turn memory:
+
+    - GATHER (``allow_build=False``): the agent asks step-by-step; if it proposes a
+      plan, a ``payload`` confirm card is emitted (persisted onto the message) and
+      the proposal is stored in ``gathering_context`` for the build turn.
+    - BUILD (``allow_build=True``): the agent builds from the confirmed proposal;
+      artifacts are uploaded and ``input_args`` back-filled (as in ``_run_ai_build``).
+
+    Conversation memory is carried across turns via ``gathering_context['agent_state']``
+    (an ``agent_state`` event from the container, not forwarded to the frontend).
+    Credentials are routed through the LLM proxy when enabled.
+    """
+    from app.services import container_service
+
+    language = (gathering_context or {}).get("language") or "zh"
+    content_buffer = ""
+    blueprint_data: dict[str, Any] | None = None
+    final_payload: dict[str, Any] | None = None
+    new_proposed: dict[str, Any] | None = None
+    new_agent_state: dict[str, Any] | None = None
+    cancelled = False
+    container_id: str | None = None
+    docker_workdir: str | None = None
+    client = None
+
+    def _is_cancelled() -> bool:
+        return get_chat_tune_generation_id(session_id, turn_id) != generation_id
+
+    # The beta agent does both gathering and building in one coroutine, so the
+    # left-panel stage must reflect the current phase: gather turns drive the
+    # GATHERING stage, build turns drive the BUILD stage.
+    phase_stage = (
+        ChatTuneActiveStage.BUILD if allow_build else ChatTuneActiveStage.GATHERING
+    )
+
+    try:
+        await asyncio.to_thread(
+            _update_session_stage,
+            session_id, phase_stage, ChatTuneStageStatus.RUNNING,
+            activate=True,
+            turn_id=turn_id,
+        )
+
+        import httpx
+        from httpx_sse import aconnect_sse
+
+        container_provider_config = await asyncio.to_thread(
+            _maybe_proxy_provider_config, provider_config, user_id, task_id
+        )
+
+        docker_workdir, host_workdir = await asyncio.to_thread(
+            container_service.prepare_chat_tune_workdir,
+            input_data_path, str(session_id), str(turn_id),
+        )
+
+        container_id = await asyncio.to_thread(
+            container_service.start_chat_tune_container,
+            str(session_id), host_workdir,
+        )
+
+        host = container_service.chat_tune_container_host(str(session_id))
+        base_url = f"http://{host}:{settings.CHAT_TUNE_CONTAINER_PORT}"
+
+        client = httpx.AsyncClient(
+            timeout=httpx.Timeout(connect=10.0, read=None, write=30.0, pool=10.0)
+        )
+
+        if not await _wait_chat_tune_ready(
+            client, base_url, settings.CHAT_TUNE_CONTAINER_READY_TIMEOUT
+        ):
+            raise RuntimeError(_t(
+                language, "构建容器启动超时，请重试",
+                "Build container timed out while starting. Please retry.",
+            ))
+
+        body = {
+            "provider_config": container_provider_config,
+            "gathering_context": gathering_context,
+            "user_content": user_content,
+            "allow_build": allow_build,
+            "agent_state": (gathering_context or {}).get("agent_state"),
+            "proposed": proposed,
+        }
+
+        stream_done = False
+        try:
+            async with aconnect_sse(
+                client, "POST", f"{base_url}/agent", json=body
+            ) as event_source:
+                async for sse in event_source.aiter_sse():
+                    if _is_cancelled():
+                        cancelled = True
+                        await asyncio.to_thread(
+                            _persist_assistant_message, assistant_message_id,
+                            ChatTuneTurnStatus.CANCELLED, content_buffer or None, None,
+                        )
+                        await asyncio.to_thread(_maybe_clear_active_turn, session_id, turn_id)
+                        return
+
+                    try:
+                        event = json.loads(sse.data)
+                    except (ValueError, TypeError):
+                        continue
+                    if not isinstance(event, dict):
+                        continue
+
+                    etype = event.get("type")
+                    if etype == "chunk":
+                        chunk = event.get("content", "")
+                        content_buffer += chunk
+                        push_chat_tune_chunk(
+                            session_id, turn_id, {"type": "chunk", "content": chunk}
+                        )
+                    elif etype == "payload":
+                        # Interactive card from the gather phase — either a
+                        # run_needs_gathering question card (ask_choice) or a
+                        # confirm_build card. Forward to the frontend and remember
+                        # it to persist onto the message; proposed is set only on
+                        # the confirm card.
+                        final_payload = event.get("data")
+                        new_proposed = event.get("proposed")
+                        if final_payload is not None:
+                            push_chat_tune_chunk(
+                                session_id, turn_id,
+                                {"type": "payload", "data": final_payload},
+                            )
+                    elif etype == "agent_state":
+                        # Conversation memory snapshot — persisted to
+                        # gathering_context, NOT forwarded to the frontend.
+                        new_agent_state = event.get("state")
+                    elif etype == "build_result":
+                        blueprint_data = event.get("blueprint_data")
+                        await asyncio.to_thread(
+                            _update_session_stage,
+                            session_id,
+                            ChatTuneActiveStage.BUILD,
+                            ChatTuneStageStatus.COMPLETED,
+                            turn_id=turn_id,
+                        )
+                    elif etype == "error":
+                        raise RuntimeError(event.get("error") or _t(
+                            language, "构建容器执行失败",
+                            "Build container execution failed",
+                        ))
+                    elif etype == "done":
+                        stream_done = True
+                        break
+        except httpx.RemoteProtocolError:
+            if not stream_done:
+                raise
+
+        # Sync produced files: the agent wrote the package under
+        # {project_name}/ in the mounted dir. Upload only that subdir and clear
+        # all prior objects under input_data_path, matching _run_ai_build.
+        if (
+            input_data_path
+            and docker_workdir
+            and isinstance(blueprint_data, dict)
+            and blueprint_data.get("built")
+        ):
+            project_name = blueprint_data.get("project_name")
+            if project_name:
+                from pathlib import Path
+
+                from app.core.storage import storage
+
+                data_path = Path(docker_workdir)
+                product_root = data_path / project_name
+                if product_root.is_dir():
+                    existing_keys = await asyncio.to_thread(
+                        storage.list_objects, input_data_path.rstrip("/") + "/"
+                    )
+                    if existing_keys:
+                        await asyncio.to_thread(storage.delete_many, existing_keys)
+
+                    for file_path in product_root.rglob("*"):
+                        if not file_path.is_file():
+                            continue
+                        rel = file_path.relative_to(data_path)
+                        key = f"{input_data_path}/{rel.as_posix()}"
+                        await asyncio.to_thread(storage.upload, key, file_path.read_bytes())
+
+                    new_input_args = await asyncio.to_thread(
+                        _extract_input_args_from_product, product_root
+                    )
+                    await asyncio.to_thread(
+                        _persist_task_input_args, task_id, new_input_args
+                    )
+
+        # Persist gathering_context updates: conversation memory (agent_state),
+        # the confirmed/pending proposal, and the build blueprint when present.
+        updated_ctx = dict(gathering_context or {})
+        ctx_changed = False
+        if new_agent_state is not None:
+            updated_ctx["agent_state"] = new_agent_state
+            ctx_changed = True
+        if new_proposed is not None:
+            updated_ctx["proposed"] = new_proposed
+            ctx_changed = True
+        if blueprint_data is not None:
+            updated_ctx["blueprint_data"] = blueprint_data
+            ctx_changed = True
+        if ctx_changed:
+            await asyncio.to_thread(
+                _persist_session_gathering_context, session_id, updated_ctx
+            )
+
+        # Left-panel stage on a clean turn end. A gather turn that proposes the
+        # plan (confirm_build card) marks GATHERING complete — requirements are
+        # settled, awaiting the user's confirm. A gather turn that only asked a
+        # question stays RUNNING (still gathering). Build-turn completion is
+        # already marked via the build_result event above.
+        if not allow_build:
+            proposing = (
+                isinstance(final_payload, dict)
+                and final_payload.get("stage") == "confirm_build"
+            )
+            await asyncio.to_thread(
+                _update_session_stage,
+                session_id,
+                ChatTuneActiveStage.GATHERING,
+                ChatTuneStageStatus.COMPLETED if proposing else ChatTuneStageStatus.RUNNING,
+                turn_id=turn_id,
+            )
+
+        # Persist the confirm-build card onto the assistant message so it survives
+        # a refresh / replay (matches how chat_tune persists its payload).
+        await asyncio.to_thread(
+            _persist_assistant_message, assistant_message_id,
+            status=ChatTuneTurnStatus.COMPLETED, content=content_buffer,
+            payload=final_payload,
+        )
+        await asyncio.to_thread(_maybe_clear_active_turn, session_id, turn_id)
+        push_chat_tune_chunk(session_id, turn_id, {"type": "done"})
+
+    except Exception as exc:
+        if cancelled:
+            return
+        if _is_cancelled():
+            cancelled = True
+            await asyncio.to_thread(
+                _persist_assistant_message, assistant_message_id,
+                ChatTuneTurnStatus.CANCELLED, content_buffer or None, None,
+            )
+            await asyncio.to_thread(_maybe_clear_active_turn, session_id, turn_id)
+            return
+
+        error_msg = _safe_error_message(exc)
+        logger.exception("AI agent build failed: session_id=%s, turn_id=%s", session_id, turn_id)
+
+        await asyncio.to_thread(
+            _update_session_stage,
+            session_id, phase_stage, ChatTuneStageStatus.FAILED,
+            turn_id=turn_id,
+        )
+
+        await asyncio.to_thread(
+            _persist_assistant_message, assistant_message_id,
+            status=ChatTuneTurnStatus.FAILED, content=content_buffer or None,
+            payload=None, error=error_msg,
+        )
+        await asyncio.to_thread(_maybe_clear_active_turn, session_id, turn_id)
+        push_chat_tune_chunk(session_id, turn_id, {"type": "error", "error": error_msg})
+
+    finally:
+        # NOTE: do NOT call revoke_task_tokens(task_id) here — proxy tokens are
+        # keyed by task_id and an evolution run for the SAME task issues its own
+        # token; a broad revoke would nuke it. The agent-build token is issued
+        # with a short bounded TTL (_AGENT_BUILD_TOKEN_TTL) and self-expires,
+        # matching how _run_ai_build relies on TTL rather than explicit revoke.
         if client is not None:
             await client.aclose()
         if container_id is not None:

--- a/src/backend/app/tasks/chat_tune_runner.py
+++ b/src/backend/app/tasks/chat_tune_runner.py
@@ -65,6 +65,18 @@ class ReviewRequest(BaseModel):
     gathering_context: dict[str, Any] | None = None
 
 
+class AgentBuildRequest(BaseModel):
+    """``POST /agent`` 请求体（AI 构建 beta）。"""
+
+    provider_config: dict[str, Any]
+    gathering_context: dict[str, Any] | None = None
+    user_content: str = ""
+    allow_build: bool = False
+    agent_state: dict[str, Any] | None = None
+    proposed: dict[str, Any] | None = None
+    max_iters: int = 40
+
+
 def _resolve_within_sandbox(base: Path, path: str) -> Path | None:
     """Resolve a user-supplied path against the sandbox root.
 
@@ -579,6 +591,42 @@ async def review(req: ReviewRequest) -> StreamingResponse:
     """执行一轮 review 对话并以 SSE 流返回事件。"""
     return StreamingResponse(
         _review_event_stream(req),
+        media_type="text/event-stream",
+        headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
+    )
+
+
+# ---- AI build (beta): AgentScope single-agent route ----
+# Defined here (rather than imported from app.tasks.agent_build_runner) so the
+# task-runner image — which only copies chat_tune_runner.py from app/tasks and
+# relies on the core llm4ad.agent package — has the /agent route without needing
+# the backend-only wrapper module. Also avoids a chat_tune_runner <-> wrapper
+# import cycle.
+
+
+async def _agent_event_stream(req: AgentBuildRequest) -> AsyncIterator[str]:
+    """Run the core agent build for this request and encode events as SSE frames."""
+    from llm4ad.agent.runner import AgentBuildConfig, run_agent_build
+
+    config = AgentBuildConfig(
+        provider_config=req.provider_config,
+        base_dir=DATA_DIR,
+        user_content=req.user_content,
+        gathering_context=req.gathering_context,
+        allow_build=req.allow_build,
+        prior_state=req.agent_state,
+        proposed=req.proposed,
+        max_iters=req.max_iters,
+    )
+    async for event in run_agent_build(config):
+        yield _sse(event)
+
+
+@app.post("/agent")
+async def agent_build(req: AgentBuildRequest) -> StreamingResponse:
+    """执行 AI 构建 (beta) 的 AgentScope agent 并以 SSE 流返回事件。"""
+    return StreamingResponse(
+        _agent_event_stream(req),
         media_type="text/event-stream",
         headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
     )

--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -30,6 +30,11 @@ dependencies = [
     "paramiko>=4.0.0",
     "nest-asyncio>=1.6.0",
     "qrcode[pil]>=8.0",
+    # AI build (beta): AgentScope core powers the single ReAct agent that runs
+    # inside the task-runner container. Core package only — never install
+    # agentscope-runtime, whose sandbox spins up its own Docker containers
+    # (container-in-container) since the agent already runs in an isolated container.
+    "agentscope>=2.0,<3.0",
 ]
 
 [tool.uv]

--- a/src/backend/uv.lock
+++ b/src/backend/uv.lock
@@ -29,6 +29,41 @@ wheels = [
 ]
 
 [[package]]
+name = "agentscope"
+version = "2.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiofiles" },
+    { name = "aioitertools" },
+    { name = "anthropic" },
+    { name = "dashscope" },
+    { name = "docstring-parser" },
+    { name = "filetype" },
+    { name = "httpx" },
+    { name = "jinja2" },
+    { name = "json-repair" },
+    { name = "json5" },
+    { name = "jsonschema" },
+    { name = "mcp" },
+    { name = "numpy" },
+    { name = "openai" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp" },
+    { name = "opentelemetry-sdk" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "python-datauri" },
+    { name = "python-frontmatter" },
+    { name = "python-socketio" },
+    { name = "shortuuid" },
+    { name = "tree-sitter" },
+    { name = "tree-sitter-bash" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/97/12/4ed72815f9bb06fd869eaf3c22765421ec263364ca52efc506fcad5cc997/agentscope-2.0.3.tar.gz", hash = "sha256:6359380e2dd0995a025d824468c4ab1b0464f92077d38333b561ab635c2956ce", size = 521636, upload-time = "2026-06-29T02:09:14.13Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/0b/9698adbd8b0887e8ce2162a356dc1be8f9f4d090be5255234ed8a2550edd/agentscope-2.0.3-py3-none-any.whl", hash = "sha256:070cc4cec54aa0fb0fc66afaaa41cde2c04b18af6c3755a075c4bc7853ab9766", size = 697856, upload-time = "2026-06-29T02:09:12.366Z" },
+]
+
+[[package]]
 name = "aiofiles"
 version = "25.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -129,6 +164,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/78/b7/15fb7a9d52e112a25b621c67b69c167805cb1f2ab8f1708a5c490d1b52fe/aiohttp-3.13.5-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:3b13560160d07e047a93f23aaa30718606493036253d5430887514715b67c9d9", size = 1772072, upload-time = "2026-03-31T22:00:07.494Z" },
     { url = "https://files.pythonhosted.org/packages/7e/df/57ba7f0c4a553fc2bd8b6321df236870ec6fd64a2a473a8a13d4f733214e/aiohttp-3.13.5-cp314-cp314t-win32.whl", hash = "sha256:9a0f4474b6ea6818b41f82172d799e4b3d29e22c2c520ce4357856fced9af2f8", size = 471819, upload-time = "2026-03-31T22:00:10.277Z" },
     { url = "https://files.pythonhosted.org/packages/62/29/2f8418269e46454a26171bfdd6a055d74febf32234e474930f2f60a17145/aiohttp-3.13.5-cp314-cp314t-win_amd64.whl", hash = "sha256:18a2f6c1182c51baa1d28d68fea51513cb2a76612f038853c0ad3c145423d3d9", size = 505441, upload-time = "2026-03-31T22:00:12.791Z" },
+]
+
+[[package]]
+name = "aioitertools"
+version = "0.13.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fd/3c/53c4a17a05fb9ea2313ee1777ff53f5e001aefd5cc85aa2f4c2d982e1e38/aioitertools-0.13.0.tar.gz", hash = "sha256:620bd241acc0bbb9ec819f1ab215866871b4bbd1f73836a55f799200ee86950c", size = 19322, upload-time = "2025-11-06T22:17:07.609Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/a1/510b0a7fadc6f43a6ce50152e69dbd86415240835868bb0bd9b5b88b1e06/aioitertools-0.13.0-py3-none-any.whl", hash = "sha256:0be0292b856f08dfac90e31f4739432f4cb6d7520ab9eb73e143f4f2fa5259be", size = 24182, upload-time = "2025-11-06T22:17:06.502Z" },
 ]
 
 [[package]]
@@ -238,6 +282,7 @@ name = "app"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
+    { name = "agentscope" },
     { name = "alembic" },
     { name = "boto3" },
     { name = "celery", extra = ["redis"] },
@@ -266,6 +311,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
+    { name = "agentscope", specifier = ">=2.0,<3.0" },
     { name = "alembic", specifier = ">=1.12.1,<2.0.0" },
     { name = "boto3", specifier = ">=1.42.85" },
     { name = "celery", extras = ["redis"], specifier = ">=5.6.3" },
@@ -483,6 +529,15 @@ wheels = [
 ]
 
 [[package]]
+name = "bidict"
+version = "0.23.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/6e/026678aa5a830e07cd9498a05d3e7e650a4f56a42f267a53d22bcda1bdc9/bidict-0.23.1.tar.gz", hash = "sha256:03069d763bc387bbd20e7d49914e75fc4132a41937fa3405417e1a5a2d006d71", size = 29093, upload-time = "2024-02-18T19:09:05.748Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/99/37/e8730c3587a65eb5645d4aba2d27aae48e8003614d6aaf15dda67f702f1f/bidict-0.23.1-py3-none-any.whl", hash = "sha256:5dae8d4d79b552a71cbabc7deb25dfe8ce710b17ff41711e13010ead2abfc3e5", size = 32764, upload-time = "2024-02-18T19:09:04.156Z" },
+]
+
+[[package]]
 name = "billiard"
 version = "4.2.4"
 source = { registry = "https://pypi.org/simple" }
@@ -572,6 +627,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/e2/c8/3ed795c0e920b461eec500798d2247ac3ba38cf20bb6497c28a9891ee9a2/Box2D-2.3.10-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:a09ded6f5a4b55f0188af2ad63a6f7d60adc7154671e9f32cef4a0cabf5ed542", size = 4419706, upload-time = "2024-11-29T18:04:28.446Z" },
     { url = "https://files.pythonhosted.org/packages/5c/2e/8b95f2779467c9af0ee62105f105a96e1b5a1380dbf5c546a09af5c51d4e/Box2D-2.3.10-cp313-cp313-win32.whl", hash = "sha256:6d4b0bd0e118e0449eadbadc6cf4617b1dbf72b411fbdccab4921108b3c2b768", size = 1193206, upload-time = "2024-11-29T18:05:01.167Z" },
     { url = "https://files.pythonhosted.org/packages/8d/90/230643c42763a1f5eb0554fbb6729befe6730f6dd9a9e4ec61cd470b94be/Box2D-2.3.10-cp313-cp313-win_amd64.whl", hash = "sha256:49f9d3d0d5956d360e25cd9733a29a3f0018297a3b554a401f19ed2c9499a507", size = 1312703, upload-time = "2024-11-29T18:05:45.749Z" },
+]
+
+[[package]]
+name = "cached-property"
+version = "2.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/76/4b/3d870836119dbe9a5e3c9a61af8cc1a8b69d75aea564572e385882d5aefb/cached_property-2.0.1.tar.gz", hash = "sha256:484d617105e3ee0e4f1f58725e72a8ef9e93deee462222dbd51cd91230897641", size = 10574, upload-time = "2024-10-25T15:43:55.667Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/11/0e/7d8225aab3bc1a0f5811f8e1b557aa034ac04bdf641925b30d3caf586b28/cached_property-2.0.1-py3-none-any.whl", hash = "sha256:f617d70ab1100b7bcf6e42228f9ddcb78c676ffa167278d9f730d1c2fba69ccb", size = 7428, upload-time = "2024-10-25T15:43:54.711Z" },
 ]
 
 [[package]]
@@ -1129,6 +1193,24 @@ wheels = [
 ]
 
 [[package]]
+name = "dashscope"
+version = "1.26.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp" },
+    { name = "certifi" },
+    { name = "cryptography" },
+    { name = "requests" },
+    { name = "rich" },
+    { name = "typer" },
+    { name = "websocket-client" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2b/b6/17b6b08ceb08f9ec2102db5a9c0afe0b5d61b63a972a4615c50252669c1e/dashscope-1.26.0.tar.gz", hash = "sha256:2c806c6e735a47f1f31814e700f5cc073cd101a860302562bd8eaa210bdef991", size = 1390453, upload-time = "2026-06-25T10:46:52.74Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fc/ec/6895fb7b8977014f8e0a009a5298ab4e6a31f06aaa07373890fee84348a3/dashscope-1.26.0-py3-none-any.whl", hash = "sha256:ddfbda55a0196ec4c1a3cfc6be610b53310dfdb95ed4a293f6cc699809500ba4", size = 1481554, upload-time = "2026-06-25T10:46:51.037Z" },
+]
+
+[[package]]
 name = "deprecated"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1273,6 +1355,15 @@ wheels = [
 [package.optional-dependencies]
 standard = [
     { name = "uvicorn", extra = ["standard"] },
+]
+
+[[package]]
+name = "filetype"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bb/29/745f7d30d47fe0f251d3ad3dc2978a23141917661998763bebb6da007eb1/filetype-1.2.0.tar.gz", hash = "sha256:66b56cd6474bf41d8c54660347d37afcc3f7d1970648de365c102ef77548aadb", size = 998020, upload-time = "2022-11-02T17:34:04.141Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/79/1b8fa1bb3568781e84c9200f951c735f3f157429f44be0495da55894d620/filetype-1.2.0-py2.py3-none-any.whl", hash = "sha256:7ce71b6880181241cf7ac8697a2f1eb6a8bd9b429f7ad6d27b8db9ba5f1c2d25", size = 19970, upload-time = "2022-11-02T17:34:01.425Z" },
 ]
 
 [[package]]
@@ -1496,6 +1587,18 @@ wheels = [
 ]
 
 [[package]]
+name = "googleapis-common-protos"
+version = "1.75.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b5/c8/f439cffde755cffa462bfbb156278fa6f9d09119719af9814b858fd4f81f/googleapis_common_protos-1.75.0.tar.gz", hash = "sha256:53a062ff3c32552fbd62c11fe23768b78e4ddf0494d5e5fd97d3f4689c75fbbd", size = 151035, upload-time = "2026-05-07T08:04:49.423Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/c8/e2645aa8ed02fd4c7a2f59d68783b65b1f3cbdfe39a6308e156509d1fee8/googleapis_common_protos-1.75.0-py3-none-any.whl", hash = "sha256:961ed60399c457ceb0ee8f285a84c870aabc9c6a832b9d37bb281b5bebde43ed", size = 300631, upload-time = "2026-05-07T08:03:30.345Z" },
+]
+
+[[package]]
 name = "graphemeu"
 version = "0.7.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1558,6 +1661,47 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/9d/82/74f4a3310cdabfbb10da554c3a672847f1ed33c6f61dd472681ce7f1fe67/griffelib-2.0.2.tar.gz", hash = "sha256:3cf20b3bc470e83763ffbf236e0076b1211bac1bc67de13daf494640f2de707e", size = 166461, upload-time = "2026-03-27T11:34:51.091Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/11/8c/c9138d881c79aa0ea9ed83cbd58d5ca75624378b38cee225dcf5c42cc91f/griffelib-2.0.2-py3-none-any.whl", hash = "sha256:925c857658fb1ba40c0772c37acbc2ab650bd794d9c1b9726922e36ea4117ea1", size = 142357, upload-time = "2026-03-27T11:34:46.275Z" },
+]
+
+[[package]]
+name = "grpcio"
+version = "1.81.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b0/b5/1ff353970a87eda4c98251e34d2dfd214abd4982dc89119c9252a2a482d2/grpcio-1.81.1.tar.gz", hash = "sha256:6fa10a767143a5e82e8eaab53918af0cd8909a57a27f8cb2288b80a613ac671b", size = 13026582, upload-time = "2026-06-11T12:46:51.673Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/85/07/9a979c81738863a738dc23d65177056e71fbb2db817740ed870b33434e7a/grpcio-1.81.1-cp312-cp312-linux_armv7l.whl", hash = "sha256:8b39472beafc0bdcafc4c8c73ad082ebfdb449d566897a61e7acb4fa88089115", size = 6053264, upload-time = "2026-06-11T12:45:21.017Z" },
+    { url = "https://files.pythonhosted.org/packages/75/95/539706ca0d3bd40dbad583dc56fd883da941f37556b629132da5762781b9/grpcio-1.81.1-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:12b7524c88d4026d3dcb7b0ebe16b6714f3b4af402ddd0f0639ab064a00c87c3", size = 12052560, upload-time = "2026-06-11T12:45:23.652Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/44/f257b7e0bd69c93b06c6cb8ac8d1b901ccb42bedabd83c1a4c77a71f8810/grpcio-1.81.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:1e123f9b37edb8375fd74130d1f69c944bbf0a7b06761ae7211154b8759e94d2", size = 6595983, upload-time = "2026-06-11T12:45:26.963Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/f3/19782aa04c960968bef8c5539329d8e3bbc3364e2e46d19eb5e5cc5e43b7/grpcio-1.81.1-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:2c2e2ae6867c2966b8daccc836d54a13218e0007e9a490aeb81dd05be64d22d7", size = 7303455, upload-time = "2026-06-11T12:45:29.707Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/8c/dea020b6d91508cd84463917a63149ec196ee7db505d032ae43fcb3303b9/grpcio-1.81.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:766bc7c9a9c340342f4c864ccbda8e78111e4751f13b895812b9c148fb79e9d0", size = 6809167, upload-time = "2026-06-11T12:45:32.52Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/c7/3030dd940408083bd32cd95d634777a71605ade4887154d93e8a89244946/grpcio-1.81.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:b259a04a737cb3496be0901328eb8b7552ed8df4865d8c8f1cf1bffcfc0776a3", size = 7412536, upload-time = "2026-06-11T12:45:35.403Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/dd/1172a9e42b168edcafefad6115346ef619a3fc02158bb170e66ced24bcdd/grpcio-1.81.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:85b10a45b8993d195c4f3ff57025b8d1e11834909ee475c403bfa60cb4caefaf", size = 8408276, upload-time = "2026-06-11T12:45:37.78Z" },
+    { url = "https://files.pythonhosted.org/packages/25/7a/71437c7f3596e5246155c515852795a85a1a8d228190212432b13b97a95d/grpcio-1.81.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:8ea1936c26b99999b27479853039a7f34713f56c49375ad52b38535ec93a796c", size = 7849660, upload-time = "2026-06-11T12:45:40.627Z" },
+    { url = "https://files.pythonhosted.org/packages/65/40/7debc0da45d2efebafb82da75644be347497fe4ee250514b8cd3b86ae8bf/grpcio-1.81.1-cp312-cp312-win32.whl", hash = "sha256:a185a04039df6cae8648bc8ab6d6fde7bf94f7188ecf7828e76ac52eef1e41d6", size = 4185819, upload-time = "2026-06-11T12:45:43.027Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/b9/8fe3ba5ed462067774ebc1f9c7f26aa7ebcc280ddd476be107153de1339e/grpcio-1.81.1-cp312-cp312-win_amd64.whl", hash = "sha256:3ad74f8bb1a18963914c5452d289422830b39459e8776ebbcd207be1fbfb1d94", size = 4930461, upload-time = "2026-06-11T12:45:45.775Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/42/dcc2e4b600538ef18327c0839d56b7d3c3812337c5d710df5877dbb39b1e/grpcio-1.81.1-cp313-cp313-linux_armv7l.whl", hash = "sha256:b10e1ff4756ed27d5a29d7fc79cfce7ef1ff56ad20025b89bac7cf79e09abbbe", size = 6054466, upload-time = "2026-06-11T12:45:48.43Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/4a/a36e03210183a8a7d4c80c3936acee679f4bd77d5861f369db47b2cc5f05/grpcio-1.81.1-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:819edbdcb42ab8598b494bcf0222684bbb7a3c772bd1b1f0be7e029a6063c28e", size = 12048795, upload-time = "2026-06-11T12:45:54.011Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/d5/d68e30b29098f63beab6fe501100fe82674ff142b32c672532da86a99b3a/grpcio-1.81.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:c5bf2dc311127d91230cc79b92188c082634a06cf66c5234db49a43b910183b0", size = 6599094, upload-time = "2026-06-11T12:45:57.799Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/b3/e837954d279754f638a11cca5dcf6b24a005efb398984cefaf7735945a54/grpcio-1.81.1-cp313-cp313-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:e8ca6a1fcdb2943c9cbc1804a1baf3acb6071d72a471591678ded84218006e14", size = 7307182, upload-time = "2026-06-11T12:46:00.568Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/1e/b47957057e729adc6cdf519a47f8be2562b7140e280f1418443eb4022192/grpcio-1.81.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e64dd101d380a115cc5a0c7856788adb535f1a4e21fc543775602f8be95180ae", size = 6810962, upload-time = "2026-06-11T12:46:03.312Z" },
+    { url = "https://files.pythonhosted.org/packages/40/26/569868e364e05b19ec8f969da53d230bcd89c962cd198f7c29943155c4d3/grpcio-1.81.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:98a07f9bf591e3a8919797bee1c53f026ba4acd587e5a4404c8e57c9ec36b2a5", size = 7415698, upload-time = "2026-06-11T12:46:06.005Z" },
+    { url = "https://files.pythonhosted.org/packages/36/0c/5440a0582cb5653fc42a6e262eeb22700943313f8076f9dc927491b20a59/grpcio-1.81.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:c261d74b1a945cf895a9d6eccd1685a8e837531beaab782da4d630a8d12deffb", size = 8407779, upload-time = "2026-06-11T12:46:08.84Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/aa/66fe9f39871d766987d869a03ee0842a026f499c7b1e62decb9e78a8088e/grpcio-1.81.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:58ad1131c300d3c9b933802b3cc4dc69d380822935ba50b28703156ea826fbf7", size = 7844521, upload-time = "2026-06-11T12:46:12.171Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/9e/69bb7194861bcd28fb3193261d4f9c3831b4446993f002cf59068943e7ab/grpcio-1.81.1-cp313-cp313-win32.whl", hash = "sha256:78e29211f26da2fdd0e9c6d2b79f489476140cf7029b6a64808ade7ca4156a42", size = 4182786, upload-time = "2026-06-11T12:46:15.192Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/20/3da8bb0d637feccdc3e1e419bb511ce93651ce7d54164f95de22cc0b8b34/grpcio-1.81.1-cp313-cp313-win_amd64.whl", hash = "sha256:edb59506291b647a30884b1d51a599d605f40b20af4a7dc3d33786a47a31de60", size = 4928648, upload-time = "2026-06-11T12:46:17.823Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/58/19414622b1bf6981bc9c05a365bd548e71876c89000083b3af489251e9c0/grpcio-1.81.1-cp314-cp314-linux_armv7l.whl", hash = "sha256:506f48f2f9c29b143fca3dad7b0d518c188b6c9648c75a2ae6e2d9f2c13a060b", size = 6055336, upload-time = "2026-06-11T12:46:20.557Z" },
+    { url = "https://files.pythonhosted.org/packages/32/f1/2ec88adb92b0eba970dd0e0e7dd086341daa3c75eba4f735f9e44bf684b0/grpcio-1.81.1-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:d865db4a6318e1c1bea83292e0ed231090538fc4ca45425b0f0480eb338bbc6e", size = 12056279, upload-time = "2026-06-11T12:46:24.255Z" },
+    { url = "https://files.pythonhosted.org/packages/41/36/e8c5f8c6ec71de73733695ebc809e98b178b534ec6d8eaa31a7ebab4ad4c/grpcio-1.81.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:e2aa72e3ce1770317ef534f63d397b55e130725f5149bd36077c3b539019db27", size = 6608225, upload-time = "2026-06-11T12:46:27.601Z" },
+    { url = "https://files.pythonhosted.org/packages/30/22/96fc577a845ab093326d9ab1adb874bd4936c8cf98ac8ed2f3db13a0a2fb/grpcio-1.81.1-cp314-cp314-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:0490c30c261eded63f3f354979f9dc4502a9fb944cccb60cd9dc85f5a7349854", size = 7306576, upload-time = "2026-06-11T12:46:30.514Z" },
+    { url = "https://files.pythonhosted.org/packages/76/7b/61dab5d5969f28d97fb1009cead1df0a5cd987d3315e1b37f18a4449f8bc/grpcio-1.81.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:410482da976329fe5f4067270401b12cf2bd552ff8020f054ecfaddb5475f9d6", size = 6812165, upload-time = "2026-06-11T12:46:33.699Z" },
+    { url = "https://files.pythonhosted.org/packages/82/78/6e501929d4f5f96462fd82fd9f0f06e5f9612207582b862868d68757b27d/grpcio-1.81.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e3657301562ac3cb8018d30d0d3ebfa39932239f7b5703422057ef14b69949f5", size = 7422962, upload-time = "2026-06-11T12:46:36.511Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/7e/f2157589e66daa78ebb3165942d05a08bdea93b9d11c2bc1e172aef89685/grpcio-1.81.1-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:24c8e57504c8f45b237e40b99262d181071e5099a07053695b75d97bb53053a0", size = 8408176, upload-time = "2026-06-11T12:46:39.803Z" },
+    { url = "https://files.pythonhosted.org/packages/da/df/c6717fef716e00d235ffb96123baf6dce76d6004f6233fa767c502861460/grpcio-1.81.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:b427c19380991a4eaab2f6144b64b99b412043314c6bf4ab544f97bb31ee4190", size = 7846681, upload-time = "2026-06-11T12:46:43.013Z" },
+    { url = "https://files.pythonhosted.org/packages/36/84/3502e9f210a6a5c4438c8aca3f88edd2e04f6a27f3d41b26cf0a0024b096/grpcio-1.81.1-cp314-cp314-win32.whl", hash = "sha256:61233fe8951e5c85dff81c2458b6528624760166946b5b47ea150a589168411f", size = 4264615, upload-time = "2026-06-11T12:46:45.741Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/b0/4af731ff7492c68a96e4c71bfd0f4590acde92b31c6fe4894e6465c10ff6/grpcio-1.81.1-cp314-cp314-win_amd64.whl", hash = "sha256:3768a5ff1b2125e6f552e561b6b2dca0e64982d8949689b4df145cf8b98d7821", size = 5070275, upload-time = "2026-06-11T12:46:48.486Z" },
 ]
 
 [[package]]
@@ -1830,6 +1974,24 @@ name = "jsmin"
 version = "3.0.1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/5e/73/e01e4c5e11ad0494f4407a3f623ad4d87714909f50b17a06ed121034ff6e/jsmin-3.0.1.tar.gz", hash = "sha256:c0959a121ef94542e807a674142606f7e90214a2b3d1eb17300244bbb5cc2bfc", size = 13925, upload-time = "2022-01-16T20:35:59.13Z" }
+
+[[package]]
+name = "json-repair"
+version = "0.61.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/59/c0/1cb689126eacd166fd5a78370f095c7d3a250808dabeda129300e5280110/json_repair-0.61.0.tar.gz", hash = "sha256:48759cc6c3052814c797d1d56787d9e1d451603a8760a55d619e97d2f49353d6", size = 50055, upload-time = "2026-06-16T12:18:33.32Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e2/b9/e996902245d5e12e55b0b2e667d3e83a4636dec3692e405e5b8ea0868263/json_repair-0.61.0-py3-none-any.whl", hash = "sha256:ee9fe5f95fcb2713d72d4495b67b794b62ff2cd24d6dba3bfb3173d9f7ab0f7d", size = 48490, upload-time = "2026-06-16T12:18:31.883Z" },
+]
+
+[[package]]
+name = "json5"
+version = "0.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/7d/05c46a96a78147ae3bf99c2f4169ce144a70220b8d6fcd56f6ec368b8ce9/json5-0.15.0.tar.gz", hash = "sha256:7424d1f1eb1d56da6e3d70643f53619862b4ce81440bdb8ecfd6f875e5ba4a71", size = 53278, upload-time = "2026-06-19T20:08:27.716Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/eb/be/59527c99478aade6bb33a68d72e6e18dd4e6ff6eacfc7d01bdb15bc76912/json5-0.15.0-py3-none-any.whl", hash = "sha256:56636a30c0e8a4665fe2179c0212f32eae3796dea89ea6f649b9436ecdb39618", size = 36570, upload-time = "2026-06-19T20:08:26.748Z" },
+]
 
 [[package]]
 name = "jsonschema"
@@ -2897,6 +3059,118 @@ wheels = [
 ]
 
 [[package]]
+name = "opentelemetry-api"
+version = "1.43.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ae/cc/e4c9584181f86494df0f6bdec1a4f3280c50db44704dc2a407e994fc87bb/opentelemetry_api-1.43.0.tar.gz", hash = "sha256:107d0d03857ea8fc7c5fcbbbd83f800c281f0d560553d61c1d675fccfd1761c1", size = 73476, upload-time = "2026-06-24T15:19:55.323Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/17/83/6dba32b85f31868400440dc7ad2ca1eab94cbbf3a7b0459ed39f8311a9e2/opentelemetry_api-1.43.0-py3-none-any.whl", hash = "sha256:20acf45e9b21851926835292e4045d290acade1edd2ff3de86d2f069687ba1fd", size = 61912, upload-time = "2026-06-24T15:19:35.434Z" },
+]
+
+[[package]]
+name = "opentelemetry-exporter-otlp"
+version = "1.43.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-exporter-otlp-proto-grpc" },
+    { name = "opentelemetry-exporter-otlp-proto-http" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ee/47/b77366bcbe719373a8cac2b4e8ad01f8ff3c9f2c223374d77ece280aae6f/opentelemetry_exporter_otlp-1.43.0.tar.gz", hash = "sha256:65aded6c50ee7dd2b9948c9d0e59ddb4ed4eea6e8532fba95cbe6a4a64a566ba", size = 6086, upload-time = "2026-06-24T15:19:58.003Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d9/26/d28cc854d2eb779f91351216c51ed0d54886f89f2dd56db9d493ba9fd429/opentelemetry_exporter_otlp-1.43.0-py3-none-any.whl", hash = "sha256:70f3fe740a64596d4157588a2ee7e4fd37d2acc0c0f522a2882b8c29316cd0f0", size = 6726, upload-time = "2026-06-24T15:19:38.437Z" },
+]
+
+[[package]]
+name = "opentelemetry-exporter-otlp-proto-common"
+version = "1.43.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-proto" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/c1/e8098490ab15abf116dcaf9fa89ededcb35547c7d08d4b5a62f573dc1e63/opentelemetry_exporter_otlp_proto_common-1.43.0.tar.gz", hash = "sha256:c4e32ba6d6b13bdb2b8f6764c4fd28d00192826561aa04f6d14eedfce7ac076f", size = 20197, upload-time = "2026-06-24T15:20:00.247Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d0/b2/41ebc74ae1d5859901f1b69305de58724bf043381103d6ef413521cbc35a/opentelemetry_exporter_otlp_proto_common-1.43.0-py3-none-any.whl", hash = "sha256:123c3f9cc87218562490c63b36f497bf3a722faf174a515d1443f31ababa6264", size = 17048, upload-time = "2026-06-24T15:19:41.264Z" },
+]
+
+[[package]]
+name = "opentelemetry-exporter-otlp-proto-grpc"
+version = "1.43.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "googleapis-common-protos" },
+    { name = "grpcio" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-common" },
+    { name = "opentelemetry-proto" },
+    { name = "opentelemetry-sdk" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e2/1d/6336453716ca0a240d4417d19e6d5b77a5e7163e5670ec4f7ec4d3ede7bf/opentelemetry_exporter_otlp_proto_grpc-1.43.0.tar.gz", hash = "sha256:1b3e0627daa9bc21884d4a13946807c255eb558bfe5bdd543dffb6f4c9faee0d", size = 27213, upload-time = "2026-06-24T15:20:00.907Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6d/74/2700b5d5c946bf2dba87073fce3dfc198c46bc92ea3d5693f54bc51c90b1/opentelemetry_exporter_otlp_proto_grpc-1.43.0-py3-none-any.whl", hash = "sha256:6a10d1feacffffda19acacbf277b736094b1e2f4dbb98c90ccb2c6e1962e2ec6", size = 19626, upload-time = "2026-06-24T15:19:42.233Z" },
+]
+
+[[package]]
+name = "opentelemetry-exporter-otlp-proto-http"
+version = "1.43.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "googleapis-common-protos" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-common" },
+    { name = "opentelemetry-proto" },
+    { name = "opentelemetry-sdk" },
+    { name = "requests" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fc/92/0b9f56412483a8891d4843890294796c9df8ab42417bd9bad8035d840cb3/opentelemetry_exporter_otlp_proto_http-1.43.0.tar.gz", hash = "sha256:fa8a42bb7d00ee5391f4c0b04d8e6a46c03caa437903296ab73a81dc11ba118f", size = 25406, upload-time = "2026-06-24T15:20:01.515Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/20/b685ed7af2e17c29ffc8af56f1fa8bc2033258fc30fb0d2b722f49d13ba0/opentelemetry_exporter_otlp_proto_http-1.43.0-py3-none-any.whl", hash = "sha256:647f603aa8efdbdb4dbff842e0729d0406a6fff26b295a72d3d60e7d963b2610", size = 21795, upload-time = "2026-06-24T15:19:43.164Z" },
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "1.43.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e0/b9/d357faefb40bda1d4799913e6af611171ff22a2dedcb93576bc92242d056/opentelemetry_proto-1.43.0.tar.gz", hash = "sha256:224778df17e1f3fafeaaa21d874236ca5f6ffc2f86e0899298ec7351aac27924", size = 46481, upload-time = "2026-06-24T15:20:07.625Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ed/a7/3e5308cf548b8f72529c7db1afdb3a404211982376a12927fd7759f77bf3/opentelemetry_proto-1.43.0-py3-none-any.whl", hash = "sha256:c58f1f7ef84bc7dc2834016c0c37fe0081dde7ca9f6339be1970fbf9cdaaa90d", size = 72489, upload-time = "2026-06-24T15:19:51.164Z" },
+]
+
+[[package]]
+name = "opentelemetry-sdk"
+version = "1.43.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3e/eb/5041074274ac0956b03637cc039d434569112468e875eddfcc9a0674ce06/opentelemetry_sdk-1.43.0.tar.gz", hash = "sha256:d8187c81c162df9913e4003dd6485f7390d9a24fc17026ec7387b8b8218b08e9", size = 254744, upload-time = "2026-06-24T15:20:08.467Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/e3/b17be23af124201c9f52eececd4cc8ddfed1597d37b4ee771895d325805c/opentelemetry_sdk-1.43.0-py3-none-any.whl", hash = "sha256:d1323a547c1ce69d6a069a17a44b7da82bb8b332051ecb074041f87642c86823", size = 178852, upload-time = "2026-06-24T15:19:52.169Z" },
+]
+
+[[package]]
+name = "opentelemetry-semantic-conventions"
+version = "0.64b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5a/30/5f26df29509eccd86b99b481ac9ffa39da49ba9577cc69071c552ae30447/opentelemetry_semantic_conventions-0.64b0.tar.gz", hash = "sha256:72f76fb2d1582d9d033dd1fcd84532e961e6ff3d90d24ba6fabc72975a83864c", size = 148340, upload-time = "2026-06-24T15:20:09.267Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f2/ca/23ba87a221b574a7c5a99d48849d80bfe8b047624681357e2b002e566187/opentelemetry_semantic_conventions-0.64b0-py3-none-any.whl", hash = "sha256:ea77e85e354b8f604ddbe5f3d9135216f982fa4d77e5859ac30f6d8a50505aa6", size = 203713, upload-time = "2026-06-24T15:19:53.339Z" },
+]
+
+[[package]]
 name = "packaging"
 version = "26.2"
 source = { registry = "https://pypi.org/simple" }
@@ -3278,6 +3552,21 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/88/fb/46dad6c0ae49ed230ab1b16c890c2b6314e2403e6c412976f4a72d64a527/propcache-0.5.2-cp314-cp314t-win_amd64.whl", hash = "sha256:d447bb0b3054be5818458fbb171208b1d9ff11eba14e18ca18b90cbb45767370", size = 47764, upload-time = "2026-05-08T21:02:07.353Z" },
     { url = "https://files.pythonhosted.org/packages/e7/c4/a47d0a63aa309d10d59ede6e9d4cff03a344a79d1f0f4cd0cd74997b53e0/propcache-0.5.2-cp314-cp314t-win_arm64.whl", hash = "sha256:fe67a3d11cd9b4efabfa45c3d00ffba2b26811442a73a581a94b67c2b5faccf6", size = 41140, upload-time = "2026-05-08T21:02:09.065Z" },
     { url = "https://files.pythonhosted.org/packages/3a/ed/1cdcab6ba3d6ab7feca11fc14f0eeea80755bb53ef4e892079f31b10a25f/propcache-0.5.2-py3-none-any.whl", hash = "sha256:be1ddfcbb376e3de5d2e2db1d58d6d67463e6b4f9f040c000de8e300295465fe", size = 14036, upload-time = "2026-05-08T21:02:10.673Z" },
+]
+
+[[package]]
+name = "protobuf"
+version = "7.35.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/da/01/9ef0afd7999eb9badb3a768b4aedd78c86d4c65cfaf1958ab276199e76b4/protobuf-7.35.1.tar.gz", hash = "sha256:ce115a26fe0c39a2c29973d914d327e516a6455464489fe3cd1e51a1b354f81a", size = 458717, upload-time = "2026-06-11T21:55:40.257Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/03/8aeeb7458d22546bf64b5250ca1daeb5ff757d900e8e4a7476c6f0db843e/protobuf-7.35.1-cp310-abi3-macosx_10_9_universal2.whl", hash = "sha256:24f857477359a85c0c235261b8ba905fd51b2562f4a64ca1df5473f29850cbf6", size = 433226, upload-time = "2026-06-11T21:55:31.719Z" },
+    { url = "https://files.pythonhosted.org/packages/37/4b/dfb89eb0e652a1ff073c39a59fb5e3a83cfe9b57a2c83fa6d78270101767/protobuf-7.35.1-cp310-abi3-manylinux2014_aarch64.whl", hash = "sha256:11d6b0ec246892d85215b0a13ca6e0233cf5284b68f0ac02646427f4ff88a799", size = 328847, upload-time = "2026-06-11T21:55:34.035Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/58/dc12f2cd484951524af6e3382c785869b9b3fb5e52ee95ae23add53ee8f9/protobuf-7.35.1-cp310-abi3-manylinux2014_s390x.whl", hash = "sha256:b73f9489a4b8b1c9cb1f8ed951c736392592edb24b9d6819f36d2e10b171d5b4", size = 344030, upload-time = "2026-06-11T21:55:34.941Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/be/5b3cfe508bfab6761414ff944e3366eb13be4fd71efcd69450f89ba39f43/protobuf-7.35.1-cp310-abi3-manylinux2014_x86_64.whl", hash = "sha256:74758715c53d7158fb76caf4f0cfdacc5329a4b1bb994f865d6cf302d413a1c4", size = 327130, upload-time = "2026-06-11T21:55:35.921Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/bc/6d6c7ba8709c85f8f2c390b2b118d6fb08a783676a572271851bf45a7d22/protobuf-7.35.1-cp310-abi3-win32.whl", hash = "sha256:353652e4efd0bca5b5fc2656abf8307ef351f0cf938c9eba09f0e09c20a25c30", size = 428945, upload-time = "2026-06-11T21:55:37.034Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/19/8d0cb6f20a1ef7b18f1c8986ad5783f22f84cce39c6ce9a6e645ea55192e/protobuf-7.35.1-cp310-abi3-win_amd64.whl", hash = "sha256:230a75ddfc2de4806e56696ce9640c1cdfdb6543b7cfce98d42a4c0a0e7bdb87", size = 439996, upload-time = "2026-06-11T21:55:38.123Z" },
+    { url = "https://files.pythonhosted.org/packages/19/c7/5f7c636ec43e0c545e28d1f1db71990108306f7bdcb89f069ba97e428e7f/protobuf-7.35.1-py3-none-any.whl", hash = "sha256:4bc97768d8fe4ad6743c8a19403e314511ed9f6d13205b687e52421c023ac1b9", size = 171659, upload-time = "2026-06-11T21:55:39.155Z" },
 ]
 
 [[package]]
@@ -3726,6 +4015,19 @@ wheels = [
 ]
 
 [[package]]
+name = "python-datauri"
+version = "3.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cached-property" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7c/3b/8a9a2ec12424a8617678d663fa70de43d917d3590416d3a2b9c7fc065d5b/python_datauri-3.0.2.tar.gz", hash = "sha256:d77c37f1f734fc035de424e643464990b2b840e9b8c7c1817c11fca19b71eeb7", size = 9746, upload-time = "2025-01-03T16:22:56.143Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bc/b6/3332df034d7f322506f2267517b051cd3605e129ecc7f9d46a6fbd540279/python_datauri-3.0.2-py2.py3-none-any.whl", hash = "sha256:b365690a1d7d1b7777009eb11a86bd069db4f194e50f4f871a47302f0587c144", size = 5803, upload-time = "2025-01-03T16:22:53.899Z" },
+]
+
+[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 source = { registry = "https://pypi.org/simple" }
@@ -3747,12 +4049,49 @@ wheels = [
 ]
 
 [[package]]
+name = "python-engineio"
+version = "4.13.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "simple-websocket" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fb/a0/f75491f942184d9960b15e763270f765fe9f239745ca5f9e16289011aed4/python_engineio-4.13.3.tar.gz", hash = "sha256:572b7783e341fed21edbc7cea297ccd378dad79265fdde96aa4664420a7c06c9", size = 79734, upload-time = "2026-06-20T22:53:52.197Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5b/96/82f6328e410515fab21d5602ba35b9377a47b5a141a0c1f9efa00ce21eb4/python_engineio-4.13.3-py3-none-any.whl", hash = "sha256:1f60ecaf1358190f0e26c48c578a60428dc02a8f1295bc3dbf53d1b31116821f", size = 59993, upload-time = "2026-06-20T22:53:50.775Z" },
+]
+
+[[package]]
+name = "python-frontmatter"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9d/e8/79cbe69864d44f3b48e70ebee0a872a7d5a4e7150c9f8577ed7a5beefff0/python_frontmatter-1.3.0.tar.gz", hash = "sha256:acc73e477a568dc2a25c9e130c6c68ae8daa8c204c8f7e813db47d6a7280dcf2", size = 8322, upload-time = "2026-05-20T19:21:44.164Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a6/a3/17c284b4f4d8ad50f0f9ba70ad8fcc35c777aeafcdbbffdd91bbdc5ab379/python_frontmatter-1.3.0-py3-none-any.whl", hash = "sha256:9f7dd9260bec99044219159a329f64f039087f9d1a2124c9442556f2fe6f82ec", size = 10562, upload-time = "2026-05-20T19:21:43.323Z" },
+]
+
+[[package]]
 name = "python-multipart"
 version = "0.0.28"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/82/54/a85eb421fbdd5007bc5af39d0f4ed9fa609e0fedbfdc2adcf0b34526870e/python_multipart-0.0.28.tar.gz", hash = "sha256:8550da197eac0f7ab748961fc9509b999fa2662ea25cef857f05249f6893c0f8", size = 45314, upload-time = "2026-05-10T11:05:16.596Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f3/a2/43bbc5860b5034e2af4ef99a0e04d726ff329c43e192ef3abaa8d7ecfce5/python_multipart-0.0.28-py3-none-any.whl", hash = "sha256:10faac07eb966c3f48dc415f9dee46c04cb10d58d30a35677db8027c825ed9b6", size = 29438, upload-time = "2026-05-10T11:05:15.052Z" },
+]
+
+[[package]]
+name = "python-socketio"
+version = "5.16.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "bidict" },
+    { name = "python-engineio" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/32/2d/ffce71017c106b75099fea569df6518c63fee5d6202ce0cfe7b01e6f22c3/python_socketio-5.16.3.tar.gz", hash = "sha256:89b136f677ae65607a84cecda9b4d6c5377b40a97582c504c25df89af16d520e", size = 128095, upload-time = "2026-06-15T22:07:04.003Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0a/38/8c5e72d53ff8eb27497c4f268a7f6d9121e727a50b65248288ad79a93053/python_socketio-5.16.3-py3-none-any.whl", hash = "sha256:e7ad14202a5e6448824c7c2f86161d04e13dec05992257df5c709e6a2798c041", size = 82087, upload-time = "2026-06-15T22:07:02.498Z" },
 ]
 
 [[package]]
@@ -4297,6 +4636,27 @@ wheels = [
 ]
 
 [[package]]
+name = "shortuuid"
+version = "1.0.13"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/e2/bcf761f3bff95856203f9559baf3741c416071dd200c0fc19fad7f078f86/shortuuid-1.0.13.tar.gz", hash = "sha256:3bb9cf07f606260584b1df46399c0b87dd84773e7b25912b7e391e30797c5e72", size = 9662, upload-time = "2024-03-11T20:11:06.879Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c0/44/21d6bf170bf40b41396480d8d49ad640bca3f2b02139cd52aa1e272830a5/shortuuid-1.0.13-py3-none-any.whl", hash = "sha256:a482a497300b49b4953e15108a7913244e1bb0d41f9d332f5e9925dba33a3c5a", size = 10529, upload-time = "2024-03-11T20:11:04.807Z" },
+]
+
+[[package]]
+name = "simple-websocket"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wsproto" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b0/d4/bfa032f961103eba93de583b161f0e6a5b63cebb8f2c7d0c6e6efe1e3d2e/simple_websocket-1.1.0.tar.gz", hash = "sha256:7939234e7aa067c534abdab3a9ed933ec9ce4691b0713c78acb195560aa52ae4", size = 17300, upload-time = "2024-10-10T22:39:31.412Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/52/59/0782e51887ac6b07ffd1570e0364cf901ebc36345fea669969d2084baebb/simple_websocket-1.1.0-py3-none-any.whl", hash = "sha256:4af6069630a38ed6c561010f0e11a5bc0d4ca569b36306eb257cd9a192497c8c", size = 13842, upload-time = "2024-10-10T22:39:29.645Z" },
+]
+
+[[package]]
 name = "six"
 version = "1.17.0"
 source = { registry = "https://pypi.org/simple" }
@@ -4551,6 +4911,22 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/4a/d0/d76206c203532076c578bf9f004613fcb9ac0c03f3a976a48d5cc791e4ff/tree_sitter-0.22.3-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:156df7e71a6c6b542ff29526cad6886a41115e42dc768c55101398d68325db54", size = 542688, upload-time = "2024-05-18T21:15:13.835Z" },
     { url = "https://files.pythonhosted.org/packages/fa/73/c3d3e161c807944262e6654e24c6c74e3cf5817a625de5bf190bc3c6d282/tree_sitter-0.22.3-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:82e1d467ce23dd2ecc37d4fb83965e891fc37b943639c517cd5acf54a2df0ff7", size = 552180, upload-time = "2024-05-18T21:15:15.684Z" },
     { url = "https://files.pythonhosted.org/packages/6b/8d/8d86a0d2966ea492dd785a94c4d77ae22c86e707f8340f3960c1c0692bc5/tree_sitter-0.22.3-cp312-cp312-win_amd64.whl", hash = "sha256:e541a0c08a04f229ba9479a8c441dd267fdaa3e5842ae70a744c178bcaf53fa3", size = 112644, upload-time = "2024-05-18T21:15:17.615Z" },
+]
+
+[[package]]
+name = "tree-sitter-bash"
+version = "0.25.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/0e/f0108be910f1eef6499eabce517e79fe3b12057280ed398da67ce2426cba/tree_sitter_bash-0.25.1.tar.gz", hash = "sha256:bfc0bdaa77bc1e86e3c6652e5a6e140c40c0a16b84185c2b63ad7cd809b88f14", size = 419703, upload-time = "2025-12-02T17:01:08.849Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/30/8e/37e7364d9c9c58da89e05c510671d8c45818afd7b31c6939ab72f8dc6c04/tree_sitter_bash-0.25.1-cp310-abi3-macosx_10_9_x86_64.whl", hash = "sha256:0e6235f59e366d220dde7d830196bed597d01e853e44d8ccd1a82c5dd2500acf", size = 194160, upload-time = "2025-12-02T17:00:59.047Z" },
+    { url = "https://files.pythonhosted.org/packages/23/bb/2d2cfbb1f89aaeb1ec892624f069d92d058d06bb66f16b9ec9fb5873ab60/tree_sitter_bash-0.25.1-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:f4a34a6504c7c5b2a9b8c5c4065531dea19ca2c35026e706cf2eeeebe2c92512", size = 202659, upload-time = "2025-12-02T17:01:00.275Z" },
+    { url = "https://files.pythonhosted.org/packages/25/f0/1bb25519be27460255d3899db677313cfa1e6306988fbf456a3d7e211bbb/tree_sitter_bash-0.25.1-cp310-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e76c4cfb20b076552406782b7f8c2a3946835993df0a44df006de54b7030c7dc", size = 230596, upload-time = "2025-12-02T17:01:01.759Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/22/9f70bc3d3b942ab9fc0f89c1dc9e087519a3a94f64ae6b7377aae3a7a0f0/tree_sitter_bash-0.25.1-cp310-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3f484c4bb8796cde7a87ca351e6116f09653edac0eb3c6d238566359dd28b117", size = 231981, upload-time = "2025-12-02T17:01:02.859Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/c3/f1540e42cd41b323c6821e45e52e1aed6ed386209aad52db996f05703963/tree_sitter_bash-0.25.1-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:5e76af6df46d958c7f5b6d5884c9743218e3902a00ccb493ec92728b1084430b", size = 228364, upload-time = "2025-12-02T17:01:03.997Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/a0/c3050a6277dfcac8c480f514dc4fe49f3f65f0eac68b4702cbaca2584e85/tree_sitter_bash-0.25.1-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a3332d71c7b7d5f78259b19d02d0ea111fcb82b72712ee4a93aaa5b226d3f0a8", size = 230074, upload-time = "2025-12-02T17:01:05.05Z" },
+    { url = "https://files.pythonhosted.org/packages/71/0f/203fe6b27211387f4b9ba8c4a321567ca4ded2624dae6ccdbd2b6e940e17/tree_sitter_bash-0.25.1-cp310-abi3-win_amd64.whl", hash = "sha256:52a6802d9218f86278aa3e8b459c3abdad67eed0fde1f9f13aca5b6c634217a6", size = 195574, upload-time = "2025-12-02T17:01:06.412Z" },
+    { url = "https://files.pythonhosted.org/packages/47/75/4ca1a9fabd8fb5aea78cea70f7837ce4dbf2afae115f62051e5fa99cba1c/tree_sitter_bash-0.25.1-cp310-abi3-win_arm64.whl", hash = "sha256:59115057ec2bae319e8082ff29559861045002964c3431ccb0fc92aa4bc9bccb", size = 191196, upload-time = "2025-12-02T17:01:07.486Z" },
 ]
 
 [[package]]
@@ -4819,6 +5195,15 @@ wheels = [
 ]
 
 [[package]]
+name = "websocket-client"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/41/aa4bf9664e4cda14c3b39865b12251e8e7d239f4cd0e3cc1b6c2ccde25c1/websocket_client-1.9.0.tar.gz", hash = "sha256:9e813624b6eb619999a97dc7958469217c3176312b3a16a4bd1bc7e08a46ec98", size = 70576, upload-time = "2025-10-07T21:16:36.495Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/34/db/b10e48aa8fff7407e67470363eac595018441cf32d5e1001567a7aeba5d2/websocket_client-1.9.0-py3-none-any.whl", hash = "sha256:af248a825037ef591efbf6ed20cc5faa03d3b47b9e5a2230a529eeee1c1fc3ef", size = 82616, upload-time = "2025-10-07T21:16:34.951Z" },
+]
+
+[[package]]
 name = "websockets"
 version = "16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -4934,6 +5319,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/82/dd/e5176e4b241c9f528402cebb238a36785a628179d7d8b71091154b3e4c9e/wrapt-2.1.2-cp314-cp314t-win_amd64.whl", hash = "sha256:08ffa54146a7559f5b8df4b289b46d963a8e74ed16ba3687f99896101a3990c5", size = 63969, upload-time = "2026-03-06T02:54:39Z" },
     { url = "https://files.pythonhosted.org/packages/5c/99/79f17046cf67e4a95b9987ea129632ba8bcec0bc81f3fb3d19bdb0bd60cd/wrapt-2.1.2-cp314-cp314t-win_arm64.whl", hash = "sha256:72aaa9d0d8e4ed0e2e98019cea47a21f823c9dd4b43c7b77bba6679ffcca6a00", size = 60554, upload-time = "2026-03-06T02:53:14.132Z" },
     { url = "https://files.pythonhosted.org/packages/1a/c7/8528ac2dfa2c1e6708f647df7ae144ead13f0a31146f43c7264b4942bf12/wrapt-2.1.2-py3-none-any.whl", hash = "sha256:b8fd6fa2b2c4e7621808f8c62e8317f4aae56e59721ad933bac5239d913cf0e8", size = 43993, upload-time = "2026-03-06T02:53:12.905Z" },
+]
+
+[[package]]
+name = "wsproto"
+version = "1.3.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c7/79/12135bdf8b9c9367b8701c2c19a14c913c120b882d50b014ca0d38083c2c/wsproto-1.3.2.tar.gz", hash = "sha256:b86885dcf294e15204919950f666e06ffc6c7c114ca900b060d6e16293528294", size = 50116, upload-time = "2025-11-20T18:18:01.871Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a4/f5/10b68b7b1544245097b2a1b8238f66f2fc6dcaeb24ba5d917f52bd2eed4f/wsproto-1.3.2-py3-none-any.whl", hash = "sha256:61eea322cdf56e8cc904bd3ad7573359a242ba65688716b0710a5eb12beab584", size = 24405, upload-time = "2025-11-20T18:18:00.454Z" },
 ]
 
 [[package]]

--- a/src/frontend/src/client/schemas.gen.ts
+++ b/src/frontend/src/client/schemas.gen.ts
@@ -638,6 +638,12 @@ export const ChatTuneTurnStartRequestSchema = {
             title: 'Language',
             description: '本轮对话使用的语言（zh/en），驱动 LLM 回答语言',
             default: 'zh'
+        },
+        beta: {
+            type: 'boolean',
+            title: 'Beta',
+            description: '是否走 AI 构建 (Beta)：用 AgentScope 单 agent 构建。仅当后端 ENABLE_AI_AGENT_BUILD 开启时生效，否则忽略并回退到默认分发。',
+            default: false
         }
     },
     type: 'object',
@@ -905,137 +911,8 @@ export const EmbeddingProviderCreateSchema = {
 } as const;
 
 export const EmbeddingProviderResponseSchema = {
-    properties: {
-        id: {
-            type: 'string',
-            format: 'uuid',
-            title: 'Id'
-        },
-        created_time: {
-            type: 'string',
-            format: 'date-time',
-            title: 'Created Time'
-        },
-        updated_time: {
-            type: 'string',
-            format: 'date-time',
-            title: 'Updated Time'
-        },
-        user_id: {
-            type: 'string',
-            format: 'uuid',
-            title: 'User Id'
-        },
-        name: {
-            type: 'string',
-            title: 'Name'
-        },
-        type: {
-            '$ref': '#/components/schemas/EmbeddingProviderType'
-        },
-        api_key: {
-            type: 'string',
-            title: 'Api Key'
-        },
-        auth_token: {
-            type: 'string',
-            title: 'Auth Token'
-        },
-        base_url: {
-            anyOf: [
-                {
-                    type: 'string'
-                },
-                {
-                    type: 'null'
-                }
-            ],
-            title: 'Base Url'
-        },
-        mode: {
-            '$ref': '#/components/schemas/EmbeddingMode'
-        },
-        model: {
-            type: 'string',
-            title: 'Model'
-        },
-        dim: {
-            type: 'integer',
-            title: 'Dim'
-        },
-        timeout: {
-            type: 'number',
-            title: 'Timeout'
-        },
-        embedding_func_max_async: {
-            type: 'integer',
-            title: 'Embedding Func Max Async'
-        },
-        text_type: {
-            '$ref': '#/components/schemas/EmbeddingProviderType'
-        },
-        text_base_url: {
-            anyOf: [
-                {
-                    type: 'string'
-                },
-                {
-                    type: 'null'
-                }
-            ],
-            title: 'Text Base Url'
-        },
-        text_api_key: {
-            type: 'string',
-            title: 'Text Api Key'
-        },
-        text_auth_token: {
-            type: 'string',
-            title: 'Text Auth Token'
-        },
-        text_model: {
-            type: 'string',
-            title: 'Text Model'
-        },
-        text_task: {
-            type: 'string',
-            title: 'Text Task'
-        },
-        code_type: {
-            '$ref': '#/components/schemas/EmbeddingProviderType'
-        },
-        code_base_url: {
-            anyOf: [
-                {
-                    type: 'string'
-                },
-                {
-                    type: 'null'
-                }
-            ],
-            title: 'Code Base Url'
-        },
-        code_api_key: {
-            type: 'string',
-            title: 'Code Api Key'
-        },
-        code_auth_token: {
-            type: 'string',
-            title: 'Code Auth Token'
-        },
-        code_model: {
-            type: 'string',
-            title: 'Code Model'
-        },
-        code_task: {
-            type: 'string',
-            title: 'Code Task'
-        }
-    },
-    type: 'object',
-    required: ['id', 'created_time', 'updated_time', 'user_id', 'name', 'type', 'api_key', 'auth_token', 'base_url', 'mode', 'model', 'dim', 'timeout', 'embedding_func_max_async', 'text_type', 'text_base_url', 'text_api_key', 'text_auth_token', 'text_model', 'text_task', 'code_type', 'code_base_url', 'code_api_key', 'code_auth_token', 'code_model', 'code_task'],
-    title: 'EmbeddingProviderResponse',
-    description: 'Embedding 供应商响应，凭据不返回明文。'
+    additionalProperties: true,
+    type: 'object'
 } as const;
 
 export const EmbeddingProviderTestByIdRequestSchema = {
@@ -1856,6 +1733,19 @@ export const ExampleTemplateListResponseSchema = {
     type: 'object',
     title: 'ExampleTemplateListResponse',
     description: '示例模板列表响应。'
+} as const;
+
+export const FeatureFlagsSchema = {
+    properties: {
+        enable_ai_agent_build: {
+            type: 'boolean',
+            title: 'Enable Ai Agent Build'
+        }
+    },
+    type: 'object',
+    required: ['enable_ai_agent_build'],
+    title: 'FeatureFlags',
+    description: 'Public feature flags the frontend uses to show/hide optional UI.'
 } as const;
 
 export const FeedbackAdminSchema = {

--- a/src/frontend/src/client/sdk.gen.ts
+++ b/src/frontend/src/client/sdk.gen.ts
@@ -3,7 +3,7 @@
 import type { CancelablePromise } from './core/CancelablePromise';
 import { OpenAPI } from './core/OpenAPI';
 import { request as __request } from './core/request';
-import type { FeedbackCreateFeedbackData, FeedbackCreateFeedbackResponse, FeedbackListFeedbacksData, FeedbackListFeedbacksResponse, FeedbackGetFeedbackStatisticsResponse, FeedbackGetFeedbackData, FeedbackGetFeedbackResponse, FeedbackUpdateFeedbackData, FeedbackUpdateFeedbackResponse, FeedbackDeleteFeedbackData, FeedbackDeleteFeedbackResponse, LiveCodesCreateLiveCodeData, LiveCodesCreateLiveCodeResponse, LiveCodesListLiveCodesData, LiveCodesListLiveCodesResponse, LiveCodesGetLiveCodeData, LiveCodesGetLiveCodeResponse, LiveCodesUpdateLiveCodeData, LiveCodesUpdateLiveCodeResponse, LiveCodesDeleteLiveCodeData, LiveCodesDeleteLiveCodeResponse, LiveCodesAddTargetsData, LiveCodesAddTargetsResponse, LiveCodesUpdateTargetData, LiveCodesUpdateTargetResponse, LiveCodesDeleteTargetData, LiveCodesDeleteTargetResponse, LiveCodesResetTargetScanData, LiveCodesResetTargetScanResponse, LiveQrContactResponse, LiveQrTargetImageData, LiveQrTargetImageResponse, LiveQrLandingData, LiveQrLandingResponse, LiveQrScanImageData, LiveQrScanImageResponse, LiveQrPublicQrcodeData, LiveQrPublicQrcodeResponse, Llm4AdChatTuneGetSessionData, Llm4AdChatTuneGetSessionResponse, Llm4AdChatTuneResetSessionData, Llm4AdChatTuneResetSessionResponse, Llm4AdChatTuneStartTurnData, Llm4AdChatTuneStartTurnResponse, Llm4AdChatTuneStopTurnData, Llm4AdChatTuneStopTurnResponse, Llm4AdChatTuneRetryTurnData, Llm4AdChatTuneRetryTurnResponse, Llm4AdChatTuneChatTuneUploadFileData, Llm4AdChatTuneChatTuneUploadFileResponse, Llm4AdChatTuneChatTuneUploadDataData, Llm4AdChatTuneChatTuneUploadDataResponse, Llm4AdChatTuneStreamTurnData, Llm4AdChatTuneStreamTurnResponse, Llm4AdProjectsCreateProjectData, Llm4AdProjectsCreateProjectResponse, Llm4AdProjectsListProjectsData, Llm4AdProjectsListProjectsResponse, Llm4AdProjectsGetProjectData, Llm4AdProjectsGetProjectResponse, Llm4AdProjectsUpdateProjectData, Llm4AdProjectsUpdateProjectResponse, Llm4AdProjectsDeleteProjectData, Llm4AdProjectsDeleteProjectResponse, Llm4AdProvidersTestProviderData, Llm4AdProvidersTestProviderResponse, Llm4AdProvidersCreateProviderData, Llm4AdProvidersCreateProviderResponse, Llm4AdProvidersListProvidersData, Llm4AdProvidersListProvidersResponse, Llm4AdProvidersGetProviderData, Llm4AdProvidersGetProviderResponse, Llm4AdProvidersUpdateProviderData, Llm4AdProvidersUpdateProviderResponse, Llm4AdProvidersDeleteProviderData, Llm4AdProvidersDeleteProviderResponse, Llm4AdProvidersTestStoredProviderData, Llm4AdProvidersTestStoredProviderResponse, Llm4AdReportsGetReportTemplatesResponse, Llm4AdReportsGenerateReportData, Llm4AdReportsGenerateReportResponse, Llm4AdReportsGetReportData, Llm4AdReportsGetReportResponse, Llm4AdReportsStopReportData, Llm4AdReportsStopReportResponse, Llm4AdReportsStreamReportData, Llm4AdReportsStreamReportResponse, Llm4AdReportsGenerateAdviseData, Llm4AdReportsGenerateAdviseResponse, Llm4AdReportsGetAdviseData, Llm4AdReportsGetAdviseResponse, Llm4AdReportsGenerateRecommendData, Llm4AdReportsGenerateRecommendResponse, Llm4AdReportsGetRecommendData, Llm4AdReportsGetRecommendResponse, Llm4AdTasksListExampleTemplatesResponse, Llm4AdTasksListTasksData, Llm4AdTasksListTasksResponse, Llm4AdTasksGetTaskData, Llm4AdTasksGetTaskResponse, Llm4AdTasksUpdateTaskData, Llm4AdTasksUpdateTaskResponse, Llm4AdTasksDeleteTaskData, Llm4AdTasksDeleteTaskResponse, Llm4AdTasksCreateTaskData, Llm4AdTasksCreateTaskResponse, Llm4AdTasksUpdateTaskTagData, Llm4AdTasksUpdateTaskTagResponse, Llm4AdTasksSetActiveChildData, Llm4AdTasksSetActiveChildResponse, Llm4AdTasksGetTaskTreeData, Llm4AdTasksGetTaskTreeResponse, Llm4AdTasksCopyTaskData, Llm4AdTasksCopyTaskResponse, Llm4AdTasksRunTaskData, Llm4AdTasksRunTaskResponse, Llm4AdTasksStopTaskData, Llm4AdTasksStopTaskResponse, Llm4AdTasksGetTaskResultData, Llm4AdTasksGetTaskResultResponse, Llm4AdTasksGetTaskStatsData, Llm4AdTasksGetTaskStatsResponse, Llm4AdTasksGenerateResultRenderData, Llm4AdTasksGenerateResultRenderResponse, Llm4AdTasksGetConfigSchemaData, Llm4AdTasksGetConfigSchemaResponse, Llm4AdTasksUploadTaskDataData, Llm4AdTasksUploadTaskDataResponse, Llm4AdTasksGetTaskDataTreeData, Llm4AdTasksGetTaskDataTreeResponse, Llm4AdTasksCreateTaskDataFileData, Llm4AdTasksCreateTaskDataFileResponse, Llm4AdTasksGetTaskDataFileData, Llm4AdTasksGetTaskDataFileResponse, Llm4AdTasksUpdateTaskDataFileData, Llm4AdTasksUpdateTaskDataFileResponse, Llm4AdTasksDeleteTaskDataFileData, Llm4AdTasksDeleteTaskDataFileResponse, Llm4AdTasksRenameTaskDataFileData, Llm4AdTasksRenameTaskDataFileResponse, Llm4AdTasksCreateTaskDataFolderData, Llm4AdTasksCreateTaskDataFolderResponse, Llm4AdTasksDeleteTaskDataFolderData, Llm4AdTasksDeleteTaskDataFolderResponse, Llm4AdTasksRenameTaskDataFolderData, Llm4AdTasksRenameTaskDataFolderResponse, Llm4AdTasksGetTaskLogsData, Llm4AdTasksGetTaskLogsResponse, Llm4AdTasksStreamTaskLogsData, Llm4AdTasksStreamTaskLogsResponse, Llm4AdTasksCodeAuthResponse, Llm4AdUserDefaultModelsGetUserDefaultModelResponse, Llm4AdUserDefaultModelsUpdateUserDefaultModelData, Llm4AdUserDefaultModelsUpdateUserDefaultModelResponse, LoginLoginAccessTokenData, LoginLoginAccessTokenResponse, LoginRefreshAccessTokenData, LoginRefreshAccessTokenResponse, LoginRecoverPasswordData, LoginRecoverPasswordResponse, LoginResetPasswordData, LoginResetPasswordResponse, PermissionCreateData, PermissionCreateResponse, PermissionGetData, PermissionGetResponse, PermissionPermissionsResponse, PrivacyPolicyGetPrivacyPolicyContentData, PrivacyPolicyGetPrivacyPolicyContentResponse, PrivacyPolicyAcceptPrivacyPolicyAuthenticatedResponse, PrivacyPolicyAcceptPrivacyPolicyBeforeLoginData, PrivacyPolicyAcceptPrivacyPolicyBeforeLoginResponse, PrivacyPolicyCheckPrivacyPolicyStatusResponse, UsersReadUsersData, UsersReadUsersResponse, UsersCreateUserData, UsersCreateUserResponse, UsersReadUserMeResponse, UsersDeleteUserMeResponse, UsersUpdateUserMeData, UsersUpdateUserMeResponse, UsersUpdatePasswordMeData, UsersUpdatePasswordMeResponse, UsersRegisterUserData, UsersRegisterUserResponse, UsersVerifyEmailData, UsersVerifyEmailResponse, UsersResendVerifyCodeData, UsersResendVerifyCodeResponse, UsersReadUserByIdData, UsersReadUserByIdResponse, UsersUpdateUserData, UsersUpdateUserResponse, UsersDeleteUserData, UsersDeleteUserResponse, UtilsTestEmailData, UtilsTestEmailResponse, UtilsHealthCheckResponse, UtilsFeatureFlagsResponse, UtilsCodeServerGetCodeTokenData, UtilsCodeServerGetCodeTokenResponse, UtilsTestingTestS3Response, UtilsTestingTestCurrentUserDpResponse, UtilsTestingTestCurrentUserResponse, UtilsTestingTestSuperuserDpResponse, UtilsTestingTestSuperuserResponse, UtilsTestingTestRequirePermissionDpResponse, UtilsTestingTestGetTaskInfoData, UtilsTestingTestGetTaskInfoResponse } from './types.gen';
+import type { FeedbackCreateFeedbackData, FeedbackCreateFeedbackResponse, FeedbackListFeedbacksData, FeedbackListFeedbacksResponse, FeedbackGetFeedbackStatisticsResponse, FeedbackGetFeedbackData, FeedbackGetFeedbackResponse, FeedbackUpdateFeedbackData, FeedbackUpdateFeedbackResponse, FeedbackDeleteFeedbackData, FeedbackDeleteFeedbackResponse, LiveCodesCreateLiveCodeData, LiveCodesCreateLiveCodeResponse, LiveCodesListLiveCodesData, LiveCodesListLiveCodesResponse, LiveCodesGetLiveCodeData, LiveCodesGetLiveCodeResponse, LiveCodesUpdateLiveCodeData, LiveCodesUpdateLiveCodeResponse, LiveCodesDeleteLiveCodeData, LiveCodesDeleteLiveCodeResponse, LiveCodesAddTargetsData, LiveCodesAddTargetsResponse, LiveCodesUpdateTargetData, LiveCodesUpdateTargetResponse, LiveCodesDeleteTargetData, LiveCodesDeleteTargetResponse, LiveCodesResetTargetScanData, LiveCodesResetTargetScanResponse, LiveQrContactResponse, LiveQrTargetImageData, LiveQrTargetImageResponse, LiveQrLandingData, LiveQrLandingResponse, LiveQrScanImageData, LiveQrScanImageResponse, LiveQrPublicQrcodeData, LiveQrPublicQrcodeResponse, Llm4AdChatTuneGetSessionData, Llm4AdChatTuneGetSessionResponse, Llm4AdChatTuneResetSessionData, Llm4AdChatTuneResetSessionResponse, Llm4AdChatTuneStartTurnData, Llm4AdChatTuneStartTurnResponse, Llm4AdChatTuneStopTurnData, Llm4AdChatTuneStopTurnResponse, Llm4AdChatTuneRetryTurnData, Llm4AdChatTuneRetryTurnResponse, Llm4AdChatTuneChatTuneUploadFileData, Llm4AdChatTuneChatTuneUploadFileResponse, Llm4AdChatTuneChatTuneUploadDataData, Llm4AdChatTuneChatTuneUploadDataResponse, Llm4AdChatTuneStreamTurnData, Llm4AdChatTuneStreamTurnResponse, Llm4AdEmbeddingProvidersTestEmbeddingProviderData, Llm4AdEmbeddingProvidersTestEmbeddingProviderResponse, Llm4AdEmbeddingProvidersCreateEmbeddingProviderData, Llm4AdEmbeddingProvidersCreateEmbeddingProviderResponse, Llm4AdEmbeddingProvidersListEmbeddingProvidersData, Llm4AdEmbeddingProvidersListEmbeddingProvidersResponse, Llm4AdEmbeddingProvidersGetEmbeddingProviderData, Llm4AdEmbeddingProvidersGetEmbeddingProviderResponse, Llm4AdEmbeddingProvidersUpdateEmbeddingProviderData, Llm4AdEmbeddingProvidersUpdateEmbeddingProviderResponse, Llm4AdEmbeddingProvidersDeleteEmbeddingProviderData, Llm4AdEmbeddingProvidersDeleteEmbeddingProviderResponse, Llm4AdEmbeddingProvidersTestStoredEmbeddingProviderData, Llm4AdEmbeddingProvidersTestStoredEmbeddingProviderResponse, Llm4AdLlmproxyProxyLlmData, Llm4AdLlmproxyProxyLlmResponse, Llm4AdLlmproxyProxyLlm1Data, Llm4AdLlmproxyProxyLlm1Response, Llm4AdLlmproxyProxyLlm2Data, Llm4AdLlmproxyProxyLlm2Response, Llm4AdLlmproxyProxyLlm3Data, Llm4AdLlmproxyProxyLlm3Response, Llm4AdLlmproxyProxyLlm4Data, Llm4AdLlmproxyProxyLlm4Response, Llm4AdLlmproxyProxyLlm5Data, Llm4AdLlmproxyProxyLlm5Response, Llm4AdProjectsCreateProjectData, Llm4AdProjectsCreateProjectResponse, Llm4AdProjectsListProjectsData, Llm4AdProjectsListProjectsResponse, Llm4AdProjectsGetProjectData, Llm4AdProjectsGetProjectResponse, Llm4AdProjectsUpdateProjectData, Llm4AdProjectsUpdateProjectResponse, Llm4AdProjectsDeleteProjectData, Llm4AdProjectsDeleteProjectResponse, Llm4AdProvidersTestProviderData, Llm4AdProvidersTestProviderResponse, Llm4AdProvidersCreateProviderData, Llm4AdProvidersCreateProviderResponse, Llm4AdProvidersListProvidersData, Llm4AdProvidersListProvidersResponse, Llm4AdProvidersGetProviderData, Llm4AdProvidersGetProviderResponse, Llm4AdProvidersUpdateProviderData, Llm4AdProvidersUpdateProviderResponse, Llm4AdProvidersDeleteProviderData, Llm4AdProvidersDeleteProviderResponse, Llm4AdProvidersTestStoredProviderData, Llm4AdProvidersTestStoredProviderResponse, Llm4AdReportsGetReportTemplatesResponse, Llm4AdReportsGenerateReportData, Llm4AdReportsGenerateReportResponse, Llm4AdReportsGetReportData, Llm4AdReportsGetReportResponse, Llm4AdReportsStopReportData, Llm4AdReportsStopReportResponse, Llm4AdReportsStreamReportData, Llm4AdReportsStreamReportResponse, Llm4AdReportsGenerateAdviseData, Llm4AdReportsGenerateAdviseResponse, Llm4AdReportsGetAdviseData, Llm4AdReportsGetAdviseResponse, Llm4AdReportsGenerateRecommendData, Llm4AdReportsGenerateRecommendResponse, Llm4AdReportsGetRecommendData, Llm4AdReportsGetRecommendResponse, Llm4AdTasksListExampleTemplatesResponse, Llm4AdTasksListTasksData, Llm4AdTasksListTasksResponse, Llm4AdTasksGetTaskData, Llm4AdTasksGetTaskResponse, Llm4AdTasksUpdateTaskData, Llm4AdTasksUpdateTaskResponse, Llm4AdTasksDeleteTaskData, Llm4AdTasksDeleteTaskResponse, Llm4AdTasksCreateTaskData, Llm4AdTasksCreateTaskResponse, Llm4AdTasksUpdateTaskTagData, Llm4AdTasksUpdateTaskTagResponse, Llm4AdTasksSetActiveChildData, Llm4AdTasksSetActiveChildResponse, Llm4AdTasksGetTaskTreeData, Llm4AdTasksGetTaskTreeResponse, Llm4AdTasksCopyTaskData, Llm4AdTasksCopyTaskResponse, Llm4AdTasksRunTaskData, Llm4AdTasksRunTaskResponse, Llm4AdTasksStopTaskData, Llm4AdTasksStopTaskResponse, Llm4AdTasksGetTaskResultData, Llm4AdTasksGetTaskResultResponse, Llm4AdTasksGetTaskStatsData, Llm4AdTasksGetTaskStatsResponse, Llm4AdTasksGenerateResultRenderData, Llm4AdTasksGenerateResultRenderResponse, Llm4AdTasksGetConfigSchemaData, Llm4AdTasksGetConfigSchemaResponse, Llm4AdTasksDownloadTaskWorkspaceData, Llm4AdTasksDownloadTaskWorkspaceResponse, Llm4AdTasksUploadTaskDataData, Llm4AdTasksUploadTaskDataResponse, Llm4AdTasksGetTaskDataTreeData, Llm4AdTasksGetTaskDataTreeResponse, Llm4AdTasksCreateTaskDataFileData, Llm4AdTasksCreateTaskDataFileResponse, Llm4AdTasksGetTaskDataFileData, Llm4AdTasksGetTaskDataFileResponse, Llm4AdTasksUpdateTaskDataFileData, Llm4AdTasksUpdateTaskDataFileResponse, Llm4AdTasksDeleteTaskDataFileData, Llm4AdTasksDeleteTaskDataFileResponse, Llm4AdTasksRenameTaskDataFileData, Llm4AdTasksRenameTaskDataFileResponse, Llm4AdTasksCreateTaskDataFolderData, Llm4AdTasksCreateTaskDataFolderResponse, Llm4AdTasksDeleteTaskDataFolderData, Llm4AdTasksDeleteTaskDataFolderResponse, Llm4AdTasksRenameTaskDataFolderData, Llm4AdTasksRenameTaskDataFolderResponse, Llm4AdTasksGetTaskLogsData, Llm4AdTasksGetTaskLogsResponse, Llm4AdTasksStreamTaskLogsData, Llm4AdTasksStreamTaskLogsResponse, Llm4AdTasksCodeAuthResponse, Llm4AdUserDefaultModelsGetUserDefaultModelResponse, Llm4AdUserDefaultModelsUpdateUserDefaultModelData, Llm4AdUserDefaultModelsUpdateUserDefaultModelResponse, LoginLoginAccessTokenData, LoginLoginAccessTokenResponse, LoginRefreshAccessTokenData, LoginRefreshAccessTokenResponse, LoginRecoverPasswordData, LoginRecoverPasswordResponse, LoginResetPasswordData, LoginResetPasswordResponse, PermissionCreateData, PermissionCreateResponse, PermissionGetData, PermissionGetResponse, PermissionPermissionsResponse, PrivacyPolicyGetPrivacyPolicyContentData, PrivacyPolicyGetPrivacyPolicyContentResponse, PrivacyPolicyAcceptPrivacyPolicyAuthenticatedResponse, PrivacyPolicyAcceptPrivacyPolicyBeforeLoginData, PrivacyPolicyAcceptPrivacyPolicyBeforeLoginResponse, PrivacyPolicyCheckPrivacyPolicyStatusResponse, UsersReadUsersData, UsersReadUsersResponse, UsersCreateUserData, UsersCreateUserResponse, UsersReadUserMeResponse, UsersDeleteUserMeResponse, UsersUpdateUserMeData, UsersUpdateUserMeResponse, UsersUpdatePasswordMeData, UsersUpdatePasswordMeResponse, UsersRegisterUserData, UsersRegisterUserResponse, UsersVerifyEmailData, UsersVerifyEmailResponse, UsersResendVerifyCodeData, UsersResendVerifyCodeResponse, UsersReadUserByIdData, UsersReadUserByIdResponse, UsersUpdateUserData, UsersUpdateUserResponse, UsersDeleteUserData, UsersDeleteUserResponse, UtilsTestEmailData, UtilsTestEmailResponse, UtilsHealthCheckResponse, UtilsFeatureFlagsResponse, UtilsCodeServerGetCodeTokenData, UtilsCodeServerGetCodeTokenResponse, UtilsTestingTestS3Response, UtilsTestingTestCurrentUserDpResponse, UtilsTestingTestCurrentUserResponse, UtilsTestingTestSuperuserDpResponse, UtilsTestingTestSuperuserResponse, UtilsTestingTestRequirePermissionDpResponse, UtilsTestingTestGetTaskInfoData, UtilsTestingTestGetTaskInfoResponse } from './types.gen';
 
 export class FeedbackService {
     /**
@@ -789,6 +789,324 @@ export class Llm4AdChatTuneService {
             path: {
                 task_id: data.taskId,
                 turn_id: data.turnId
+            },
+            errors: {
+                422: 'Validation Error'
+            }
+        });
+    }
+}
+
+export class Llm4AdEmbeddingProvidersService {
+    /**
+     * 测试 embedding 供应商配置连通性
+     * @param data The data for the request.
+     * @param data.requestBody
+     * @returns EmbeddingProviderTestResponse Successful Response
+     * @throws ApiError
+     */
+    public static testEmbeddingProvider(data: Llm4AdEmbeddingProvidersTestEmbeddingProviderData): CancelablePromise<Llm4AdEmbeddingProvidersTestEmbeddingProviderResponse> {
+        return __request(OpenAPI, {
+            method: 'POST',
+            url: '/api/v1/llm4ad/embedding-providers/test',
+            body: data.requestBody,
+            mediaType: 'application/json',
+            errors: {
+                422: 'Validation Error'
+            }
+        });
+    }
+    
+    /**
+     * 创建 embedding 供应商配置
+     * @param data The data for the request.
+     * @param data.requestBody
+     * @returns EmbeddingProviderResponse Successful Response
+     * @throws ApiError
+     */
+    public static createEmbeddingProvider(data: Llm4AdEmbeddingProvidersCreateEmbeddingProviderData): CancelablePromise<Llm4AdEmbeddingProvidersCreateEmbeddingProviderResponse> {
+        return __request(OpenAPI, {
+            method: 'POST',
+            url: '/api/v1/llm4ad/embedding-providers/',
+            body: data.requestBody,
+            mediaType: 'application/json',
+            errors: {
+                422: 'Validation Error'
+            }
+        });
+    }
+    
+    /**
+     * 分页查询 embedding 供应商配置列表
+     * @param data The data for the request.
+     * @param data.skip
+     * @param data.limit
+     * @returns PaginatedEmbeddingProviderResponse Successful Response
+     * @throws ApiError
+     */
+    public static listEmbeddingProviders(data: Llm4AdEmbeddingProvidersListEmbeddingProvidersData = {}): CancelablePromise<Llm4AdEmbeddingProvidersListEmbeddingProvidersResponse> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/api/v1/llm4ad/embedding-providers/',
+            query: {
+                skip: data.skip,
+                limit: data.limit
+            },
+            errors: {
+                422: 'Validation Error'
+            }
+        });
+    }
+    
+    /**
+     * 获取单个 embedding 供应商配置详情
+     * @param data The data for the request.
+     * @param data.providerId
+     * @returns EmbeddingProviderResponse Successful Response
+     * @throws ApiError
+     */
+    public static getEmbeddingProvider(data: Llm4AdEmbeddingProvidersGetEmbeddingProviderData): CancelablePromise<Llm4AdEmbeddingProvidersGetEmbeddingProviderResponse> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/api/v1/llm4ad/embedding-providers/{provider_id}',
+            path: {
+                provider_id: data.providerId
+            },
+            errors: {
+                422: 'Validation Error'
+            }
+        });
+    }
+    
+    /**
+     * 更新 embedding 供应商配置
+     * @param data The data for the request.
+     * @param data.providerId
+     * @param data.requestBody
+     * @returns EmbeddingProviderResponse Successful Response
+     * @throws ApiError
+     */
+    public static updateEmbeddingProvider(data: Llm4AdEmbeddingProvidersUpdateEmbeddingProviderData): CancelablePromise<Llm4AdEmbeddingProvidersUpdateEmbeddingProviderResponse> {
+        return __request(OpenAPI, {
+            method: 'PATCH',
+            url: '/api/v1/llm4ad/embedding-providers/{provider_id}',
+            path: {
+                provider_id: data.providerId
+            },
+            body: data.requestBody,
+            mediaType: 'application/json',
+            errors: {
+                422: 'Validation Error'
+            }
+        });
+    }
+    
+    /**
+     * 删除 embedding 供应商配置
+     * @param data The data for the request.
+     * @param data.providerId
+     * @returns Message Successful Response
+     * @throws ApiError
+     */
+    public static deleteEmbeddingProvider(data: Llm4AdEmbeddingProvidersDeleteEmbeddingProviderData): CancelablePromise<Llm4AdEmbeddingProvidersDeleteEmbeddingProviderResponse> {
+        return __request(OpenAPI, {
+            method: 'DELETE',
+            url: '/api/v1/llm4ad/embedding-providers/{provider_id}',
+            path: {
+                provider_id: data.providerId
+            },
+            errors: {
+                422: 'Validation Error'
+            }
+        });
+    }
+    
+    /**
+     * 测试已存储 embedding 供应商配置连通性
+     * @param data The data for the request.
+     * @param data.providerId
+     * @param data.requestBody
+     * @returns EmbeddingProviderTestResponse Successful Response
+     * @throws ApiError
+     */
+    public static testStoredEmbeddingProvider(data: Llm4AdEmbeddingProvidersTestStoredEmbeddingProviderData): CancelablePromise<Llm4AdEmbeddingProvidersTestStoredEmbeddingProviderResponse> {
+        return __request(OpenAPI, {
+            method: 'POST',
+            url: '/api/v1/llm4ad/embedding-providers/{provider_id}/test',
+            path: {
+                provider_id: data.providerId
+            },
+            body: data.requestBody,
+            mediaType: 'application/json',
+            errors: {
+                422: 'Validation Error'
+            }
+        });
+    }
+}
+
+export class Llm4AdLlmproxyService {
+    /**
+     * Proxy Llm
+     * 透明反向代理：校验代理 token 后用真实凭据转发到上游大模型。
+     *
+     * Args:
+     * path: 上游 API 子路径（如 ``chat/completions`` 或 ``v1/messages``）。
+     * request: 原始入站请求。
+     *
+     * Returns:
+     * 透传上游响应的 ``StreamingResponse``，或鉴权失败时的错误响应。
+     * @param data The data for the request.
+     * @param data.path
+     * @returns unknown Successful Response
+     * @throws ApiError
+     */
+    public static proxyLlm(data: Llm4AdLlmproxyProxyLlmData): CancelablePromise<Llm4AdLlmproxyProxyLlmResponse> {
+        return __request(OpenAPI, {
+            method: 'DELETE',
+            url: '/api/v1/llm4ad/llmproxy/{path}',
+            path: {
+                path: data.path
+            },
+            errors: {
+                422: 'Validation Error'
+            }
+        });
+    }
+    
+    /**
+     * Proxy Llm
+     * 透明反向代理：校验代理 token 后用真实凭据转发到上游大模型。
+     *
+     * Args:
+     * path: 上游 API 子路径（如 ``chat/completions`` 或 ``v1/messages``）。
+     * request: 原始入站请求。
+     *
+     * Returns:
+     * 透传上游响应的 ``StreamingResponse``，或鉴权失败时的错误响应。
+     * @param data The data for the request.
+     * @param data.path
+     * @returns unknown Successful Response
+     * @throws ApiError
+     */
+    public static proxyLlm1(data: Llm4AdLlmproxyProxyLlm1Data): CancelablePromise<Llm4AdLlmproxyProxyLlm1Response> {
+        return __request(OpenAPI, {
+            method: 'OPTIONS',
+            url: '/api/v1/llm4ad/llmproxy/{path}',
+            path: {
+                path: data.path
+            },
+            errors: {
+                422: 'Validation Error'
+            }
+        });
+    }
+    
+    /**
+     * Proxy Llm
+     * 透明反向代理：校验代理 token 后用真实凭据转发到上游大模型。
+     *
+     * Args:
+     * path: 上游 API 子路径（如 ``chat/completions`` 或 ``v1/messages``）。
+     * request: 原始入站请求。
+     *
+     * Returns:
+     * 透传上游响应的 ``StreamingResponse``，或鉴权失败时的错误响应。
+     * @param data The data for the request.
+     * @param data.path
+     * @returns unknown Successful Response
+     * @throws ApiError
+     */
+    public static proxyLlm2(data: Llm4AdLlmproxyProxyLlm2Data): CancelablePromise<Llm4AdLlmproxyProxyLlm2Response> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/api/v1/llm4ad/llmproxy/{path}',
+            path: {
+                path: data.path
+            },
+            errors: {
+                422: 'Validation Error'
+            }
+        });
+    }
+    
+    /**
+     * Proxy Llm
+     * 透明反向代理：校验代理 token 后用真实凭据转发到上游大模型。
+     *
+     * Args:
+     * path: 上游 API 子路径（如 ``chat/completions`` 或 ``v1/messages``）。
+     * request: 原始入站请求。
+     *
+     * Returns:
+     * 透传上游响应的 ``StreamingResponse``，或鉴权失败时的错误响应。
+     * @param data The data for the request.
+     * @param data.path
+     * @returns unknown Successful Response
+     * @throws ApiError
+     */
+    public static proxyLlm3(data: Llm4AdLlmproxyProxyLlm3Data): CancelablePromise<Llm4AdLlmproxyProxyLlm3Response> {
+        return __request(OpenAPI, {
+            method: 'POST',
+            url: '/api/v1/llm4ad/llmproxy/{path}',
+            path: {
+                path: data.path
+            },
+            errors: {
+                422: 'Validation Error'
+            }
+        });
+    }
+    
+    /**
+     * Proxy Llm
+     * 透明反向代理：校验代理 token 后用真实凭据转发到上游大模型。
+     *
+     * Args:
+     * path: 上游 API 子路径（如 ``chat/completions`` 或 ``v1/messages``）。
+     * request: 原始入站请求。
+     *
+     * Returns:
+     * 透传上游响应的 ``StreamingResponse``，或鉴权失败时的错误响应。
+     * @param data The data for the request.
+     * @param data.path
+     * @returns unknown Successful Response
+     * @throws ApiError
+     */
+    public static proxyLlm4(data: Llm4AdLlmproxyProxyLlm4Data): CancelablePromise<Llm4AdLlmproxyProxyLlm4Response> {
+        return __request(OpenAPI, {
+            method: 'PATCH',
+            url: '/api/v1/llm4ad/llmproxy/{path}',
+            path: {
+                path: data.path
+            },
+            errors: {
+                422: 'Validation Error'
+            }
+        });
+    }
+    
+    /**
+     * Proxy Llm
+     * 透明反向代理：校验代理 token 后用真实凭据转发到上游大模型。
+     *
+     * Args:
+     * path: 上游 API 子路径（如 ``chat/completions`` 或 ``v1/messages``）。
+     * request: 原始入站请求。
+     *
+     * Returns:
+     * 透传上游响应的 ``StreamingResponse``，或鉴权失败时的错误响应。
+     * @param data The data for the request.
+     * @param data.path
+     * @returns unknown Successful Response
+     * @throws ApiError
+     */
+    public static proxyLlm5(data: Llm4AdLlmproxyProxyLlm5Data): CancelablePromise<Llm4AdLlmproxyProxyLlm5Response> {
+        return __request(OpenAPI, {
+            method: 'PUT',
+            url: '/api/v1/llm4ad/llmproxy/{path}',
+            path: {
+                path: data.path
             },
             errors: {
                 422: 'Validation Error'
@@ -1828,6 +2146,27 @@ export class Llm4AdTasksService {
     }
     
     /**
+     * 下载任务 IDE 工作区
+     * Download the authorized task IDE workspace as a ZIP archive.
+     * @param data The data for the request.
+     * @param data.taskId
+     * @returns unknown Successful Response
+     * @throws ApiError
+     */
+    public static downloadTaskWorkspace(data: Llm4AdTasksDownloadTaskWorkspaceData): CancelablePromise<Llm4AdTasksDownloadTaskWorkspaceResponse> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/api/v1/llm4ad/tasks/{task_id}/workspace/download',
+            path: {
+                task_id: data.taskId
+            },
+            errors: {
+                422: 'Validation Error'
+            }
+        });
+    }
+    
+    /**
      * 批量上传任务输入数据文件
      * 批量上传任务的输入数据文件到 S3 存储。
      * @param data The data for the request.
@@ -2074,7 +2413,7 @@ export class Llm4AdTasksService {
      * @param data.taskId
      * @param data.cursor 分页游标，首次请求不传，后续传上一次返回的 next_cursor
      * @param data.limit 每页条数，0 表示不分页返回全部
-     * @param data.logType 按日志类型过滤
+     * @param data.logType 按日志类型过滤，多个用英文逗号分隔
      * @param data.level 按日志级别过滤，支持多选
      * @param data.q 全文搜索日志内容
      * @returns TaskLogsResponse Successful Response
@@ -2925,12 +3264,16 @@ export class UtilsService {
             url: '/api/v1/utils/health-check/'
         });
     }
-
+    
     /**
      * Feature Flags
      * 返回前端可见的特性开关。
      *
-     * 前端据此决定是否展示可选 UI（如 "AI 构建 (Beta)" 入口）。
+     * 前端据此决定是否展示可选 UI（如 "AI 构建 (Beta)" 入口）。无需鉴权——
+     * 仅暴露布尔开关，不含任何敏感信息。
+     *
+     * Returns:
+     * FeatureFlags: 当前生效的特性开关集合。
      * @returns FeatureFlags Successful Response
      * @throws ApiError
      */

--- a/src/frontend/src/client/sdk.gen.ts
+++ b/src/frontend/src/client/sdk.gen.ts
@@ -3,7 +3,7 @@
 import type { CancelablePromise } from './core/CancelablePromise';
 import { OpenAPI } from './core/OpenAPI';
 import { request as __request } from './core/request';
-import type { FeedbackCreateFeedbackData, FeedbackCreateFeedbackResponse, FeedbackListFeedbacksData, FeedbackListFeedbacksResponse, FeedbackGetFeedbackStatisticsResponse, FeedbackGetFeedbackData, FeedbackGetFeedbackResponse, FeedbackUpdateFeedbackData, FeedbackUpdateFeedbackResponse, FeedbackDeleteFeedbackData, FeedbackDeleteFeedbackResponse, LiveCodesCreateLiveCodeData, LiveCodesCreateLiveCodeResponse, LiveCodesListLiveCodesData, LiveCodesListLiveCodesResponse, LiveCodesGetLiveCodeData, LiveCodesGetLiveCodeResponse, LiveCodesUpdateLiveCodeData, LiveCodesUpdateLiveCodeResponse, LiveCodesDeleteLiveCodeData, LiveCodesDeleteLiveCodeResponse, LiveCodesAddTargetsData, LiveCodesAddTargetsResponse, LiveCodesUpdateTargetData, LiveCodesUpdateTargetResponse, LiveCodesDeleteTargetData, LiveCodesDeleteTargetResponse, LiveCodesResetTargetScanData, LiveCodesResetTargetScanResponse, LiveQrContactResponse, LiveQrTargetImageData, LiveQrTargetImageResponse, LiveQrLandingData, LiveQrLandingResponse, LiveQrScanImageData, LiveQrScanImageResponse, LiveQrPublicQrcodeData, LiveQrPublicQrcodeResponse, Llm4AdChatTuneGetSessionData, Llm4AdChatTuneGetSessionResponse, Llm4AdChatTuneResetSessionData, Llm4AdChatTuneResetSessionResponse, Llm4AdChatTuneStartTurnData, Llm4AdChatTuneStartTurnResponse, Llm4AdChatTuneStopTurnData, Llm4AdChatTuneStopTurnResponse, Llm4AdChatTuneRetryTurnData, Llm4AdChatTuneRetryTurnResponse, Llm4AdChatTuneChatTuneUploadFileData, Llm4AdChatTuneChatTuneUploadFileResponse, Llm4AdChatTuneChatTuneUploadDataData, Llm4AdChatTuneChatTuneUploadDataResponse, Llm4AdChatTuneStreamTurnData, Llm4AdChatTuneStreamTurnResponse, Llm4AdEmbeddingProvidersTestEmbeddingProviderData, Llm4AdEmbeddingProvidersTestEmbeddingProviderResponse, Llm4AdEmbeddingProvidersCreateEmbeddingProviderData, Llm4AdEmbeddingProvidersCreateEmbeddingProviderResponse, Llm4AdEmbeddingProvidersListEmbeddingProvidersData, Llm4AdEmbeddingProvidersListEmbeddingProvidersResponse, Llm4AdEmbeddingProvidersGetEmbeddingProviderData, Llm4AdEmbeddingProvidersGetEmbeddingProviderResponse, Llm4AdEmbeddingProvidersUpdateEmbeddingProviderData, Llm4AdEmbeddingProvidersUpdateEmbeddingProviderResponse, Llm4AdEmbeddingProvidersDeleteEmbeddingProviderData, Llm4AdEmbeddingProvidersDeleteEmbeddingProviderResponse, Llm4AdEmbeddingProvidersTestStoredEmbeddingProviderData, Llm4AdEmbeddingProvidersTestStoredEmbeddingProviderResponse, Llm4AdLlmproxyProxyLlmData, Llm4AdLlmproxyProxyLlmResponse, Llm4AdLlmproxyProxyLlm1Data, Llm4AdLlmproxyProxyLlm1Response, Llm4AdLlmproxyProxyLlm2Data, Llm4AdLlmproxyProxyLlm2Response, Llm4AdLlmproxyProxyLlm3Data, Llm4AdLlmproxyProxyLlm3Response, Llm4AdLlmproxyProxyLlm4Data, Llm4AdLlmproxyProxyLlm4Response, Llm4AdLlmproxyProxyLlm5Data, Llm4AdLlmproxyProxyLlm5Response, Llm4AdProjectsCreateProjectData, Llm4AdProjectsCreateProjectResponse, Llm4AdProjectsListProjectsData, Llm4AdProjectsListProjectsResponse, Llm4AdProjectsGetProjectData, Llm4AdProjectsGetProjectResponse, Llm4AdProjectsUpdateProjectData, Llm4AdProjectsUpdateProjectResponse, Llm4AdProjectsDeleteProjectData, Llm4AdProjectsDeleteProjectResponse, Llm4AdProvidersTestProviderData, Llm4AdProvidersTestProviderResponse, Llm4AdProvidersCreateProviderData, Llm4AdProvidersCreateProviderResponse, Llm4AdProvidersListProvidersData, Llm4AdProvidersListProvidersResponse, Llm4AdProvidersGetProviderData, Llm4AdProvidersGetProviderResponse, Llm4AdProvidersUpdateProviderData, Llm4AdProvidersUpdateProviderResponse, Llm4AdProvidersDeleteProviderData, Llm4AdProvidersDeleteProviderResponse, Llm4AdProvidersTestStoredProviderData, Llm4AdProvidersTestStoredProviderResponse, Llm4AdReportsGetReportTemplatesResponse, Llm4AdReportsGenerateReportData, Llm4AdReportsGenerateReportResponse, Llm4AdReportsGetReportData, Llm4AdReportsGetReportResponse, Llm4AdReportsStopReportData, Llm4AdReportsStopReportResponse, Llm4AdReportsStreamReportData, Llm4AdReportsStreamReportResponse, Llm4AdReportsGenerateAdviseData, Llm4AdReportsGenerateAdviseResponse, Llm4AdReportsGetAdviseData, Llm4AdReportsGetAdviseResponse, Llm4AdReportsGenerateRecommendData, Llm4AdReportsGenerateRecommendResponse, Llm4AdReportsGetRecommendData, Llm4AdReportsGetRecommendResponse, Llm4AdTasksListExampleTemplatesResponse, Llm4AdTasksListTasksData, Llm4AdTasksListTasksResponse, Llm4AdTasksGetTaskData, Llm4AdTasksGetTaskResponse, Llm4AdTasksUpdateTaskData, Llm4AdTasksUpdateTaskResponse, Llm4AdTasksDeleteTaskData, Llm4AdTasksDeleteTaskResponse, Llm4AdTasksCreateTaskData, Llm4AdTasksCreateTaskResponse, Llm4AdTasksUpdateTaskTagData, Llm4AdTasksUpdateTaskTagResponse, Llm4AdTasksSetActiveChildData, Llm4AdTasksSetActiveChildResponse, Llm4AdTasksGetTaskTreeData, Llm4AdTasksGetTaskTreeResponse, Llm4AdTasksCopyTaskData, Llm4AdTasksCopyTaskResponse, Llm4AdTasksRunTaskData, Llm4AdTasksRunTaskResponse, Llm4AdTasksStopTaskData, Llm4AdTasksStopTaskResponse, Llm4AdTasksGetTaskResultData, Llm4AdTasksGetTaskResultResponse, Llm4AdTasksGetTaskStatsData, Llm4AdTasksGetTaskStatsResponse, Llm4AdTasksGenerateResultRenderData, Llm4AdTasksGenerateResultRenderResponse, Llm4AdTasksGetConfigSchemaData, Llm4AdTasksGetConfigSchemaResponse, Llm4AdTasksDownloadTaskWorkspaceData, Llm4AdTasksDownloadTaskWorkspaceResponse, Llm4AdTasksUploadTaskDataData, Llm4AdTasksUploadTaskDataResponse, Llm4AdTasksGetTaskDataTreeData, Llm4AdTasksGetTaskDataTreeResponse, Llm4AdTasksCreateTaskDataFileData, Llm4AdTasksCreateTaskDataFileResponse, Llm4AdTasksGetTaskDataFileData, Llm4AdTasksGetTaskDataFileResponse, Llm4AdTasksUpdateTaskDataFileData, Llm4AdTasksUpdateTaskDataFileResponse, Llm4AdTasksDeleteTaskDataFileData, Llm4AdTasksDeleteTaskDataFileResponse, Llm4AdTasksRenameTaskDataFileData, Llm4AdTasksRenameTaskDataFileResponse, Llm4AdTasksCreateTaskDataFolderData, Llm4AdTasksCreateTaskDataFolderResponse, Llm4AdTasksDeleteTaskDataFolderData, Llm4AdTasksDeleteTaskDataFolderResponse, Llm4AdTasksRenameTaskDataFolderData, Llm4AdTasksRenameTaskDataFolderResponse, Llm4AdTasksGetTaskLogsData, Llm4AdTasksGetTaskLogsResponse, Llm4AdTasksStreamTaskLogsData, Llm4AdTasksStreamTaskLogsResponse, Llm4AdTasksCodeAuthResponse, Llm4AdUserDefaultModelsGetUserDefaultModelResponse, Llm4AdUserDefaultModelsUpdateUserDefaultModelData, Llm4AdUserDefaultModelsUpdateUserDefaultModelResponse, LoginLoginAccessTokenData, LoginLoginAccessTokenResponse, LoginRefreshAccessTokenData, LoginRefreshAccessTokenResponse, LoginRecoverPasswordData, LoginRecoverPasswordResponse, LoginResetPasswordData, LoginResetPasswordResponse, PermissionCreateData, PermissionCreateResponse, PermissionGetData, PermissionGetResponse, PermissionPermissionsResponse, PrivacyPolicyGetPrivacyPolicyContentData, PrivacyPolicyGetPrivacyPolicyContentResponse, PrivacyPolicyAcceptPrivacyPolicyAuthenticatedResponse, PrivacyPolicyAcceptPrivacyPolicyBeforeLoginData, PrivacyPolicyAcceptPrivacyPolicyBeforeLoginResponse, PrivacyPolicyCheckPrivacyPolicyStatusResponse, UsersReadUsersData, UsersReadUsersResponse, UsersCreateUserData, UsersCreateUserResponse, UsersReadUserMeResponse, UsersDeleteUserMeResponse, UsersUpdateUserMeData, UsersUpdateUserMeResponse, UsersUpdatePasswordMeData, UsersUpdatePasswordMeResponse, UsersRegisterUserData, UsersRegisterUserResponse, UsersVerifyEmailData, UsersVerifyEmailResponse, UsersResendVerifyCodeData, UsersResendVerifyCodeResponse, UsersReadUserByIdData, UsersReadUserByIdResponse, UsersUpdateUserData, UsersUpdateUserResponse, UsersDeleteUserData, UsersDeleteUserResponse, UtilsTestEmailData, UtilsTestEmailResponse, UtilsHealthCheckResponse, UtilsCodeServerGetCodeTokenData, UtilsCodeServerGetCodeTokenResponse, UtilsTestingTestS3Response, UtilsTestingTestCurrentUserDpResponse, UtilsTestingTestCurrentUserResponse, UtilsTestingTestSuperuserDpResponse, UtilsTestingTestSuperuserResponse, UtilsTestingTestRequirePermissionDpResponse, UtilsTestingTestGetTaskInfoData, UtilsTestingTestGetTaskInfoResponse } from './types.gen';
+import type { FeedbackCreateFeedbackData, FeedbackCreateFeedbackResponse, FeedbackListFeedbacksData, FeedbackListFeedbacksResponse, FeedbackGetFeedbackStatisticsResponse, FeedbackGetFeedbackData, FeedbackGetFeedbackResponse, FeedbackUpdateFeedbackData, FeedbackUpdateFeedbackResponse, FeedbackDeleteFeedbackData, FeedbackDeleteFeedbackResponse, LiveCodesCreateLiveCodeData, LiveCodesCreateLiveCodeResponse, LiveCodesListLiveCodesData, LiveCodesListLiveCodesResponse, LiveCodesGetLiveCodeData, LiveCodesGetLiveCodeResponse, LiveCodesUpdateLiveCodeData, LiveCodesUpdateLiveCodeResponse, LiveCodesDeleteLiveCodeData, LiveCodesDeleteLiveCodeResponse, LiveCodesAddTargetsData, LiveCodesAddTargetsResponse, LiveCodesUpdateTargetData, LiveCodesUpdateTargetResponse, LiveCodesDeleteTargetData, LiveCodesDeleteTargetResponse, LiveCodesResetTargetScanData, LiveCodesResetTargetScanResponse, LiveQrContactResponse, LiveQrTargetImageData, LiveQrTargetImageResponse, LiveQrLandingData, LiveQrLandingResponse, LiveQrScanImageData, LiveQrScanImageResponse, LiveQrPublicQrcodeData, LiveQrPublicQrcodeResponse, Llm4AdChatTuneGetSessionData, Llm4AdChatTuneGetSessionResponse, Llm4AdChatTuneResetSessionData, Llm4AdChatTuneResetSessionResponse, Llm4AdChatTuneStartTurnData, Llm4AdChatTuneStartTurnResponse, Llm4AdChatTuneStopTurnData, Llm4AdChatTuneStopTurnResponse, Llm4AdChatTuneRetryTurnData, Llm4AdChatTuneRetryTurnResponse, Llm4AdChatTuneChatTuneUploadFileData, Llm4AdChatTuneChatTuneUploadFileResponse, Llm4AdChatTuneChatTuneUploadDataData, Llm4AdChatTuneChatTuneUploadDataResponse, Llm4AdChatTuneStreamTurnData, Llm4AdChatTuneStreamTurnResponse, Llm4AdProjectsCreateProjectData, Llm4AdProjectsCreateProjectResponse, Llm4AdProjectsListProjectsData, Llm4AdProjectsListProjectsResponse, Llm4AdProjectsGetProjectData, Llm4AdProjectsGetProjectResponse, Llm4AdProjectsUpdateProjectData, Llm4AdProjectsUpdateProjectResponse, Llm4AdProjectsDeleteProjectData, Llm4AdProjectsDeleteProjectResponse, Llm4AdProvidersTestProviderData, Llm4AdProvidersTestProviderResponse, Llm4AdProvidersCreateProviderData, Llm4AdProvidersCreateProviderResponse, Llm4AdProvidersListProvidersData, Llm4AdProvidersListProvidersResponse, Llm4AdProvidersGetProviderData, Llm4AdProvidersGetProviderResponse, Llm4AdProvidersUpdateProviderData, Llm4AdProvidersUpdateProviderResponse, Llm4AdProvidersDeleteProviderData, Llm4AdProvidersDeleteProviderResponse, Llm4AdProvidersTestStoredProviderData, Llm4AdProvidersTestStoredProviderResponse, Llm4AdReportsGetReportTemplatesResponse, Llm4AdReportsGenerateReportData, Llm4AdReportsGenerateReportResponse, Llm4AdReportsGetReportData, Llm4AdReportsGetReportResponse, Llm4AdReportsStopReportData, Llm4AdReportsStopReportResponse, Llm4AdReportsStreamReportData, Llm4AdReportsStreamReportResponse, Llm4AdReportsGenerateAdviseData, Llm4AdReportsGenerateAdviseResponse, Llm4AdReportsGetAdviseData, Llm4AdReportsGetAdviseResponse, Llm4AdReportsGenerateRecommendData, Llm4AdReportsGenerateRecommendResponse, Llm4AdReportsGetRecommendData, Llm4AdReportsGetRecommendResponse, Llm4AdTasksListExampleTemplatesResponse, Llm4AdTasksListTasksData, Llm4AdTasksListTasksResponse, Llm4AdTasksGetTaskData, Llm4AdTasksGetTaskResponse, Llm4AdTasksUpdateTaskData, Llm4AdTasksUpdateTaskResponse, Llm4AdTasksDeleteTaskData, Llm4AdTasksDeleteTaskResponse, Llm4AdTasksCreateTaskData, Llm4AdTasksCreateTaskResponse, Llm4AdTasksUpdateTaskTagData, Llm4AdTasksUpdateTaskTagResponse, Llm4AdTasksSetActiveChildData, Llm4AdTasksSetActiveChildResponse, Llm4AdTasksGetTaskTreeData, Llm4AdTasksGetTaskTreeResponse, Llm4AdTasksCopyTaskData, Llm4AdTasksCopyTaskResponse, Llm4AdTasksRunTaskData, Llm4AdTasksRunTaskResponse, Llm4AdTasksStopTaskData, Llm4AdTasksStopTaskResponse, Llm4AdTasksGetTaskResultData, Llm4AdTasksGetTaskResultResponse, Llm4AdTasksGetTaskStatsData, Llm4AdTasksGetTaskStatsResponse, Llm4AdTasksGenerateResultRenderData, Llm4AdTasksGenerateResultRenderResponse, Llm4AdTasksGetConfigSchemaData, Llm4AdTasksGetConfigSchemaResponse, Llm4AdTasksUploadTaskDataData, Llm4AdTasksUploadTaskDataResponse, Llm4AdTasksGetTaskDataTreeData, Llm4AdTasksGetTaskDataTreeResponse, Llm4AdTasksCreateTaskDataFileData, Llm4AdTasksCreateTaskDataFileResponse, Llm4AdTasksGetTaskDataFileData, Llm4AdTasksGetTaskDataFileResponse, Llm4AdTasksUpdateTaskDataFileData, Llm4AdTasksUpdateTaskDataFileResponse, Llm4AdTasksDeleteTaskDataFileData, Llm4AdTasksDeleteTaskDataFileResponse, Llm4AdTasksRenameTaskDataFileData, Llm4AdTasksRenameTaskDataFileResponse, Llm4AdTasksCreateTaskDataFolderData, Llm4AdTasksCreateTaskDataFolderResponse, Llm4AdTasksDeleteTaskDataFolderData, Llm4AdTasksDeleteTaskDataFolderResponse, Llm4AdTasksRenameTaskDataFolderData, Llm4AdTasksRenameTaskDataFolderResponse, Llm4AdTasksGetTaskLogsData, Llm4AdTasksGetTaskLogsResponse, Llm4AdTasksStreamTaskLogsData, Llm4AdTasksStreamTaskLogsResponse, Llm4AdTasksCodeAuthResponse, Llm4AdUserDefaultModelsGetUserDefaultModelResponse, Llm4AdUserDefaultModelsUpdateUserDefaultModelData, Llm4AdUserDefaultModelsUpdateUserDefaultModelResponse, LoginLoginAccessTokenData, LoginLoginAccessTokenResponse, LoginRefreshAccessTokenData, LoginRefreshAccessTokenResponse, LoginRecoverPasswordData, LoginRecoverPasswordResponse, LoginResetPasswordData, LoginResetPasswordResponse, PermissionCreateData, PermissionCreateResponse, PermissionGetData, PermissionGetResponse, PermissionPermissionsResponse, PrivacyPolicyGetPrivacyPolicyContentData, PrivacyPolicyGetPrivacyPolicyContentResponse, PrivacyPolicyAcceptPrivacyPolicyAuthenticatedResponse, PrivacyPolicyAcceptPrivacyPolicyBeforeLoginData, PrivacyPolicyAcceptPrivacyPolicyBeforeLoginResponse, PrivacyPolicyCheckPrivacyPolicyStatusResponse, UsersReadUsersData, UsersReadUsersResponse, UsersCreateUserData, UsersCreateUserResponse, UsersReadUserMeResponse, UsersDeleteUserMeResponse, UsersUpdateUserMeData, UsersUpdateUserMeResponse, UsersUpdatePasswordMeData, UsersUpdatePasswordMeResponse, UsersRegisterUserData, UsersRegisterUserResponse, UsersVerifyEmailData, UsersVerifyEmailResponse, UsersResendVerifyCodeData, UsersResendVerifyCodeResponse, UsersReadUserByIdData, UsersReadUserByIdResponse, UsersUpdateUserData, UsersUpdateUserResponse, UsersDeleteUserData, UsersDeleteUserResponse, UtilsTestEmailData, UtilsTestEmailResponse, UtilsHealthCheckResponse, UtilsFeatureFlagsResponse, UtilsCodeServerGetCodeTokenData, UtilsCodeServerGetCodeTokenResponse, UtilsTestingTestS3Response, UtilsTestingTestCurrentUserDpResponse, UtilsTestingTestCurrentUserResponse, UtilsTestingTestSuperuserDpResponse, UtilsTestingTestSuperuserResponse, UtilsTestingTestRequirePermissionDpResponse, UtilsTestingTestGetTaskInfoData, UtilsTestingTestGetTaskInfoResponse } from './types.gen';
 
 export class FeedbackService {
     /**
@@ -36,7 +36,7 @@ export class FeedbackService {
             }
         });
     }
-
+    
     /**
      * 查询反馈列表
      * 查询反馈列表。
@@ -79,7 +79,7 @@ export class FeedbackService {
             }
         });
     }
-
+    
     /**
      * 获取反馈统计信息（管理员）
      * 获取反馈统计信息。
@@ -104,7 +104,7 @@ export class FeedbackService {
             url: '/api/v1/feedback/statistics'
         });
     }
-
+    
     /**
      * 获取反馈详情
      * 获取单个反馈的详细信息。
@@ -139,7 +139,7 @@ export class FeedbackService {
             }
         });
     }
-
+    
     /**
      * 更新反馈（管理员）
      * 更新反馈信息。
@@ -178,7 +178,7 @@ export class FeedbackService {
             }
         });
     }
-
+    
     /**
      * 删除反馈（管理员）
      * 删除反馈。
@@ -234,7 +234,7 @@ export class LiveCodesService {
             }
         });
     }
-
+    
     /**
      * 分页查询活码列表
      * 分页查询全部活码（全管理员共享）。
@@ -257,7 +257,7 @@ export class LiveCodesService {
             }
         });
     }
-
+    
     /**
      * 获取活码详情
      * 获取活码详情，包含全部真实群码及其实时有效状态。
@@ -278,7 +278,7 @@ export class LiveCodesService {
             }
         });
     }
-
+    
     /**
      * 更新活码
      * 更新活码名称、切换策略、落地页文案、启用状态等。
@@ -302,7 +302,7 @@ export class LiveCodesService {
             }
         });
     }
-
+    
     /**
      * 删除活码
      * 删除活码及其全部真实群码（含对象存储清理）。
@@ -323,7 +323,7 @@ export class LiveCodesService {
             }
         });
     }
-
+    
     /**
      * 批量上传真实群码
      * 为活码批量上传真实群码图片，统一设置有效期与扫码上限。
@@ -347,7 +347,7 @@ export class LiveCodesService {
             }
         });
     }
-
+    
     /**
      * 更新真实群码
      * 更新真实群码的备注、过期时间、扫码上限、启用状态、排序。
@@ -373,7 +373,7 @@ export class LiveCodesService {
             }
         });
     }
-
+    
     /**
      * 删除真实群码
      * 删除某张真实群码（含对象存储清理）。
@@ -396,7 +396,7 @@ export class LiveCodesService {
             }
         });
     }
-
+    
     /**
      * 重置真实群码扫码计数
      * 将某张真实群码的扫码计数清零，便于满员后复用同一张群码。
@@ -437,7 +437,7 @@ export class LiveQrService {
             url: '/api/v1/live-qr/contact'
         });
     }
-
+    
     /**
      * 真实群码图片（公开）
      * 按 target_id 返回真实群码图片，免鉴权、内联、不计扫码数。
@@ -461,7 +461,7 @@ export class LiveQrService {
             }
         });
     }
-
+    
     /**
      * 活码落地页
      * 渲染活码落地页：展示当前有效群码与长按识别引导，永久不变。
@@ -482,7 +482,7 @@ export class LiveQrService {
             }
         });
     }
-
+    
     /**
      * 当前有效群码图片
      * 返回当前有效的真实群码图片，并累计扫码计数（同一客户端去重）。
@@ -510,7 +510,7 @@ export class LiveQrService {
             }
         });
     }
-
+    
     /**
      * 活码永久二维码 PNG（公开）
      * 返回活码的永久二维码 PNG（编码对外落地页 URL），免鉴权可直接用于 ``<img>``。
@@ -565,7 +565,7 @@ export class Llm4AdChatTuneService {
             }
         });
     }
-
+    
     /**
      * Reset chat tune history for a task
      * 清空任务的调参对话历史，会话保留并重置为初始配置。
@@ -586,7 +586,7 @@ export class Llm4AdChatTuneService {
             }
         });
     }
-
+    
     /**
      * Start a new chat tune turn for a task
      * 触发新一轮调参生成。
@@ -622,7 +622,7 @@ export class Llm4AdChatTuneService {
             }
         });
     }
-
+    
     /**
      * Stop the current chat tune turn
      * 停止指定轮次的生成。幂等：对已结束的轮次返回当前状态。
@@ -645,7 +645,7 @@ export class Llm4AdChatTuneService {
             }
         });
     }
-
+    
     /**
      * Retry a failed or stopped chat tune turn
      * 对失败或已停止的轮次原地重跑。
@@ -684,7 +684,7 @@ export class Llm4AdChatTuneService {
             }
         });
     }
-
+    
     /**
      * 调参对话中上传文件到任务数据目录
      * 上传文件到 ``input_data_path`` 下的第一个子目录。
@@ -720,7 +720,7 @@ export class Llm4AdChatTuneService {
             }
         });
     }
-
+    
     /**
      * 调参对话中上传目录到任务数据目录
      * 上传目录到 ``input_data_path`` 下的第一个子目录。
@@ -757,7 +757,7 @@ export class Llm4AdChatTuneService {
             }
         });
     }
-
+    
     /**
      * SSE stream for a chat tune turn
      * SSE 端点：实时推送指定轮次的调参生成进度。
@@ -797,324 +797,6 @@ export class Llm4AdChatTuneService {
     }
 }
 
-export class Llm4AdEmbeddingProvidersService {
-    /**
-     * 测试 embedding 供应商配置连通性
-     * @param data The data for the request.
-     * @param data.requestBody
-     * @returns EmbeddingProviderTestResponse Successful Response
-     * @throws ApiError
-     */
-    public static testEmbeddingProvider(data: Llm4AdEmbeddingProvidersTestEmbeddingProviderData): CancelablePromise<Llm4AdEmbeddingProvidersTestEmbeddingProviderResponse> {
-        return __request(OpenAPI, {
-            method: 'POST',
-            url: '/api/v1/llm4ad/embedding-providers/test',
-            body: data.requestBody,
-            mediaType: 'application/json',
-            errors: {
-                422: 'Validation Error'
-            }
-        });
-    }
-
-    /**
-     * 创建 embedding 供应商配置
-     * @param data The data for the request.
-     * @param data.requestBody
-     * @returns EmbeddingProviderResponse Successful Response
-     * @throws ApiError
-     */
-    public static createEmbeddingProvider(data: Llm4AdEmbeddingProvidersCreateEmbeddingProviderData): CancelablePromise<Llm4AdEmbeddingProvidersCreateEmbeddingProviderResponse> {
-        return __request(OpenAPI, {
-            method: 'POST',
-            url: '/api/v1/llm4ad/embedding-providers/',
-            body: data.requestBody,
-            mediaType: 'application/json',
-            errors: {
-                422: 'Validation Error'
-            }
-        });
-    }
-
-    /**
-     * 分页查询 embedding 供应商配置列表
-     * @param data The data for the request.
-     * @param data.skip
-     * @param data.limit
-     * @returns PaginatedEmbeddingProviderResponse Successful Response
-     * @throws ApiError
-     */
-    public static listEmbeddingProviders(data: Llm4AdEmbeddingProvidersListEmbeddingProvidersData = {}): CancelablePromise<Llm4AdEmbeddingProvidersListEmbeddingProvidersResponse> {
-        return __request(OpenAPI, {
-            method: 'GET',
-            url: '/api/v1/llm4ad/embedding-providers/',
-            query: {
-                skip: data.skip,
-                limit: data.limit
-            },
-            errors: {
-                422: 'Validation Error'
-            }
-        });
-    }
-
-    /**
-     * 获取单个 embedding 供应商配置详情
-     * @param data The data for the request.
-     * @param data.providerId
-     * @returns EmbeddingProviderResponse Successful Response
-     * @throws ApiError
-     */
-    public static getEmbeddingProvider(data: Llm4AdEmbeddingProvidersGetEmbeddingProviderData): CancelablePromise<Llm4AdEmbeddingProvidersGetEmbeddingProviderResponse> {
-        return __request(OpenAPI, {
-            method: 'GET',
-            url: '/api/v1/llm4ad/embedding-providers/{provider_id}',
-            path: {
-                provider_id: data.providerId
-            },
-            errors: {
-                422: 'Validation Error'
-            }
-        });
-    }
-
-    /**
-     * 更新 embedding 供应商配置
-     * @param data The data for the request.
-     * @param data.providerId
-     * @param data.requestBody
-     * @returns EmbeddingProviderResponse Successful Response
-     * @throws ApiError
-     */
-    public static updateEmbeddingProvider(data: Llm4AdEmbeddingProvidersUpdateEmbeddingProviderData): CancelablePromise<Llm4AdEmbeddingProvidersUpdateEmbeddingProviderResponse> {
-        return __request(OpenAPI, {
-            method: 'PATCH',
-            url: '/api/v1/llm4ad/embedding-providers/{provider_id}',
-            path: {
-                provider_id: data.providerId
-            },
-            body: data.requestBody,
-            mediaType: 'application/json',
-            errors: {
-                422: 'Validation Error'
-            }
-        });
-    }
-
-    /**
-     * 删除 embedding 供应商配置
-     * @param data The data for the request.
-     * @param data.providerId
-     * @returns Message Successful Response
-     * @throws ApiError
-     */
-    public static deleteEmbeddingProvider(data: Llm4AdEmbeddingProvidersDeleteEmbeddingProviderData): CancelablePromise<Llm4AdEmbeddingProvidersDeleteEmbeddingProviderResponse> {
-        return __request(OpenAPI, {
-            method: 'DELETE',
-            url: '/api/v1/llm4ad/embedding-providers/{provider_id}',
-            path: {
-                provider_id: data.providerId
-            },
-            errors: {
-                422: 'Validation Error'
-            }
-        });
-    }
-
-    /**
-     * 测试已存储 embedding 供应商配置连通性
-     * @param data The data for the request.
-     * @param data.providerId
-     * @param data.requestBody
-     * @returns EmbeddingProviderTestResponse Successful Response
-     * @throws ApiError
-     */
-    public static testStoredEmbeddingProvider(data: Llm4AdEmbeddingProvidersTestStoredEmbeddingProviderData): CancelablePromise<Llm4AdEmbeddingProvidersTestStoredEmbeddingProviderResponse> {
-        return __request(OpenAPI, {
-            method: 'POST',
-            url: '/api/v1/llm4ad/embedding-providers/{provider_id}/test',
-            path: {
-                provider_id: data.providerId
-            },
-            body: data.requestBody,
-            mediaType: 'application/json',
-            errors: {
-                422: 'Validation Error'
-            }
-        });
-    }
-}
-
-export class Llm4AdLlmproxyService {
-    /**
-     * Proxy Llm
-     * 透明反向代理：校验代理 token 后用真实凭据转发到上游大模型。
-     *
-     * Args:
-     * path: 上游 API 子路径（如 ``chat/completions`` 或 ``v1/messages``）。
-     * request: 原始入站请求。
-     *
-     * Returns:
-     * 透传上游响应的 ``StreamingResponse``，或鉴权失败时的错误响应。
-     * @param data The data for the request.
-     * @param data.path
-     * @returns unknown Successful Response
-     * @throws ApiError
-     */
-    public static proxyLlm(data: Llm4AdLlmproxyProxyLlmData): CancelablePromise<Llm4AdLlmproxyProxyLlmResponse> {
-        return __request(OpenAPI, {
-            method: 'OPTIONS',
-            url: '/api/v1/llm4ad/llmproxy/{path}',
-            path: {
-                path: data.path
-            },
-            errors: {
-                422: 'Validation Error'
-            }
-        });
-    }
-
-    /**
-     * Proxy Llm
-     * 透明反向代理：校验代理 token 后用真实凭据转发到上游大模型。
-     *
-     * Args:
-     * path: 上游 API 子路径（如 ``chat/completions`` 或 ``v1/messages``）。
-     * request: 原始入站请求。
-     *
-     * Returns:
-     * 透传上游响应的 ``StreamingResponse``，或鉴权失败时的错误响应。
-     * @param data The data for the request.
-     * @param data.path
-     * @returns unknown Successful Response
-     * @throws ApiError
-     */
-    public static proxyLlm1(data: Llm4AdLlmproxyProxyLlm1Data): CancelablePromise<Llm4AdLlmproxyProxyLlm1Response> {
-        return __request(OpenAPI, {
-            method: 'GET',
-            url: '/api/v1/llm4ad/llmproxy/{path}',
-            path: {
-                path: data.path
-            },
-            errors: {
-                422: 'Validation Error'
-            }
-        });
-    }
-
-    /**
-     * Proxy Llm
-     * 透明反向代理：校验代理 token 后用真实凭据转发到上游大模型。
-     *
-     * Args:
-     * path: 上游 API 子路径（如 ``chat/completions`` 或 ``v1/messages``）。
-     * request: 原始入站请求。
-     *
-     * Returns:
-     * 透传上游响应的 ``StreamingResponse``，或鉴权失败时的错误响应。
-     * @param data The data for the request.
-     * @param data.path
-     * @returns unknown Successful Response
-     * @throws ApiError
-     */
-    public static proxyLlm2(data: Llm4AdLlmproxyProxyLlm2Data): CancelablePromise<Llm4AdLlmproxyProxyLlm2Response> {
-        return __request(OpenAPI, {
-            method: 'POST',
-            url: '/api/v1/llm4ad/llmproxy/{path}',
-            path: {
-                path: data.path
-            },
-            errors: {
-                422: 'Validation Error'
-            }
-        });
-    }
-
-    /**
-     * Proxy Llm
-     * 透明反向代理：校验代理 token 后用真实凭据转发到上游大模型。
-     *
-     * Args:
-     * path: 上游 API 子路径（如 ``chat/completions`` 或 ``v1/messages``）。
-     * request: 原始入站请求。
-     *
-     * Returns:
-     * 透传上游响应的 ``StreamingResponse``，或鉴权失败时的错误响应。
-     * @param data The data for the request.
-     * @param data.path
-     * @returns unknown Successful Response
-     * @throws ApiError
-     */
-    public static proxyLlm3(data: Llm4AdLlmproxyProxyLlm3Data): CancelablePromise<Llm4AdLlmproxyProxyLlm3Response> {
-        return __request(OpenAPI, {
-            method: 'DELETE',
-            url: '/api/v1/llm4ad/llmproxy/{path}',
-            path: {
-                path: data.path
-            },
-            errors: {
-                422: 'Validation Error'
-            }
-        });
-    }
-
-    /**
-     * Proxy Llm
-     * 透明反向代理：校验代理 token 后用真实凭据转发到上游大模型。
-     *
-     * Args:
-     * path: 上游 API 子路径（如 ``chat/completions`` 或 ``v1/messages``）。
-     * request: 原始入站请求。
-     *
-     * Returns:
-     * 透传上游响应的 ``StreamingResponse``，或鉴权失败时的错误响应。
-     * @param data The data for the request.
-     * @param data.path
-     * @returns unknown Successful Response
-     * @throws ApiError
-     */
-    public static proxyLlm4(data: Llm4AdLlmproxyProxyLlm4Data): CancelablePromise<Llm4AdLlmproxyProxyLlm4Response> {
-        return __request(OpenAPI, {
-            method: 'PUT',
-            url: '/api/v1/llm4ad/llmproxy/{path}',
-            path: {
-                path: data.path
-            },
-            errors: {
-                422: 'Validation Error'
-            }
-        });
-    }
-
-    /**
-     * Proxy Llm
-     * 透明反向代理：校验代理 token 后用真实凭据转发到上游大模型。
-     *
-     * Args:
-     * path: 上游 API 子路径（如 ``chat/completions`` 或 ``v1/messages``）。
-     * request: 原始入站请求。
-     *
-     * Returns:
-     * 透传上游响应的 ``StreamingResponse``，或鉴权失败时的错误响应。
-     * @param data The data for the request.
-     * @param data.path
-     * @returns unknown Successful Response
-     * @throws ApiError
-     */
-    public static proxyLlm5(data: Llm4AdLlmproxyProxyLlm5Data): CancelablePromise<Llm4AdLlmproxyProxyLlm5Response> {
-        return __request(OpenAPI, {
-            method: 'PATCH',
-            url: '/api/v1/llm4ad/llmproxy/{path}',
-            path: {
-                path: data.path
-            },
-            errors: {
-                422: 'Validation Error'
-            }
-        });
-    }
-}
-
 export class Llm4AdProjectsService {
     /**
      * 创建新项目（属于当前用户）
@@ -1143,7 +825,7 @@ export class Llm4AdProjectsService {
             }
         });
     }
-
+    
     /**
      * 分页查询项目列表
      * 分页查询当前用户的所有项目。
@@ -1184,7 +866,7 @@ export class Llm4AdProjectsService {
             }
         });
     }
-
+    
     /**
      * 获取单个项目详情
      * 获取项目详情。
@@ -1213,7 +895,7 @@ export class Llm4AdProjectsService {
             }
         });
     }
-
+    
     /**
      * 更新项目信息
      * 更新项目的名称或描述。
@@ -1248,7 +930,7 @@ export class Llm4AdProjectsService {
             }
         });
     }
-
+    
     /**
      * 删除项目（同时删除其下的所有任务）
      * 删除项目及其关联的所有任务（级联删除）。
@@ -1305,7 +987,7 @@ export class Llm4AdProvidersService {
             }
         });
     }
-
+    
     /**
      * 创建新供应商配置（属于当前用户）
      * 创建一个新的 LLM 供应商配置，自动关联到当前登录用户。
@@ -1333,7 +1015,7 @@ export class Llm4AdProvidersService {
             }
         });
     }
-
+    
     /**
      * 分页查询供应商配置列表
      * 分页查询当前用户的所有供应商配置。
@@ -1365,7 +1047,7 @@ export class Llm4AdProvidersService {
             }
         });
     }
-
+    
     /**
      * 获取单个供应商配置详情
      * 获取供应商配置详情。
@@ -1394,7 +1076,7 @@ export class Llm4AdProvidersService {
             }
         });
     }
-
+    
     /**
      * 更新供应商配置
      * 更新供应商配置信息。
@@ -1429,7 +1111,7 @@ export class Llm4AdProvidersService {
             }
         });
     }
-
+    
     /**
      * 删除供应商配置
      * 删除指定的供应商配置。
@@ -1458,7 +1140,7 @@ export class Llm4AdProvidersService {
             }
         });
     }
-
+    
     /**
      * 测试已存储供应商的联通性（按 ID）
      * Test connectivity of a stored provider using its persisted credentials.
@@ -1517,7 +1199,7 @@ export class Llm4AdReportsService {
             url: '/api/v1/llm4ad/tasks/reports/report-templates'
         });
     }
-
+    
     /**
      * Trigger evolution insight report generation
      * 触发指定任务的报告后台生成。
@@ -1553,7 +1235,7 @@ export class Llm4AdReportsService {
             }
         });
     }
-
+    
     /**
      * Get a specific report
      * 从数据库读取指定类型的报告内容。
@@ -1585,7 +1267,7 @@ export class Llm4AdReportsService {
             }
         });
     }
-
+    
     /**
      * Stop report generation
      * 停止指定类型报告的生成过程。
@@ -1619,7 +1301,7 @@ export class Llm4AdReportsService {
             }
         });
     }
-
+    
     /**
      * SSE stream for report generation progress
      * SSE 端点：实时推送报告生成进度。
@@ -1661,7 +1343,7 @@ export class Llm4AdReportsService {
             }
         });
     }
-
+    
     /**
      * Trigger evolve-block advise generation
      * 触发进化块分析建议的后台生成。
@@ -1698,7 +1380,7 @@ export class Llm4AdReportsService {
             }
         });
     }
-
+    
     /**
      * Get cached block advise result
      * 获取缓存的进化块分析建议结果。
@@ -1727,7 +1409,7 @@ export class Llm4AdReportsService {
             }
         });
     }
-
+    
     /**
      * Trigger evolve-block recommend generation
      * 触发进化块推荐的后台生成。
@@ -1764,7 +1446,7 @@ export class Llm4AdReportsService {
             }
         });
     }
-
+    
     /**
      * Get cached block recommend result
      * 获取缓存的进化块推荐结果。
@@ -1808,7 +1490,7 @@ export class Llm4AdTasksService {
             url: '/api/v1/llm4ad/tasks/templates'
         });
     }
-
+    
     /**
      * 获取项目下的任务列表
      * 分页查询指定项目下的所有任务。
@@ -1833,7 +1515,7 @@ export class Llm4AdTasksService {
             }
         });
     }
-
+    
     /**
      * 获取任务详情
      * 获取单个任务的详细信息，包含存储用量。
@@ -1854,7 +1536,7 @@ export class Llm4AdTasksService {
             }
         });
     }
-
+    
     /**
      * 修改任务参数
      * 修改任务的名称、描述或运行参数。
@@ -1878,7 +1560,7 @@ export class Llm4AdTasksService {
             }
         });
     }
-
+    
     /**
      * 删除任务
      * 删除任务及其关联的存储数据。任务运行中（pending/running）时不允许操作，需先停止任务。
@@ -1899,7 +1581,7 @@ export class Llm4AdTasksService {
             }
         });
     }
-
+    
     /**
      * 创建任务（自动生成默认参数）
      * 创建新任务。若未提供 input_args，将自动填充 AppConfig 默认值。
@@ -1919,7 +1601,7 @@ export class Llm4AdTasksService {
             }
         });
     }
-
+    
     /**
      * 修改任务标签
      * 修改任务的标签。
@@ -1943,7 +1625,7 @@ export class Llm4AdTasksService {
             }
         });
     }
-
+    
     /**
      * 设置根任务当前选中的子任务版本
      * 设置根任务的活跃子版本。传 child_id=null 可清除选中（读取时默认回退为指向自身）。
@@ -1967,7 +1649,7 @@ export class Llm4AdTasksService {
             }
         });
     }
-
+    
     /**
      * 获取任务树
      * 根据根任务 ID 获取任务树，包含根任务及其所有子任务的常用信息。
@@ -1988,7 +1670,7 @@ export class Llm4AdTasksService {
             }
         });
     }
-
+    
     /**
      * 复制任务
      * 复制指定任务，名称加后缀，数据存在则复制一份，状态重置为未初始化。
@@ -2012,7 +1694,7 @@ export class Llm4AdTasksService {
             }
         });
     }
-
+    
     /**
      * 运行任务（提交到Celery）
      * 运行指定任务，提交到 Celery 异步执行。
@@ -2033,7 +1715,7 @@ export class Llm4AdTasksService {
             }
         });
     }
-
+    
     /**
      * 停止任务
      * 停止正在运行或等待中的任务，撤销 Celery 任务并将状态置为失败。
@@ -2054,7 +1736,7 @@ export class Llm4AdTasksService {
             }
         });
     }
-
+    
     /**
      * 获取任务在Celery中的执行结果
      * 查询任务的 Celery 执行结果，并将状态同步回数据库。
@@ -2075,7 +1757,7 @@ export class Llm4AdTasksService {
             }
         });
     }
-
+    
     /**
      * 获取任务基本统计信息
      * 获取任务的基本统计信息：解的个数、解的平均分、解的最高分。
@@ -2096,7 +1778,7 @@ export class Llm4AdTasksService {
             }
         });
     }
-
+    
     /**
      * 生成任务结果渲染数据
      * 生成指定任务的结果渲染数据。
@@ -2123,7 +1805,7 @@ export class Llm4AdTasksService {
             }
         });
     }
-
+    
     /**
      * 获取参数配置的schema
      * 获取参数配置的schema。
@@ -2144,28 +1826,7 @@ export class Llm4AdTasksService {
             }
         });
     }
-
-    /**
-     * 下载任务 IDE 工作区
-     * Download the authorized task IDE workspace as a ZIP archive.
-     * @param data The data for the request.
-     * @param data.taskId
-     * @returns unknown Successful Response
-     * @throws ApiError
-     */
-    public static downloadTaskWorkspace(data: Llm4AdTasksDownloadTaskWorkspaceData): CancelablePromise<Llm4AdTasksDownloadTaskWorkspaceResponse> {
-        return __request(OpenAPI, {
-            method: 'GET',
-            url: '/api/v1/llm4ad/tasks/{task_id}/workspace/download',
-            path: {
-                task_id: data.taskId
-            },
-            errors: {
-                422: 'Validation Error'
-            }
-        });
-    }
-
+    
     /**
      * 批量上传任务输入数据文件
      * 批量上传任务的输入数据文件到 S3 存储。
@@ -2189,7 +1850,7 @@ export class Llm4AdTasksService {
             }
         });
     }
-
+    
     /**
      * 获取任务输入数据的目录树
      * 获取任务 input_data_path 对应存储中的文件目录树。
@@ -2210,7 +1871,7 @@ export class Llm4AdTasksService {
             }
         });
     }
-
+    
     /**
      * 在任务输入数据中创建新文件
      * 在任务输入数据目录中创建一个带 hello-world 示例的 Python 文件。
@@ -2234,7 +1895,7 @@ export class Llm4AdTasksService {
             }
         });
     }
-
+    
     /**
      * 获取任务输入数据中的文件内容
      * 获取任务输入数据目录中指定文件的文本内容。
@@ -2259,7 +1920,7 @@ export class Llm4AdTasksService {
             }
         });
     }
-
+    
     /**
      * 修改任务输入数据中的文件内容
      * 修改任务输入数据目录中指定文件的内容。内容以 UTF-8 写入；是否允许编辑由前端控制。
@@ -2283,7 +1944,7 @@ export class Llm4AdTasksService {
             }
         });
     }
-
+    
     /**
      * 删除任务输入数据中的文件
      * 删除任务输入数据目录中的指定文件。
@@ -2308,7 +1969,7 @@ export class Llm4AdTasksService {
             }
         });
     }
-
+    
     /**
      * 重命名任务输入数据中的文件
      * 重命名任务输入数据目录中的指定文件。
@@ -2332,7 +1993,7 @@ export class Llm4AdTasksService {
             }
         });
     }
-
+    
     /**
      * 在任务输入数据中创建子文件夹（占位文件方式）
      * 在已有目录下新建空文件夹，通过写入占位文件标记目录存在。不支持创建顶级文件夹。
@@ -2356,7 +2017,7 @@ export class Llm4AdTasksService {
             }
         });
     }
-
+    
     /**
      * 删除任务输入数据中的文件夹（递归）
      * 递归删除指定文件夹及其所有内容。
@@ -2381,7 +2042,7 @@ export class Llm4AdTasksService {
             }
         });
     }
-
+    
     /**
      * 重命名任务输入数据中的文件夹
      * 重命名任务输入数据目录中的指定文件夹（递归 copy + delete）。
@@ -2405,7 +2066,7 @@ export class Llm4AdTasksService {
             }
         });
     }
-
+    
     /**
      * 获取任务日志（游标分页，倒序查询）
      * 获取任务日志，游标分页倒序查询。首次加载最新一页，后续向前翻页。
@@ -2438,7 +2099,7 @@ export class Llm4AdTasksService {
             }
         });
     }
-
+    
     /**
      * SSE 实时日志流
      * SSE 端点，实时推送任务日志和状态更新。
@@ -2466,7 +2127,7 @@ export class Llm4AdTasksService {
             }
         });
     }
-
+    
     /**
      * code认证
      * 验证 code-server 请求的 cookie token，返回用户信息用于 iframe 代理。
@@ -2501,7 +2162,7 @@ export class Llm4AdUserDefaultModelsService {
             url: '/api/v1/llm4ad/user-default-models/'
         });
     }
-
+    
     /**
      * 更新当前用户的默认模型配置
      * 更新当前用户的默认模型配置。
@@ -2566,7 +2227,7 @@ export class LoginService {
             }
         });
     }
-
+    
     /**
      * 刷新token
      * 使用刷新令牌获取新的访问令牌和刷新令牌。
@@ -2599,7 +2260,7 @@ export class LoginService {
             }
         });
     }
-
+    
     /**
      * 找回密码申请
      * 发起密码找回流程，向用户邮箱发送重置链接。
@@ -2632,7 +2293,7 @@ export class LoginService {
             }
         });
     }
-
+    
     /**
      * 重置密码
      * 使用重置令牌设置新密码。
@@ -2693,7 +2354,7 @@ export class PermissionService {
             }
         });
     }
-
+    
     /**
      * Get
      * 根据主键获取单个权限（仅超级管理员）。
@@ -2721,7 +2382,7 @@ export class PermissionService {
             }
         });
     }
-
+    
     /**
      * Permissions
      * 获取所有权限列表（仅超级管理员）。
@@ -2769,7 +2430,7 @@ export class PrivacyPolicyService {
             }
         });
     }
-
+    
     /**
      * Accept Privacy Policy Authenticated
      * 已登录用户同意隐私协议。
@@ -2794,7 +2455,7 @@ export class PrivacyPolicyService {
             url: '/api/v1/privacy-policy/accept'
         });
     }
-
+    
     /**
      * Accept Privacy Policy Before Login
      * 登录前同意隐私协议。
@@ -2826,7 +2487,7 @@ export class PrivacyPolicyService {
             }
         });
     }
-
+    
     /**
      * Check Privacy Policy Status
      * 检查当前用户的隐私协议同意状态。
@@ -2880,7 +2541,7 @@ export class UsersService {
             }
         });
     }
-
+    
     /**
      * Create User
      * 管理员创建新用户，创建成功后发送欢迎邮件。
@@ -2913,7 +2574,7 @@ export class UsersService {
             }
         });
     }
-
+    
     /**
      * Read User Me
      * 获取当前登录用户信息。
@@ -2926,7 +2587,7 @@ export class UsersService {
             url: '/api/v1/users/me'
         });
     }
-
+    
     /**
      * Delete User Me
      * 删除当前登录用户账号（超级管理员不可自删）。
@@ -2949,7 +2610,7 @@ export class UsersService {
             url: '/api/v1/users/me'
         });
     }
-
+    
     /**
      * Update User Me
      * 更新当前登录用户的个人信息。
@@ -2982,7 +2643,7 @@ export class UsersService {
             }
         });
     }
-
+    
     /**
      * Update Password Me
      * 修改当前登录用户的密码。
@@ -3015,7 +2676,7 @@ export class UsersService {
             }
         });
     }
-
+    
     /**
      * Register User
      * 用户自助注册，注册后发送邮箱验证码。
@@ -3048,7 +2709,7 @@ export class UsersService {
             }
         });
     }
-
+    
     /**
      * Verify Email
      * 校验邮箱验证码，验证通过后标记用户邮箱已验证。
@@ -3078,7 +2739,7 @@ export class UsersService {
             }
         });
     }
-
+    
     /**
      * Resend Verify Code
      * 重新发送邮箱验证码。
@@ -3110,7 +2771,7 @@ export class UsersService {
             }
         });
     }
-
+    
     /**
      * Read User By Id
      * 根据 ID 获取用户信息。
@@ -3144,7 +2805,7 @@ export class UsersService {
             }
         });
     }
-
+    
     /**
      * Update User
      * 管理员更新指定用户信息。
@@ -3181,7 +2842,7 @@ export class UsersService {
             }
         });
     }
-
+    
     /**
      * Delete User
      * 管理员删除指定用户（不可删除自己）。
@@ -3246,7 +2907,7 @@ export class UtilsService {
             }
         });
     }
-
+    
     /**
      * Health Check
      * 健康检查端点。
@@ -3262,6 +2923,21 @@ export class UtilsService {
         return __request(OpenAPI, {
             method: 'GET',
             url: '/api/v1/utils/health-check/'
+        });
+    }
+
+    /**
+     * Feature Flags
+     * 返回前端可见的特性开关。
+     *
+     * 前端据此决定是否展示可选 UI（如 "AI 构建 (Beta)" 入口）。
+     * @returns FeatureFlags Successful Response
+     * @throws ApiError
+     */
+    public static featureFlags(): CancelablePromise<UtilsFeatureFlagsResponse> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/api/v1/utils/features/'
         });
     }
 }
@@ -3317,7 +2993,7 @@ export class UtilsTestingService {
             url: '/api/v1/utils/test_s3'
         });
     }
-
+    
     /**
      * 测试当前用户依赖
      * 测试 require_user 依赖注入是否正常工作。
@@ -3330,7 +3006,7 @@ export class UtilsTestingService {
             url: '/api/v1/utils/test_current_user_dp'
         });
     }
-
+    
     /**
      * 测试当前用户
      * 测试获取当前登录用户信息。
@@ -3343,7 +3019,7 @@ export class UtilsTestingService {
             url: '/api/v1/utils/test_current_user'
         });
     }
-
+    
     /**
      * 测试需要超管权限依赖
      * 测试 require_superuser 依赖注入是否正常工作。
@@ -3356,7 +3032,7 @@ export class UtilsTestingService {
             url: '/api/v1/utils/test_superuser_dp'
         });
     }
-
+    
     /**
      * 测试需要超管权限
      * 测试获取超级管理员用户信息。
@@ -3369,7 +3045,7 @@ export class UtilsTestingService {
             url: '/api/v1/utils/test_superuser'
         });
     }
-
+    
     /**
      * 测试需要特定权限依赖（超管除外）
      * 测试 require_permission 依赖注入（需 item:read 权限）。
@@ -3382,7 +3058,7 @@ export class UtilsTestingService {
             url: '/api/v1/utils/test_require_permission_dp'
         });
     }
-
+    
     /**
      * 测试获取任务信息
      * 测试查询 Celery 任务状态（注意：Celery 永远能返回结果，需自行维护任务表）。

--- a/src/frontend/src/client/types.gen.ts
+++ b/src/frontend/src/client/types.gen.ts
@@ -421,36 +421,8 @@ export type EmbeddingProviderCreate = {
     code_task?: string;
 };
 
-/**
- * Embedding 供应商响应，凭据不返回明文。
- */
 export type EmbeddingProviderResponse = {
-    id: string;
-    created_time: string;
-    updated_time: string;
-    user_id: string;
-    name: string;
-    type: EmbeddingProviderType;
-    api_key: string;
-    auth_token: string;
-    base_url: (string | null);
-    mode: EmbeddingMode;
-    model: string;
-    dim: number;
-    timeout: number;
-    embedding_func_max_async: number;
-    text_type: EmbeddingProviderType;
-    text_base_url: (string | null);
-    text_api_key: string;
-    text_auth_token: string;
-    text_model: string;
-    text_task: string;
-    code_type: EmbeddingProviderType;
-    code_base_url: (string | null);
-    code_api_key: string;
-    code_auth_token: string;
-    code_model: string;
-    code_task: string;
+    [key: string]: unknown;
 };
 
 /**
@@ -662,6 +634,13 @@ export type ExampleTemplateListResponse = {
      * 可用的示例模板列表
      */
     templates?: Array<ExampleTemplateItem>;
+};
+
+/**
+ * Public feature flags the frontend uses to show/hide optional UI.
+ */
+export type FeatureFlags = {
+    enable_ai_agent_build: boolean;
 };
 
 /**
@@ -2750,7 +2729,7 @@ export type Llm4AdTasksGetTaskLogsData = {
      */
     limit?: number;
     /**
-     * 按日志类型过滤
+     * 按日志类型过滤，多个用英文逗号分隔
      */
     logType?: (string | null);
     /**
@@ -2907,10 +2886,6 @@ export type UtilsTestEmailData = {
 export type UtilsTestEmailResponse = (Message);
 
 export type UtilsHealthCheckResponse = (boolean);
-
-export type FeatureFlags = {
-    enable_ai_agent_build: boolean;
-};
 
 export type UtilsFeatureFlagsResponse = (FeatureFlags);
 

--- a/src/frontend/src/client/types.gen.ts
+++ b/src/frontend/src/client/types.gen.ts
@@ -272,6 +272,10 @@ export type ChatTuneTurnStartRequest = {
      * 本轮对话使用的语言（zh/en），驱动 LLM 回答语言
      */
     language?: 'zh' | 'en';
+    /**
+     * 是否走 AI 构建 (Beta)：用 AgentScope 单 agent 构建。仅当后端 ENABLE_AI_AGENT_BUILD 开启时生效，否则忽略并回退到默认分发。
+     */
+    beta?: boolean;
 };
 
 /**
@@ -2903,6 +2907,12 @@ export type UtilsTestEmailData = {
 export type UtilsTestEmailResponse = (Message);
 
 export type UtilsHealthCheckResponse = (boolean);
+
+export type FeatureFlags = {
+    enable_ai_agent_build: boolean;
+};
+
+export type UtilsFeatureFlagsResponse = (FeatureFlags);
 
 export type UtilsCodeServerGetCodeTokenData = {
     /**

--- a/src/frontend/src/components/Evolution/TaskDetail/ChatTuneView.tsx
+++ b/src/frontend/src/components/Evolution/TaskDetail/ChatTuneView.tsx
@@ -63,7 +63,7 @@ import type {
   ProviderResponse,
   TaskResponse,
 } from "@/client"
-import { Llm4AdChatTuneService, Llm4AdTasksService } from "@/client"
+import { Llm4AdChatTuneService, Llm4AdTasksService, UtilsService } from "@/client"
 import OnboardingTour from "@/components/Onboarding/OnboardingTour"
 import { useTheme } from "@/components/theme-provider"
 import {
@@ -256,6 +256,16 @@ export default function ChatTuneView({
   const [targetStage, setTargetStage] = useState<ChatTuneActiveStage | null>(
     null,
   )
+  const [betaBuild, setBetaBuild] = useState(false)
+
+  // Feature flags (e.g. whether the AI build Beta entry is enabled). Cached
+  // long — flags only change on backend redeploy.
+  const { data: featureFlags } = useQuery({
+    queryKey: ["featureFlags"],
+    queryFn: () => UtilsService.featureFlags(),
+    staleTime: 5 * 60 * 1000,
+  })
+  const betaEnabled = featureFlags?.enable_ai_agent_build ?? false
 
   const selectedProvider = providerList.find((p) => p.id === providerId)
   const availableModels = useMemo(
@@ -624,6 +634,7 @@ export default function ChatTuneView({
             model_name: modelName || undefined,
             target_stage: targetStage,
             language: i18n.language?.startsWith("zh") ? "zh" : "en",
+            beta: betaBuild || undefined,
           },
         })
         // The backend has accepted the turn; if the user has since switched
@@ -682,6 +693,7 @@ export default function ChatTuneView({
       providerId,
       modelName,
       targetStage,
+      betaBuild,
       connectToStream,
       refetchSession,
       i18n.language,
@@ -1236,6 +1248,22 @@ export default function ChatTuneView({
                       disabled={isGenerating}
                       t={t}
                     />
+                    {betaEnabled && (
+                      <button
+                        type="button"
+                        onClick={() => setBetaBuild((v) => !v)}
+                        disabled={isGenerating}
+                        title={t("evolution.chatTune.betaBuild.desc")}
+                        className={`h-6 px-2 flex items-center gap-1 rounded-md border text-[11px] font-medium transition-colors disabled:opacity-50 ${
+                          betaBuild
+                            ? "border-primary bg-primary/10 text-primary"
+                            : "border-transparent text-muted-foreground/60 hover:text-foreground hover:bg-muted"
+                        }`}
+                      >
+                        <Sparkles className="size-3" />
+                        <span>{t("evolution.chatTune.betaBuild.label")}</span>
+                      </button>
+                    )}
                     <AlertDialog>
                       <AlertDialogTrigger asChild>
                         <button
@@ -1757,9 +1785,9 @@ export function CardRenderer({
             {t(`evolution.chatTune.stages.${card.stage}`)}
           </p>
         </div>
-        <p className="text-sm font-medium text-foreground leading-snug">
-          {card.prompt}
-        </p>
+        <div className="text-sm text-foreground">
+          <ChatMarkdown content={card.prompt} />
+        </div>
         {card.hint && !locked && (
           <p className="text-xs text-muted-foreground leading-relaxed">
             {card.hint}

--- a/src/frontend/src/i18n/locales/en.json
+++ b/src/frontend/src/i18n/locales/en.json
@@ -1125,6 +1125,10 @@
         "review": "Review",
         "reviewDesc": "Review or revise the built artifacts"
       },
+      "betaBuild": {
+        "label": "Agent Build (Beta)",
+        "desc": "Have an AI agent autonomously build and self-verify the task package (experimental)"
+      },
       "stages": {
         "scenario": "Scenario",
         "data": "Data",
@@ -1133,7 +1137,9 @@
         "evolution": "Algorithm",
         "coder": "Code Generation",
         "advanced": "Advanced",
-        "confirm": "Confirm & Submit"
+        "confirm": "Confirm & Submit",
+        "run_needs_gathering": "Requirements",
+        "confirm_build": "Confirm Build"
       }
     }
   },

--- a/src/frontend/src/i18n/locales/zh.json
+++ b/src/frontend/src/i18n/locales/zh.json
@@ -1126,6 +1126,10 @@
         "review": "审阅",
         "reviewDesc": "对已构建结果进行审阅或修改"
       },
+      "betaBuild": {
+        "label": "Agent 构建 (Beta)",
+        "desc": "用 AI Agent 自主构建并自检任务包（测试功能）"
+      },
       "stages": {
         "scenario": "场景",
         "data": "数据准备",
@@ -1134,7 +1138,9 @@
         "evolution": "进化算法",
         "coder": "代码生成",
         "advanced": "高级配置",
-        "confirm": "确认提交"
+        "confirm": "确认提交",
+        "run_needs_gathering": "需求收集",
+        "confirm_build": "确认构建"
       }
     }
   },

--- a/src/llm4ad/agent/__init__.py
+++ b/src/llm4ad/agent/__init__.py
@@ -1,0 +1,30 @@
+"""AgentScope-based AI build (beta): a single ReAct agent for LLM4AD task packages.
+
+The agent builds and self-verifies an LLM4AD task package. Shared by the backend
+(HTTP/SSE endpoint) and the ``llm4ad chatv2`` CLI. agentscope is an optional
+dependency (the ``agent`` extra; requires Python >=3.11) and is imported lazily
+inside :mod:`llm4ad.agent.runner`, so importing this package does not require
+agentscope to be installed.
+"""
+
+from __future__ import annotations
+
+from llm4ad.agent.runner import (
+    AgentBuildConfig,
+    build_model,
+    make_tools,
+    run_agent_build,
+)
+from llm4ad.agent.sandbox import resolve_within_sandbox, sse_frame
+from llm4ad.agent.skill import build_system_prompt, build_task_message
+
+__all__ = [
+    "AgentBuildConfig",
+    "build_model",
+    "build_system_prompt",
+    "build_task_message",
+    "make_tools",
+    "resolve_within_sandbox",
+    "run_agent_build",
+    "sse_frame",
+]

--- a/src/llm4ad/agent/runner.py
+++ b/src/llm4ad/agent/runner.py
@@ -1,0 +1,1090 @@
+"""AI build (beta) agent runner: a single AgentScope ReAct agent (hybrid path).
+
+Core, framework-agnostic implementation shared by the backend (wrapped in an HTTP
+SSE endpoint) and the ``llm4ad chatv2`` CLI (run directly on the host). Replaces
+the rigid three-stage chat-tune state machine with one agent that drives the whole
+flow conversationally.
+
+Hybrid build strategy (two verification layers, no third):
+
+1. The agent gathers requirements (reading the workspace with read-only tools when
+   present), then calls ``build_task`` — which runs the existing, proven
+   :class:`BuildOrchestrator`. The orchestrator generates the package and runs its
+   own deterministic validation gate before returning a blueprint, and
+   ``config.yaml`` is produced programmatically inside it (never agent free-text).
+2. The agent then *verifies* by running ``debug_run.py`` / ``test_evaluator.py`` via
+   ``run_python``, reads any error, and calls ``rebuild_evaluator`` to fix the
+   evaluator. This is the agentic self-correction layer on top of the gate.
+
+The agent does NOT hand-write the package files; the engine does. The agent's tools
+are read-only inspection plus the stateful build/rebuild operations.
+
+Security model — a tool-level path fence:
+
+- Inspection tools (``read_file``, ``list_dir``) and ``run_python`` resolve every
+  path through :func:`llm4ad.agent.sandbox.resolve_within_sandbox` and refuse
+  anything escaping ``base_dir``. No general shell, so no Bash escape surface.
+  ``build_task``/``rebuild_evaluator`` only ever write into the workspace via the
+  engine's ``write_task_directory``.
+- In the backend the agent runs inside an isolated, single-use container (defense in
+  depth). In the CLI it runs on the host: the path fence still confines file
+  read/write to ``base_dir``, but ``run_python`` executes generated code with the
+  invoking user's privileges — intended for local developer use, not untrusted
+  multi-tenant input.
+
+Multi-provider: ``provider_config['type']`` maps onto the matching AgentScope model
+class (OpenAI / OpenAI-compatible such as DeepSeek or Qwen / Anthropic). The same
+``provider_config`` also drives the engine's own LLM calls via the llm4ad
+``BaseProvider``.
+
+agentscope is imported lazily inside functions so this module imports cleanly under
+Python 3.10 (agentscope requires >=3.11); install the ``agent`` extra to use it.
+
+Event protocol (dicts): ``chunk`` / ``build_result`` / ``done`` / ``error``.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import subprocess
+import traceback
+from collections.abc import AsyncIterator
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+_MAX_ERROR_LEN = 2000
+_MAX_TOOL_OUTPUT = 20000
+_RUN_PYTHON_TIMEOUT = 600
+_DEFAULT_MAX_ITERS = 40
+_MAX_REPAIR_ATTEMPTS = 10
+
+
+@dataclass
+class AgentBuildConfig:
+    """Inputs for one agent build run.
+
+    Attributes:
+        provider_config: llm4ad provider config (``type``/``api_key``/``auth_token``/
+            ``base_url``/``model``). Drives both the AgentScope model and the engine.
+        base_dir: Workspace/sandbox root. All tool file access is fenced here and the
+            built package is written under it.
+        user_content: The user's instruction for this turn.
+        gathering_context: Optional prior context (may carry ``description``).
+        allow_build: Phase selector. ``False`` (default) = GATHER phase: the agent
+            can only inspect + ``propose_build`` (no build tools). ``True`` = BUILD
+            phase (post-confirmation): the agent gets build/verify tools.
+        prior_state: JSON-serialized ``AgentState`` from the previous turn, so the
+            conversation memory resumes across separate invocations.
+        proposed: The confirmed build plan recorded by ``propose_build`` in a prior
+            gather turn; injected into the BUILD-phase task message.
+        max_iters: Max agent ReAct iterations.
+    """
+
+    provider_config: dict[str, Any]
+    base_dir: str
+    user_content: str = ""
+    gathering_context: dict[str, Any] | None = None
+    allow_build: bool = False
+    prior_state: dict[str, Any] | None = None
+    proposed: dict[str, Any] | None = None
+    max_iters: int = _DEFAULT_MAX_ITERS
+    surface: str = "platform"  # "platform" (Web UI) or "cli"; shapes how the agent
+    # talks about running the package (platform users don't set env vars / run the
+    # CLI themselves; the platform runs it for them).
+
+
+# --------------------------------------------------------------------------- #
+# Provider config -> AgentScope model                                         #
+# --------------------------------------------------------------------------- #
+
+
+def build_model(provider_config: dict[str, Any]) -> Any:
+    """Build an AgentScope chat model from an llm4ad ``provider_config``.
+
+    Maps the provider ``type`` onto the matching AgentScope model class:
+
+    - ``anthropic`` -> ``AnthropicChatModel`` (native Messages API).
+    - everything else -> ``OpenAIChatModel`` (OpenAI Chat Completions), covering
+      OpenAI, DeepSeek, Qwen, vLLM and most gateways via ``base_url``.
+
+    ``base_url`` / ``api_key`` pass straight through, so pointing them at the backend
+    LLM proxy with a one-time token needs no special-casing here.
+
+    Args:
+        provider_config: Dict with ``type``, ``api_key``, ``auth_token``,
+            ``base_url``, ``model``.
+
+    Returns:
+        An AgentScope ``ChatModelBase`` instance with streaming enabled.
+    """
+    ptype = (provider_config.get("type") or "openai").lower()
+    api_key = provider_config.get("api_key") or "EMPTY"
+    auth_token = provider_config.get("auth_token") or ""
+    base_url = provider_config.get("base_url") or None
+    model_name = provider_config.get("model") or ""
+
+    if ptype == "anthropic":
+        from agentscope.credential import AnthropicCredential
+        from agentscope.model import AnthropicChatModel
+
+        client_kwargs: dict[str, Any] = {}
+        if auth_token:
+            client_kwargs["auth_token"] = auth_token
+        return AnthropicChatModel(
+            credential=AnthropicCredential(api_key=api_key, base_url=base_url),
+            model=model_name,
+            stream=True,
+            client_kwargs=client_kwargs or None,
+        )
+
+    from agentscope.credential import OpenAICredential
+    from agentscope.model import OpenAIChatModel
+
+    return OpenAIChatModel(
+        credential=OpenAICredential(api_key=api_key, base_url=base_url),
+        model=model_name,
+        stream=True,
+    )
+
+
+def _build_llm_provider(provider_config: dict[str, Any]) -> Any:
+    """Build the llm4ad ``BaseProvider`` the engine uses for its own LLM calls.
+
+    Args:
+        provider_config: The same provider config used for the agent model.
+
+    Returns:
+        A ``BaseProvider`` instance created via the llm4ad registry.
+    """
+    from llm4ad.infra.provider.base import BaseProvider
+
+    return BaseProvider.create(provider_config["type"], config=provider_config)
+
+
+def _truncate(text: str, limit: int = _MAX_TOOL_OUTPUT) -> str:
+    """Truncate tool output to keep the agent context bounded."""
+    if len(text) <= limit:
+        return text
+    return text[:limit] + f"\n\n... (truncated, {len(text)} total chars)"
+
+
+# Rough per-LLM-call output-token assumptions for the cost estimate. Each
+# evolved candidate costs two calls: a planner call (idea) + a coder call (code).
+# These are conservative mid-range guesses for a *rough* range, not a promise.
+_PLANNER_TOKENS_PER_CALL = 3000
+_CODER_TOKENS_PER_CALL = 3000
+
+
+def estimate_evolution_cost(evolution: dict[str, Any]) -> dict[str, Any]:
+    """Estimate LLM call count and token usage from evolution parameters.
+
+    Formula (island GA, upper bound — early stopping may cut it short):
+      initial_population = num_islands * island_population_size
+      per_generation_offspring = num_islands * island_population_size * (1 - elite_ratio)
+      total_candidates = initial_population + per_generation_offspring * max_generations
+      llm_calls = total_candidates * 2   (planner + coder per candidate)
+      tokens ≈ llm_calls * (planner + coder tokens per call)
+
+    Args:
+        evolution: The ``evolution`` section of a produced config.yaml.
+
+    Returns:
+        A dict with the key params, ``total_candidates``, ``llm_calls`` and a
+        ``tokens_low``/``tokens_high`` output-token range (upper-bound style).
+    """
+    num_islands = int(evolution.get("num_islands", 1) or 1)
+    pop = int(evolution.get("island_population_size", evolution.get("population_size", 1)) or 1)
+    gens = int(evolution.get("max_generations", 1) or 1)
+    elite = float(evolution.get("elite_ratio", 0.1) or 0.0)
+
+    initial = num_islands * pop
+    per_gen = num_islands * pop * (1.0 - elite)
+    total_candidates = int(round(initial + per_gen * gens))
+    llm_calls = total_candidates * 2  # planner + coder
+    per_call = _PLANNER_TOKENS_PER_CALL + _CODER_TOKENS_PER_CALL
+    # Give a range: low ~= half the mid guess, high = the mid guess (upper bound).
+    tokens_high = llm_calls * per_call
+    tokens_low = tokens_high // 2
+    return {
+        "num_islands": num_islands,
+        "island_population_size": pop,
+        "max_generations": gens,
+        "elite_ratio": elite,
+        "total_candidates": total_candidates,
+        "llm_calls": llm_calls,
+        "tokens_low": tokens_low,
+        "tokens_high": tokens_high,
+    }
+
+
+def _fmt_tokens(n: int) -> str:
+    """Format a token count compactly (e.g. 1.2M, 340K)."""
+    if n >= 1_000_000:
+        return f"{n / 1_000_000:.1f}M"
+    if n >= 1_000:
+        return f"{n / 1_000:.0f}K"
+    return str(n)
+
+
+def build_config_summary_md(base_dir: str, project_name: str) -> str:
+    """Read the produced config.yaml and render an evolution-params + cost summary.
+
+    Returns a markdown block (heading + params table + token estimate) to append
+    to the build completion message, or "" if the config can't be read/parsed.
+
+    Args:
+        base_dir: Workspace root.
+        project_name: Produced project directory name.
+
+    Returns:
+        A markdown string, or "" on failure (the caller still reports success).
+    """
+    import yaml
+
+    cfg_path = Path(base_dir).resolve() / project_name / "config.yaml"
+    try:
+        cfg = yaml.safe_load(cfg_path.read_text(encoding="utf-8")) or {}
+    except (OSError, yaml.YAMLError):
+        return ""
+    evo = cfg.get("evolution") or {}
+    if not isinstance(evo, dict):
+        return ""
+    est = estimate_evolution_cost(evo)
+    etype = evo.get("type", "island_ga")
+    lines = [
+        "### ⚙️ 进化参数配置",
+        "",
+        "| 参数 | 值 |",
+        "|---|---|",
+        f"| 进化算法 | {etype} |",
+        f"| 迭代代数 (max_generations) | {est['max_generations']} |",
+        f"| 岛屿数 (num_islands) | {est['num_islands']} |",
+        f"| 每岛种群 (island_population_size) | {est['island_population_size']} |",
+        f"| 变异率 (mutation_rate) | {evo.get('mutation_rate', '—')} |",
+        f"| 交叉率 (crossover_rate) | {evo.get('crossover_rate', '—')} |",
+        f"| 精英比例 (elite_ratio) | {evo.get('elite_ratio', '—')} |",
+        "",
+        "### 💰 预计 token 消耗（粗略上限）",
+        "",
+        f"- 预计生成候选算法：约 **{est['total_candidates']}** 个"
+        f"（每个含 planner + coder 两次 LLM 调用，共约 **{est['llm_calls']}** 次调用）",
+        f"- 预计输出 token：约 **{_fmt_tokens(est['tokens_low'])} ~ "
+        f"{_fmt_tokens(est['tokens_high'])}**",
+        "",
+        "> 这是**按迭代代数满跑**估算的上限；实际会因早停（early stopping）而更少，"
+        "且不含输入 token。可通过调小 `max_generations` / `island_population_size` 降低消耗。",
+    ]
+    return "\n".join(lines)
+
+
+@dataclass
+class _BuildState:
+    """Mutable per-run state shared with the tools.
+
+    Holds the current blueprint/needs (so rebuild tools can act on them) and, in
+    the gather phase, the plan recorded by ``propose_build`` (so the runner can
+    emit a confirmation card after the turn).
+    """
+
+    blueprint: Any | None = None
+    needs: Any | None = None
+    project_name: str = ""
+    proposed: dict[str, Any] | None = None
+    summary_text: str = ""
+    pending_choice: dict[str, Any] | None = None
+    files_changed: bool = False
+
+
+# --------------------------------------------------------------------------- #
+# Tools                                                                        #
+# --------------------------------------------------------------------------- #
+
+
+def make_tools(
+    base_dir: str,
+    provider_config: dict[str, Any],
+    state: _BuildState,
+    *,
+    allow_build: bool = False,
+) -> list[Any]:
+    """Build the agent's tools for the current phase.
+
+    - GATHER phase (``allow_build=False``): only ``read_file``, ``list_dir`` and
+      ``propose_build``. No build tools, so the agent cannot start building before
+      the user confirms — a hard gate, not just a prompt instruction.
+    - BUILD phase (``allow_build=True``): adds ``run_python``, ``build_task`` and
+      ``rebuild_evaluator``. ``build_task`` runs the existing
+      :class:`BuildOrchestrator` (engine generates everything and runs its
+      deterministic validation gate).
+
+    Inspection and execution tools are fenced to ``base_dir``.
+
+    Args:
+        base_dir: Sandbox/workspace root.
+        provider_config: Provider config driving the engine's LLM calls.
+        state: Mutable holder for the produced blueprint / needs / proposal.
+        allow_build: Whether to include the build/verify tools (BUILD phase).
+
+    Returns:
+        List of ``FunctionTool`` instances to register on the toolkit.
+    """
+    from agentscope.tool import FunctionTool
+
+    from llm4ad.agent.sandbox import resolve_within_sandbox
+    from llm4ad.builder.writer import write_task_directory
+    from llm4ad.consultant.build_orchestrator import BuildError, BuildOrchestrator
+    from llm4ad.consultant.needs import NeedsProfile
+
+    base = Path(base_dir).resolve()
+
+    def read_file(path: str) -> str:
+        """Read a UTF-8 text file from the workspace (for inspecting user code).
+
+        Args:
+            path: Workspace-relative path to read.
+
+        Returns:
+            The file content, or an error message if missing / out of bounds.
+        """
+        resolved = resolve_within_sandbox(base, path)
+        if resolved is None:
+            return f"Error: Access denied, path escapes workspace: {path}"
+        if not resolved.is_file():
+            return f"Error: File not found: {path}"
+        try:
+            return _truncate(resolved.read_text(encoding="utf-8", errors="replace"))
+        except OSError as e:
+            return f"Error reading file: {e}"
+
+    def write_file(path: str, content: str) -> str:
+        """Create or overwrite a workspace file with the given content.
+
+        Use to apply changes the user asks for — e.g. tweak ``config.yaml`` values,
+        adjust generated code, or update data. Confined to the workspace. After
+        writing, re-verify with run_python.
+
+        Args:
+            path: Workspace-relative path to write (parent dirs are created).
+            content: Full new file content (replaces any existing content).
+
+        Returns:
+            A confirmation, or an error if the path escapes the workspace.
+        """
+        resolved = resolve_within_sandbox(base, path)
+        if resolved is None:
+            return f"Error: Access denied, path escapes workspace: {path}"
+        try:
+            resolved.parent.mkdir(parents=True, exist_ok=True)
+            resolved.write_text(content, encoding="utf-8")
+        except OSError as e:
+            return f"Error writing file: {e}"
+        state.files_changed = True
+        return f"Wrote {len(content)} chars to {resolved.relative_to(base).as_posix()}"
+
+    def edit_file(path: str, old_string: str, new_string: str) -> str:
+        """Replace an exact substring in a workspace file (targeted edit).
+
+        Prefer this over write_file for small changes (e.g. changing one
+        ``config.yaml`` value like ``max_generations: 5`` -> ``max_generations: 20``):
+        it avoids rewriting the whole file. ``old_string`` must occur EXACTLY once.
+
+        Args:
+            path: Workspace-relative path to edit.
+            old_string: Exact text to find (must be unique in the file).
+            new_string: Text to replace it with.
+
+        Returns:
+            A confirmation, or an error (not found / not unique / out of bounds).
+        """
+        resolved = resolve_within_sandbox(base, path)
+        if resolved is None:
+            return f"Error: Access denied, path escapes workspace: {path}"
+        if not resolved.is_file():
+            return f"Error: File not found: {path}"
+        try:
+            text = resolved.read_text(encoding="utf-8", errors="replace")
+        except OSError as e:
+            return f"Error reading file: {e}"
+        count = text.count(old_string)
+        if count == 0:
+            return f"Error: old_string not found in {path}"
+        if count > 1:
+            return f"Error: old_string occurs {count} times in {path}; make it unique."
+        try:
+            resolved.write_text(text.replace(old_string, new_string, 1), encoding="utf-8")
+        except OSError as e:
+            return f"Error writing file: {e}"
+        state.files_changed = True
+        return f"Edited {resolved.relative_to(base).as_posix()}"
+
+    def list_dir(path: str = ".") -> str:
+        """List files and directories under a workspace path (recursive, capped).
+
+        Args:
+            path: Workspace-relative directory (defaults to the workspace root).
+
+        Returns:
+            A newline-separated listing of relative paths, or an error message.
+        """
+        resolved = resolve_within_sandbox(base, path)
+        if resolved is None:
+            return f"Error: Access denied, path escapes workspace: {path}"
+        if not resolved.is_dir():
+            return f"Error: Directory not found: {path}"
+        entries: list[str] = []
+        for p in sorted(resolved.rglob("*")):
+            try:
+                rel = p.relative_to(base).as_posix()
+            except ValueError:
+                continue
+            entries.append(f"{rel}/" if p.is_dir() else rel)
+            if len(entries) >= 1000:
+                entries.append("... (truncated, >1000 entries)")
+                break
+        return "\n".join(entries) if entries else "(empty)"
+
+    def run_python(path: str, args: str = "") -> str:
+        """Run a python file inside the workspace and capture stdout/stderr.
+
+        Use this to verify the built package: run ``<project>/debug_run.py`` or
+        ``<project>/test_evaluator.py`` and read the output to find errors, then call
+        ``rebuild_evaluator`` to fix them.
+
+        Args:
+            path: Workspace-relative path to the ``.py`` file to execute.
+            args: Optional space-separated command-line arguments.
+
+        Returns:
+            Combined stdout/stderr and the exit code, or an error message.
+        """
+        resolved = resolve_within_sandbox(base, path)
+        if resolved is None:
+            return f"Error: Access denied, path escapes workspace: {path}"
+        if not resolved.is_file():
+            return f"Error: File not found: {path}"
+        cmd = ["python", str(resolved), *args.split()] if args else ["python", str(resolved)]
+        try:
+            proc = subprocess.run(  # noqa: S603 - fixed interpreter, sandboxed path
+                cmd,
+                cwd=str(resolved.parent),
+                capture_output=True,
+                text=True,
+                timeout=_RUN_PYTHON_TIMEOUT,
+            )
+        except subprocess.TimeoutExpired:
+            return f"Error: execution timed out after {_RUN_PYTHON_TIMEOUT}s"
+        except OSError as e:
+            return f"Error executing python: {e}"
+        return _truncate(
+            f"[exit code {proc.returncode}]\n"
+            f"--- stdout ---\n{proc.stdout}\n--- stderr ---\n{proc.stderr}"
+        )
+
+    async def build_task(
+        description: str,
+        project_name: str = "",
+        metrics_hints: str = "",
+        evaluation_hints: str = "",
+        data_path: str = "",
+        code_path: str = "",
+        language: str = "python",
+        use_existing_evaluator: bool = False,
+        existing_evaluator_path: str = "",
+    ) -> str:
+        """Generate a complete, validated LLM4AD task package from requirements.
+
+        Runs the proven build engine: it analyzes the requirements, generates the
+        evaluator, the algorithm with EVOLVE markers, sample data, config.yaml,
+        debug_run.py and test_evaluator.py, and runs a deterministic validation
+        gate. Call this once requirements are clear. Afterwards, verify with
+        run_python and fix issues with rebuild_evaluator.
+
+        Args:
+            description: Natural-language problem description (what to optimize,
+                inputs/outputs, the function to evolve).
+            project_name: Optional project slug (auto-generated if empty).
+            metrics_hints: Optional comma-separated metric hints
+                (e.g. "minimize tour length, maximize valid").
+            evaluation_hints: Optional free-form notes on how to evaluate.
+            data_path: Optional workspace-relative path to existing user data.
+            code_path: Optional workspace-relative path to existing user code to
+                integrate instead of generating an algorithm from scratch.
+            language: Algorithm language (default "python").
+            use_existing_evaluator: Reuse an evaluator from the user's code instead
+                of generating one.
+            existing_evaluator_path: Workspace-relative path to that evaluator.
+
+        Returns:
+            A summary of the produced package (project dir + files), or the
+            validation error if the gate failed.
+        """
+        needs = NeedsProfile(
+            description=description,
+            project_name=project_name or None,
+            metrics_hints=[h.strip() for h in metrics_hints.split(",") if h.strip()],
+            evaluation_hints=evaluation_hints,
+            data_path=(str(base / data_path) if data_path else None),
+            code_path=(str(base / code_path) if code_path else None),
+            language=language,
+            use_existing_evaluator=use_existing_evaluator,
+            existing_evaluator_path=(
+                str(base / existing_evaluator_path) if existing_evaluator_path else None
+            ),
+        )
+        provider = _build_llm_provider(provider_config)
+        orchestrator = BuildOrchestrator(provider, console=None, max_repair_attempts=_MAX_REPAIR_ATTEMPTS)
+        try:
+            blueprint = await orchestrator.build(needs)
+        except BuildError as exc:
+            return f"Build failed at validation gate: {exc}"
+        write_task_directory(blueprint, str(base))
+        state.blueprint = blueprint
+        state.needs = needs
+        state.project_name = blueprint.project_name
+        files = sorted(
+            p.relative_to(base).as_posix()
+            for p in (base / blueprint.project_name).rglob("*")
+            if p.is_file()
+        )
+        cfg_summary = build_config_summary_md(str(base), blueprint.project_name)
+        return (
+            f"Build succeeded and passed the validation gate.\n"
+            f"Project: {blueprint.project_name}\n"
+            f"Files:\n" + "\n".join(f"  {f}" for f in files) + "\n\n"
+            f"Now verify by running `{blueprint.project_name}/test_evaluator.py` and "
+            f"`{blueprint.project_name}/debug_run.py` with run_python.\n\n"
+            f"When you report completion to the user, INCLUDE the following evolution "
+            f"config & cost summary verbatim (it is pre-computed — do not recompute):\n\n"
+            + (cfg_summary or "(config summary unavailable)")
+        )
+
+    async def rebuild_evaluator(modification_request: str) -> str:
+        """Modify the current package's evaluator based on a fix/feedback.
+
+        Use after run_python reveals an evaluator problem, or to apply a user's
+        requested change to evaluation logic. Requires a prior successful build_task.
+
+        Args:
+            modification_request: What to change about the evaluator (the error to
+                fix, or the user's requested behavior change).
+
+        Returns:
+            A confirmation, or an error if there is no current build / it failed.
+        """
+        if state.blueprint is None or state.needs is None:
+            return "Error: no current build. Call build_task first."
+        provider = _build_llm_provider(provider_config)
+        orchestrator = BuildOrchestrator(provider, console=None, max_repair_attempts=_MAX_REPAIR_ATTEMPTS)
+        try:
+            blueprint = await orchestrator.rebuild_evaluator(
+                state.blueprint, modification_request, state.needs
+            )
+        except Exception as exc:  # noqa: BLE001 - surface any failure to the agent
+            return f"Rebuild failed: {type(exc).__name__}: {exc}"
+        write_task_directory(blueprint, str(base))
+        state.blueprint = blueprint
+        return (
+            "Evaluator updated and rewritten to the workspace. "
+            f"Re-verify with run_python on `{state.project_name}/test_evaluator.py`."
+        )
+
+    def propose_plan(
+        summary: str,
+        description: str,
+        function_to_evolve: str = "",
+        io_format: str = "",
+        metrics_hints: str = "",
+        evaluation_hints: str = "",
+        project_name: str = "",
+        data_path: str = "",
+        code_path: str = "",
+        language: str = "python",
+        use_existing_evaluator: bool = False,
+        existing_evaluator_path: str = "",
+    ) -> str:
+        """Record the structured Plan and hand off to user confirmation (GATHER).
+
+        Call this ONLY when the 7 plan items are clear. It does NOT build — it
+        records the Plan and shows the user a confirmation card listing all 7
+        items plus a "still anything to add?" prompt. Building happens only after
+        the user confirms.
+
+        Args:
+            summary: One-paragraph natural-language recap shown atop the card.
+            description: Full problem description (item 1). Passed to the engine.
+            function_to_evolve: Name/role of the function or algorithm to evolve
+                (item 2). Leave the agent's chosen design if the user had no
+                constraint.
+            io_format: Input/output format of that function (item 2).
+            metrics_hints: The evaluation metric(s), min/max (item 3).
+            evaluation_hints: Free-form notes on how to evaluate.
+            project_name: Project slug the agent proposed (item 7).
+            data_path: Workspace-relative path to user-provided data, else "" to
+                generate sample data (item 5).
+            code_path: Workspace-relative path to user-provided code, else "" to
+                generate from scratch (item 4).
+            language: Programming language, default python (item 6).
+            use_existing_evaluator: Reuse an evaluator found in user code (item 4).
+            existing_evaluator_path: Workspace-relative path to that evaluator.
+
+        Returns:
+            A confirmation that the Plan was recorded and the user is being asked.
+        """
+        state.proposed = {
+            "description": description,
+            "function_to_evolve": function_to_evolve,
+            "io_format": io_format,
+            "project_name": project_name,
+            "metrics_hints": metrics_hints,
+            "evaluation_hints": evaluation_hints,
+            "data_path": data_path,
+            "code_path": code_path,
+            "language": language,
+            "use_existing_evaluator": use_existing_evaluator,
+            "existing_evaluator_path": existing_evaluator_path,
+        }
+        state.summary_text = summary.strip()
+        return (
+            "Plan recorded. The user is now shown a confirmation card with the 7 "
+            "plan items. Stop here and wait for their decision — do nothing else."
+        )
+
+    def ask_choice(
+        question: str,
+        options: list[str],
+        allow_custom: bool = True,
+        upload: str = "none",
+    ) -> str:
+        """Ask the user ONE question, offering clickable preset options (GATHER).
+
+        Prefer this over plain-text questions: predict the likely answers and offer
+        them as buttons so the user can click instead of type. Offer 2-4 concise
+        options. Only one ask_choice per turn, then stop and wait for the answer.
+
+        Attaching upload to a specific option (PREFERRED): put a ``[dir]`` or
+        ``[file]`` tag at the START of that option's text. Clicking THAT option
+        then opens a directory / file picker. Example:
+        ``["由你来设计 — 我帮你设计求解函数",
+          "[dir] 进化我现有的代码 — 上传我的项目目录让 LLM 优化"]``
+        This is better than a separate "upload" option because the upload lives on
+        the semantically meaningful choice ("evolve my code"), so one click does it.
+
+        Args:
+            question: The single question to ask.
+            options: 2-4 preset answers. Each item may be ``"Label"`` or
+                ``"Label — short description"`` (em dash separates label from hint).
+                Prefix an option with ``[dir]`` or ``[file]`` to make clicking it
+                open a directory / file picker.
+            allow_custom: If True (default), a "自行输入 / Enter your own" free-text
+                option is appended so the user isn't boxed in.
+            upload: Legacy fallback: ``"file"`` / ``"dir"`` appends a standalone
+                upload option. Prefer the inline ``[dir]``/``[file]`` tag instead.
+
+        Returns:
+            Confirmation that the question was shown; then stop and wait.
+        """
+        import re
+
+        opts: list[dict[str, Any]] = []
+        for raw in options:
+            text = raw.strip()
+            ask_dir = ask_file = False
+            # Inline upload tag at the start: [dir] / [file] (also 目录/文件).
+            m = re.match(r"^\[(dir|file|目录|文件)\]\s*", text, flags=re.IGNORECASE)
+            if m:
+                tag = m.group(1).lower()
+                ask_dir = tag in ("dir", "目录")
+                ask_file = tag in ("file", "文件")
+                text = text[m.end():]
+            if " — " in text:
+                label, desc = text.split(" — ", 1)
+            elif " - " in text:
+                label, desc = text.split(" - ", 1)
+            else:
+                label, desc = text, ""
+            opt: dict[str, Any] = {
+                "value": text,
+                "label": label.strip(),
+                "description": desc.strip(),
+            }
+            if ask_dir:
+                opt["ask_for_dir"] = True
+            elif ask_file:
+                opt["ask_for_path"] = True
+            opts.append(opt)
+        if upload == "file":
+            opts.append({
+                "value": "__upload_file__",
+                "label": "上传文件 / Upload a file",
+                "description": "选择本地文件提供给助手",
+                "ask_for_path": True,
+            })
+        elif upload == "dir":
+            opts.append({
+                "value": "__upload_dir__",
+                "label": "上传目录 / Upload a directory",
+                "description": "选择本地项目目录提供给助手",
+                "ask_for_dir": True,
+            })
+        if allow_custom:
+            opts.append({
+                "value": "__custom__",
+                "label": "自行输入 / Enter your own",
+                "description": "",
+                "is_custom": True,
+            })
+        state.pending_choice = {"question": question.strip(), "options": opts}
+        return (
+            "Options shown to the user. Stop here and wait for their selection — "
+            "do not ask anything else or take other actions this turn."
+        )
+
+    if not allow_build:
+        # GATHER phase: inspection + ask + propose only. No build tools => hard gate.
+        return [
+            FunctionTool(read_file, is_read_only=True),
+            FunctionTool(list_dir, is_read_only=True),
+            FunctionTool(ask_choice),
+            FunctionTool(propose_plan),
+        ]
+
+    # BUILD phase (post-confirmation): full build + verify + edit toolset.
+    return [
+        FunctionTool(read_file, is_read_only=True),
+        FunctionTool(list_dir, is_read_only=True),
+        FunctionTool(run_python),
+        FunctionTool(build_task),
+        FunctionTool(rebuild_evaluator),
+        FunctionTool(write_file),
+        FunctionTool(edit_file),
+    ]
+
+
+# --------------------------------------------------------------------------- #
+# Agent loop                                                                  #
+# --------------------------------------------------------------------------- #
+
+
+def _blueprint_data(state: _BuildState, base_dir: str) -> dict[str, Any]:
+    """Build the ``build_result`` payload describing what to persist.
+
+    Reports ``built: True`` when either the engine produced a blueprint this turn
+    OR the agent edited files (follow-up change), so the backend re-uploads the
+    (possibly edited) package. ``project_name`` is taken from the blueprint, else
+    detected from the workspace (the top-level dir containing a config.yaml).
+
+    Args:
+        state: Build state (blueprint may be None on a pure follow-up edit).
+        base_dir: Workspace root, used to detect the project dir when editing.
+
+    Returns:
+        A dict with ``project_name`` and ``built``.
+    """
+    if state.blueprint is not None:
+        data = asdict(state.blueprint)
+        data["built"] = True
+        return data
+    if state.files_changed:
+        project = state.project_name or _detect_project_dir(base_dir)
+        if project:
+            return {"project_name": project, "built": True}
+    return {"project_name": "", "built": False}
+
+
+def _detect_project_dir(base_dir: str) -> str:
+    """Detect the produced project dir: the top-level dir holding a config.yaml.
+
+    Args:
+        base_dir: Workspace root.
+
+    Returns:
+        The project directory name, or "" if none found.
+    """
+    base = Path(base_dir).resolve()
+    try:
+        for cfg in sorted(base.glob("*/config.yaml")):
+            return cfg.parent.relative_to(base).as_posix()
+        for p in sorted(base.iterdir()):
+            if p.is_dir() and not p.name.startswith("."):
+                return p.name
+    except OSError:
+        pass
+    return ""
+
+
+def _confirm_build_card(summary: str, proposed: dict[str, Any] | None = None) -> dict[str, Any]:
+    """Build the confirm/decline card shown after a gather proposal.
+
+    Renders the structured 7-item Plan in the card prompt (the frontend displays
+    ``prompt`` as the card body), followed by an "anything to add?" cue, then
+    confirm / keep-adjusting buttons. Matches the frontend-recognized
+    ``kind:"choice", stage:"confirm_build"`` shape so the existing renderer and
+    submission routing work unchanged.
+
+    Args:
+        summary: The agent's one-paragraph task recap.
+        proposed: The structured plan dict recorded by ``propose_plan``.
+
+    Returns:
+        The payload dict for a ``{"type": "payload", "data": ...}`` event.
+    """
+    import uuid
+
+    def _md_cell(text: str) -> str:
+        """Escape a value for use inside a markdown table cell."""
+        return str(text).replace("|", "\\|").replace("\n", " ")
+
+    lines: list[str] = []
+    if proposed:
+        # Render the plan as markdown (heading + table), the SAME style the agent
+        # uses for its post-build summary, so the card matches that clean look.
+        # The frontend renders card.prompt with the markdown component.
+        code_src = (
+            f"复用已有代码 `{proposed['code_path']}`"
+            if proposed.get("code_path")
+            else "从零生成"
+        )
+        eval_src = (
+            f"复用已有评估器 `{proposed['existing_evaluator_path']}`"
+            if proposed.get("use_existing_evaluator")
+            else "自动生成"
+        )
+        data_src = (
+            f"使用已有数据 `{proposed['data_path']}`"
+            if proposed.get("data_path")
+            else "自动生成样本"
+        )
+        fn = proposed.get("function_to_evolve") or "由助手设计"
+        io = proposed.get("io_format") or "由助手设计"
+        metric = proposed.get("metrics_hints") or proposed.get("evaluation_hints") or "(未填)"
+        lines = [
+            "## 📋 构建方案确认",
+            "",
+            "| # | 项目 | 内容 |",
+            "|---|---|---|",
+            f"| 1 | 问题描述 | {_md_cell(proposed.get('description') or '(未填)')} |",
+            f"| 2 | 进化目标 | {_md_cell(fn)} |",
+            f"| 3 | 输入 / 输出 | {_md_cell(io)} |",
+            f"| 4 | 评估指标 | {_md_cell(metric)} |",
+            f"| 5 | 代码来源 | {_md_cell(code_src)}（评估器：{_md_cell(eval_src)}） |",
+            f"| 6 | 数据来源 | {_md_cell(data_src)} |",
+            f"| 7 | 语言 / 项目名 | {_md_cell(proposed.get('language') or 'python')} / "
+            f"`{_md_cell(proposed.get('project_name') or '自动')}` |",
+            "",
+            "还有要补充或修改的吗？**确认无误我就开始构建** 🚀",
+        ]
+    elif summary:
+        lines.append(summary.strip())
+
+    prompt = "\n".join(lines) if lines else "需求已明确，是否开始构建？"
+    return {
+        "cardId": f"card-{uuid.uuid4().hex[:8]}",
+        "kind": "choice",
+        "stage": "confirm_build",
+        "prompt": prompt,
+        "hint": "",
+        "options": [
+            {
+                "value": "confirm_build",
+                "label": "确认构建",
+                "description": "按上述方案开始构建任务",
+            },
+            {
+                "value": "decline_build",
+                "label": "继续调整",
+                "description": "继续对话补充或修改需求",
+            },
+        ],
+    }
+
+
+def _choice_card(pending: dict[str, Any]) -> dict[str, Any]:
+    """Build a gather-phase question card with clickable preset options.
+
+    Uses the frontend-recognized ``kind:"choice"`` shape with stage
+    ``run_needs_gathering`` (rendered generically as option buttons, plus custom
+    free-text and file/dir pickers per option flags).
+
+    Args:
+        pending: ``{"question": str, "options": [ {value,label,description,
+            is_custom?, ask_for_path?, ask_for_dir?}, ... ]}`` from ``ask_choice``.
+
+    Returns:
+        The payload dict for a ``{"type": "payload", "data": ...}`` event.
+    """
+    import uuid
+
+    return {
+        "cardId": f"card-{uuid.uuid4().hex[:8]}",
+        "kind": "choice",
+        "stage": "run_needs_gathering",
+        "prompt": pending.get("question", ""),
+        "hint": "",
+        "options": pending.get("options", []),
+    }
+
+
+async def run_agent_build(config: AgentBuildConfig) -> AsyncIterator[dict[str, Any]]:
+    """Drive the AgentScope build agent for one turn, yielding SSE-shaped events.
+
+    Two-phase, memory-preserving:
+
+    - GATHER (``config.allow_build=False``): the agent asks one question at a time
+      (no build tools). If it calls ``propose_build``, a confirm-build ``payload``
+      card is emitted at the end of the turn.
+    - BUILD (``config.allow_build=True``): the agent builds from the confirmed
+      plan and self-verifies.
+
+    The agent's ``AgentState`` is restored from ``config.prior_state`` at the start
+    and emitted as an ``agent_state`` event at the end, so conversation memory
+    resumes across separate invocations.
+
+    Args:
+        config: Inputs for this run.
+
+    Yields:
+        Event dicts: ``chunk``, ``payload`` (confirm card), ``build_result``,
+        ``agent_state`` (memory snapshot), ``done``, or ``error``.
+    """
+    from agentscope.agent import Agent, ReActConfig
+    from agentscope.event import (
+        TextBlockDeltaEvent,
+        ToolCallStartEvent,
+        ToolResultEndEvent,
+    )
+    from agentscope.message import UserMsg
+    from agentscope.permission import PermissionMode
+    from agentscope.state import AgentState
+    from agentscope.tool import Toolkit
+
+    from llm4ad.agent.skill import (
+        build_gather_system_prompt,
+        build_gather_task_message,
+        build_system_prompt,
+        build_task_message,
+    )
+
+    try:
+        state = _BuildState()
+        model = build_model(config.provider_config)
+        toolkit = Toolkit(
+            tools=make_tools(
+                config.base_dir,
+                config.provider_config,
+                state,
+                allow_build=config.allow_build,
+            )
+        )
+
+        system_prompt = (
+            build_system_prompt(config.base_dir, config.surface)
+            if config.allow_build
+            else build_gather_system_prompt(config.base_dir)
+        )
+
+        # Restore prior conversation memory if present (resume across turns).
+        prior_state = None
+        if config.prior_state:
+            try:
+                prior_state = AgentState.model_validate(config.prior_state)
+            except Exception:  # noqa: BLE001 - corrupt/incompatible state: start fresh
+                prior_state = None
+
+        agent = Agent(
+            name="llm4ad-builder",
+            system_prompt=system_prompt,
+            model=model,
+            toolkit=toolkit,
+            react_config=ReActConfig(max_iters=config.max_iters),
+            state=prior_state,
+        )
+        # No human to confirm tool prompts; the only tools are the fenced ones
+        # above, so bypass the prompt (the path fence is the guarantee).
+        agent.state.permission_context.mode = PermissionMode.BYPASS
+
+        if config.allow_build:
+            task_text = build_task_message(config.proposed, config.user_content)
+        else:
+            task_text = build_gather_task_message(
+                config.gathering_context or {}, config.user_content
+            )
+        # UserMsg factory wraps a plain string in a TextBlock; Msg(content=str)
+        # alone would fail validation (content must be a list of blocks).
+        inputs = UserMsg(name="user", content=task_text)
+
+        # In the GATHER phase, ask_choice / propose_plan are turn-ending: once the
+        # agent has asked the user something (or proposed the plan), the turn is
+        # over and we wait for the user's reply. AgentScope's ReAct loop would
+        # otherwise keep reasoning and self-answer its own questions. Breaking the
+        # stream here is safe: _execute_tool_call saves the tool call AND its
+        # result to context BEFORE yielding ToolResultEndEvent, so the persisted
+        # AgentState is consistent for the next turn.
+        turn_ending_tools = {"ask_choice", "propose_plan"}
+        tool_names: dict[str, str] = {}  # tool_call_id -> tool name
+        stop_after_turn = False
+
+        _stream = agent.reply_stream(inputs)
+        async for event in _stream:
+            if isinstance(event, TextBlockDeltaEvent):
+                if event.delta:
+                    yield {"type": "chunk", "content": event.delta}
+            elif isinstance(event, ToolCallStartEvent):
+                tool_names[event.tool_call_id] = event.tool_call_name
+                yield {"type": "chunk", "content": f"\n\n🔧 `{event.tool_call_name}` ...\n"}
+            elif isinstance(event, ToolResultEndEvent):
+                yield {"type": "chunk", "content": "✓\n"}
+                if (
+                    not config.allow_build
+                    and tool_names.get(event.tool_call_id) in turn_ending_tools
+                ):
+                    # The gather-phase question/proposal is recorded; end the turn.
+                    stop_after_turn = True
+                    break
+
+        if stop_after_turn:
+            # Close the reply generator cleanly after the intentional early break
+            # (the tool call + result are already persisted to context).
+            aclose = getattr(_stream, "aclose", None)
+            if aclose is not None:
+                with contextlib.suppress(Exception):
+                    await aclose()
+
+        # GATHER phase: emit an interactive card. A pending question (ask_choice)
+        # takes priority over a proposal; the two are mutually exclusive because
+        # the agent stops after either.
+        if not config.allow_build and state.pending_choice is not None:
+            yield {"type": "payload", "data": _choice_card(state.pending_choice)}
+        elif not config.allow_build and state.proposed is not None:
+            yield {
+                "type": "payload",
+                "data": _confirm_build_card(state.summary_text, state.proposed),
+                "proposed": state.proposed,
+            }
+
+        # BUILD phase: report what was produced (or edited, for a follow-up).
+        if config.allow_build:
+            yield {"type": "build_result", "blueprint_data": _blueprint_data(state, config.base_dir)}
+
+        # Persist conversation memory for the next turn (not forwarded to the user).
+        state_dump: dict[str, Any] | None = None
+        try:
+            state_dump = agent.state.model_dump(mode="json")
+        except Exception:  # noqa: BLE001 - never fail the turn over serialization
+            state_dump = None
+        if state_dump is not None:
+            yield {"type": "agent_state", "state": state_dump}
+
+        yield {"type": "done"}
+    except Exception as exc:
+        tb = traceback.format_exc()
+        msg = f"{type(exc).__name__}: {exc}\n{tb}"[:_MAX_ERROR_LEN]
+        yield {"type": "error", "error": msg}
+
+
+__all__ = [
+    "AgentBuildConfig",
+    "build_model",
+    "make_tools",
+    "run_agent_build",
+]

--- a/src/llm4ad/agent/sandbox.py
+++ b/src/llm4ad/agent/sandbox.py
@@ -1,0 +1,61 @@
+"""Pure sandbox/path utilities shared by the agent build runner.
+
+Lifted verbatim from the backend ``chat_tune_runner`` so the agent-build logic can
+live in core (importable by both the backend and the CLI) without depending on the
+backend package. No backend, FastAPI, or agentscope dependency here — only stdlib.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+
+def resolve_within_sandbox(base: Path, path: str) -> Path | None:
+    """Resolve a user/LLM-supplied path against the sandbox root.
+
+    Resolution rules (designed around common LLM path mistakes):
+
+    1. Relative paths (e.g. ``code/x.py`` or ``./code/x.py``) resolve against ``base``.
+    2. Absolute paths already prefixed by ``base`` are accepted as-is.
+    3. Other absolute paths — including an LLM mistakenly writing ``/code/x.py`` when
+       it means a project-internal ``code/x.py`` — are rewritten to relative and
+       resolved per rule 1.
+    4. If ``..`` still escapes ``base`` after the above, return ``None``.
+
+    This tolerates the LLM not knowing the real mount point while never relaxing the
+    guarantee against genuine out-of-bounds access.
+
+    Args:
+        base: Sandbox root directory (already resolved).
+        path: User/LLM-supplied path.
+
+    Returns:
+        The resolved absolute path inside ``base``; ``None`` if it escapes.
+    """
+    candidate = Path(path)
+    if candidate.is_absolute():
+        try:
+            # Already inside base: accept.
+            candidate.resolve().relative_to(base)
+            resolved = candidate.resolve()
+        except ValueError:
+            # Outside base: strip the leading root and treat as relative
+            # (tolerate "/code/x.py"-style mistakes).
+            rel = Path(*candidate.parts[1:]) if len(candidate.parts) > 1 else Path()
+            resolved = (base / rel).resolve()
+    else:
+        resolved = (base / candidate).resolve()
+
+    if resolved != base and base not in resolved.parents:
+        return None
+    return resolved
+
+
+def sse_frame(obj: dict[str, Any]) -> str:
+    """Encode an event dict as a single SSE frame."""
+    return f"data: {json.dumps(obj, ensure_ascii=False, default=str)}\n\n"
+
+
+__all__ = ["resolve_within_sandbox", "sse_frame"]

--- a/src/llm4ad/agent/skill.py
+++ b/src/llm4ad/agent/skill.py
@@ -1,0 +1,332 @@
+"""Domain knowledge ("skill") for the AI build (beta) agent — hybrid path.
+
+The beta agent runs in two phases across turns:
+
+- **Gather**: converse with the user, asking ONE missing detail at a time, until
+  the requirements are clear enough. Then call ``propose_build`` to present a
+  summary and stop — the user must confirm before anything is built. In this
+  phase the agent has NO build tools, so it cannot start building on its own.
+- **Build**: after the user confirms, the agent uses the proven build engine
+  (``build_task``) and self-verifies by running the produced scripts
+  (``run_python``), fixing issues via ``rebuild_evaluator``.
+
+This module holds the phase-specific system prompts and the task-message builder.
+Pure functions — no backend/agentscope deps.
+"""
+
+from __future__ import annotations
+
+import json
+from functools import lru_cache
+from pathlib import Path
+from typing import Any
+
+# The portable domain-knowledge skill lives inside the package so it ships with
+# pip installs and is readable inside the task-runner container. Repo-root
+# skills/llm4ad-task-builder/ is the external copy for Claude Code / Qwen Code.
+_SKILL_PATH = Path(__file__).parent / "skills" / "llm4ad-task-builder" / "SKILL.md"
+
+
+@lru_cache(maxsize=1)
+def load_skill_body() -> str:
+    """Return the SKILL.md body (frontmatter stripped), or "" if unavailable.
+
+    The domain knowledge (what a task package is, file contracts, how it runs on
+    the platform) is maintained once in SKILL.md and injected into the agent's
+    system prompts so the in-platform agent and external coding agents share one
+    source of truth.
+
+    Returns:
+        The Markdown body with the leading YAML frontmatter block removed; empty
+        string if the file is missing (the prompts still work without it).
+    """
+    try:
+        text = _SKILL_PATH.read_text(encoding="utf-8")
+    except OSError:
+        return ""
+    # Strip a leading YAML frontmatter block delimited by --- ... ---.
+    if text.startswith("---"):
+        end = text.find("\n---", 3)
+        if end != -1:
+            nl = text.find("\n", end + 1)
+            text = text[nl + 1:] if nl != -1 else ""
+    return text.strip()
+
+
+def _with_skill_knowledge(prompt: str) -> str:
+    """Append the shared SKILL.md domain knowledge to a system prompt.
+
+    Args:
+        prompt: The phase-specific system prompt.
+
+    Returns:
+        The prompt with the SKILL.md body appended as a reference section, or the
+        prompt unchanged if SKILL.md could not be loaded.
+    """
+    body = load_skill_body()
+    if not body:
+        return prompt
+    return (
+        prompt
+        + "\n\n---\n\nREFERENCE — LLM4AD task-package domain knowledge "
+        "(authoritative; follow these contracts when building):\n\n"
+        + body
+    )
+
+
+def build_gather_system_prompt(workspace_dir: str) -> str:
+    """System prompt for the GATHER phase: step-by-step requirement gathering.
+
+    The agent asks one question at a time and, when ready, calls ``propose_build``
+    to summarize and hand off to a confirmation step. It has no build tools here,
+    so it physically cannot start building before the user confirms.
+
+    Args:
+        workspace_dir: The sandbox root (informational; tool paths are fenced here).
+
+    Returns:
+        The full system prompt string.
+    """
+    prompt = f"""You are a friendly, proactive assistant helping a user specify an \
+LLM4AD task before it is built. LLM4AD evolves a marked block of code (between \
+EVOLVE_START / EVOLVE_END) to optimize a problem, scored by a custom evaluator.
+
+Your ONLY job right now is to gather requirements through a smooth conversation. \
+You must NOT build anything yet — there is no build tool in this phase, and the \
+actual build happens only after the user explicitly confirms.
+
+TOOLS (all confined to the workspace {workspace_dir}; workspace-relative paths, \
+no access outside it):
+- ask_choice(question, options, allow_custom=True, upload="none"): ask ONE \
+question with clickable preset options. PREFER THIS over plain-text questions — \
+predict the user's likely answers and offer 2-4 concise options so they can click \
+instead of type. Use ``upload="file"`` / ``upload="dir"`` when you need them to \
+point at existing code/data. After calling it, STOP and wait for their choice.
+- read_file(path), list_dir(path="."): read the user's uploaded code/data. Use \
+these ONLY after the user has chosen to reuse existing code and uploaded it — do \
+NOT scan the workspace on your own at the start of the conversation (it is empty \
+until the user uploads something).
+- propose_plan(summary, description, function_to_evolve="", io_format="", \
+metrics_hints="", evaluation_hints="", project_name="", data_path="", \
+code_path="", language="python", use_existing_evaluator=False, \
+existing_evaluator_path=""): call ONLY when the plan items below are clear. It \
+shows the user a structured Plan card with a confirm button. Fill every field you \
+know; leave the agent's own choice for items the user didn't constrain (e.g. \
+function design). Do not call early.
+
+WHAT TO GATHER (ask ONE at a time, using ask_choice with preset options wherever \
+possible; mirror and exceed the classic wizard):
+1. **Problem description** (required — ask) — what is being optimized. UNLESS the \
+first message already makes it concrete, open with ask_choice offering: "运筹优化 / \
+Operations Research — TSP、背包、调度", "数学求解 / Mathematical — 数值优化、方程、回归", \
+"AI/ML 策略演化 / AI-ML strategy — 网络架构、超参数、RL策略". If already concrete, skip.
+2. **What code to evolve** — ask what algorithm/function they want to evolve, and \
+offer via ask_choice TWO options: "由你设计 / Let you design it" AND \
+"[dir] 进化我现有的代码 / Evolve my existing code" — note the ``[dir]`` prefix, which \
+makes clicking THAT option open a directory picker (do NOT add a separate "upload" \
+option). ONLY if they upload: inspect it with read_file/list_dir, and if you find \
+an evaluator script (``*evaluator.py``), ask whether to reuse it (set \
+use_existing_evaluator=True + existing_evaluator_path, and skip regenerating \
+metrics). If they let you design it, YOU choose the function and I/O format — \
+record them in function_to_evolve / io_format.
+3. **Evaluation metric(s)** (required — ask clearly) — what to minimize/maximize. \
+Offer likely options via ask_choice when you can infer them.
+4. **Data source** — ask_choice with two options: "由你生成样本数据 / Generate sample \
+data" AND "[dir] 上传我的数据 / Upload my data" (the ``[dir]`` prefix makes that \
+option open a picker). Record data_path only if they upload.
+5. **Programming language** — ask_choice with Python as the default option.
+6. **Project name** — propose one from the description and ask the user to confirm \
+or rename.
+
+STYLE:
+- One question per turn. Lead with ask_choice + preset options; fall back to \
+plain text only for genuinely open-ended questions.
+- You MAY answer the user's own questions (e.g. "what is an evaluator?", "what does \
+TSP mean?") and give brief guidance — then continue gathering. This is a strength \
+over the old fixed wizard; use it.
+- Tailor options to what you've learned, rather than generic templates.
+- When the items are clear, STOP asking and call propose_plan with a clear \
+``summary`` and every field filled. Keep your own text before the card SHORT — do \
+NOT re-list the plan in prose and do NOT mention how many items there are; the card \
+renders the structured plan and asks the user whether anything needs adjusting. A \
+single brief sentence like "需求已明确，请确认下面的方案：" is enough.
+
+Respond in the user's language."""
+    return _with_skill_knowledge(prompt)
+
+
+def _closing_for_surface(surface: str) -> str:
+    """Return the surface-specific closing guidance for the build prompt.
+
+    Platform (Web UI) users do not run the CLI or set env vars themselves — the
+    platform runs the package for them — so the agent must not tell them to run
+    ``llm4ad run`` or export ``LLM_*``. CLI users do run it themselves.
+
+    Args:
+        surface: ``"platform"`` or ``"cli"``.
+
+    Returns:
+        A closing-guidance paragraph for the system prompt.
+    """
+    if surface == "cli":
+        return (
+            "CLOSING (CLI): after the build is verified, tell the user they can run "
+            "it with `llm4ad run <project>/config.yaml` (it needs LLM_BASE_URL / "
+            "LLM_API_KEY / LLM_MODEL env vars set), and that they may tune "
+            "config.yaml evolution parameters. Offer to keep helping."
+        )
+    return (
+        "CLOSING (platform): the user is on the web platform — they do NOT run any "
+        "CLI command and do NOT set environment variables; the platform runs the "
+        "task for them. So do NOT mention `llm4ad run` or LLM_* env vars. Instead, "
+        "after the build is verified, tell them the task package is ready and offer "
+        "to keep helping — e.g. tuning evolution parameters (max_generations, "
+        "num_islands, mutation_rate, ...), adjusting the algorithm or evaluator, or "
+        "answering any questions. Say something like: “任务包已构建完成并通过验证。我"
+        "可以继续帮你调整演化参数，或者你有别的需求也可以随时告诉我，我都能为你解答。”"
+    )
+
+
+def build_system_prompt(workspace_dir: str, surface: str = "platform") -> str:
+    """System prompt for the BUILD phase: build + self-verify (post-confirmation).
+
+    Reached only after the user confirmed the proposal. The requirements are
+    already settled and injected into the task message; the agent builds and
+    verifies without re-gathering.
+
+    Args:
+        workspace_dir: The sandbox root (informational; tool paths are fenced here).
+        surface: ``"platform"`` (Web UI — the platform runs the package for the
+            user; do NOT tell them to run the CLI or set env vars) or ``"cli"``
+            (the user runs ``llm4ad run`` themselves).
+
+    Returns:
+        The full system prompt string.
+    """
+    prompt = f"""You are an expert assistant that builds runnable LLM4AD task \
+packages. The user has ALREADY confirmed the requirements (given below); build \
+the task now — do not re-ask for requirements.
+
+LLM4AD evolves a marked block of code (between EVOLVE_START / EVOLVE_END) to \
+optimize a problem, scored by a custom evaluator. The build engine generates the \
+package for you; after that you can refine any file directly. Your job: (1) \
+trigger the build from the confirmed requirements, (2) verify it runs and fix it \
+if not, and (3) apply any further changes the user asks for (e.g. tuning config \
+parameters, adjusting the algorithm or evaluator).
+
+All your tools operate inside the workspace ({workspace_dir}); paths are \
+workspace-relative and you cannot access anything outside it:
+- read_file(path), list_dir(path="."): inspect the workspace / any user code/data.
+- build_task(description, project_name="", metrics_hints="", evaluation_hints="", \
+data_path="", code_path="", language="python"): generate a complete, validated \
+package (evaluator, algorithm with EVOLVE markers, sample data, config.yaml, \
+debug_run.py, test_evaluator.py) and run a validation gate.
+- run_python(path, args=""): run a .py file and read stdout/stderr, to verify the \
+built package.
+- rebuild_evaluator(modification_request): regenerate/fix the evaluator via the \
+engine after a build.
+- write_file(path, content): create or overwrite a file. Use to apply changes.
+- edit_file(path, old_string, new_string): replace an exact unique substring in a \
+file — the preferred way to make a small change, e.g. tune a single config.yaml \
+value like ``max_generations`` / ``num_islands`` / ``mutation_rate``, or patch a \
+few lines of the algorithm/evaluator without rewriting the whole file.
+
+WORKFLOW:
+1. Call build_task using the confirmed requirements. If it returns a \
+validation-gate error, refine and retry (or rebuild_evaluator).
+2. VERIFY (required): run `<project>/test_evaluator.py` then \
+`<project>/debug_run.py` with run_python. If either fails, diagnose and fix (via \
+edit_file / write_file / rebuild_evaluator), then re-verify. Repeat until both run \
+without errors.
+3. FOLLOW-UP CHANGES: when the user asks to adjust something after the build — a \
+config parameter, the algorithm, the evaluator, sample data — read the relevant \
+file, apply the change with edit_file (or write_file for larger rewrites, \
+rebuild_evaluator for evaluator logic), then re-verify with run_python and briefly \
+report what changed. Never tell the user to edit files themselves; you have the \
+tools to do it.
+
+COMPLETION CRITERIA (for a build): done only when build_task succeeded AND \
+test_evaluator.py loads the evaluator AND debug_run.py runs without raising. Then \
+briefly summarize what was built and the verification result. If a tool reports a \
+path-access error, you tried to leave the workspace — stay within it.
+
+{_closing_for_surface(surface)}
+
+Respond in the user's language."""
+    return _with_skill_knowledge(prompt)
+
+
+def build_gather_task_message(gathering_context: dict[str, Any], user_content: str) -> str:
+    """Assemble the GATHER-phase user message.
+
+    Args:
+        gathering_context: Session context (conversation memory lives in the
+            restored AgentState, not here; this may carry ``description``).
+        user_content: The user's message this turn.
+
+    Returns:
+        The user-role task message.
+    """
+    parts: list[str] = []
+    description = gathering_context.get("description")
+    if description:
+        parts.append(f"Initial problem description:\n{description}")
+    if user_content.strip():
+        parts.append(user_content.strip())
+    if not parts:
+        parts.append(
+            "Greet the user briefly and ask your first question about the "
+            "optimization problem they want to build an LLM4AD task for."
+        )
+    return "\n\n".join(parts)
+
+
+def build_task_message(proposed: dict[str, Any] | None, user_content: str) -> str:
+    """Assemble the BUILD-phase user message.
+
+    Two situations:
+    - Fresh build (``proposed`` given): the user just confirmed a plan; build it.
+    - Follow-up (``proposed`` is None): the package already exists and the user is
+      asking for a change (e.g. tune a config value, adjust code); apply it and
+      re-verify.
+
+    Args:
+        proposed: The confirmed requirements recorded by ``propose_build``, or None
+            for a follow-up change request.
+        user_content: The user's message this turn.
+
+    Returns:
+        The user-role task message.
+    """
+    parts: list[str] = []
+    if proposed:
+        parts.append(
+            "The user confirmed this build plan:\n"
+            + json.dumps(proposed, ensure_ascii=False, indent=2)
+        )
+        if user_content.strip():
+            parts.append(f"Additional user note:\n{user_content.strip()}")
+        parts.append(
+            "\nBuild the task package now from the confirmed plan, then self-verify "
+            "with run_python until test_evaluator.py and debug_run.py both run cleanly."
+        )
+    else:
+        # Follow-up: the package is already built; apply the requested change.
+        if user_content.strip():
+            parts.append(f"User request:\n{user_content.strip()}")
+        parts.append(
+            "\nThe task package already exists in the workspace. Use list_dir/read_file "
+            "to locate the relevant file, apply the requested change with edit_file "
+            "(or write_file / rebuild_evaluator as appropriate), then re-verify with "
+            "run_python and briefly report what you changed. Do not rebuild from "
+            "scratch unless the user asks for it."
+        )
+    return "\n\n".join(parts)
+
+
+__all__ = [
+    "build_gather_system_prompt",
+    "build_gather_task_message",
+    "build_system_prompt",
+    "build_task_message",
+]

--- a/src/llm4ad/agent/skills/llm4ad-task-builder/SKILL.md
+++ b/src/llm4ad/agent/skills/llm4ad-task-builder/SKILL.md
@@ -1,0 +1,148 @@
+---
+name: llm4ad-task-builder
+description: "Use when a user wants to build an LLM4AD_Next task package — a runnable directory that lets the LLM4AD platform evolve an algorithm for their problem. Covers what files a task package contains, each file's contract, and how the package is run on the LLM4AD platform."
+---
+
+# Building an LLM4AD_Next Task Package
+
+## What LLM4AD_Next is
+
+LLM4AD_Next is an automated algorithm-design platform: it combines an LLM with
+evolutionary optimization to discover and improve algorithms automatically. The
+user describes a problem (e.g. "evolve a solver for the Traveling Salesman
+Problem"), marks the code region to evolve with `# EVOLVE_START` / `# EVOLVE_END`,
+and the platform repeatedly asks an LLM to propose better code inside that region,
+scores each candidate with a custom evaluator, and keeps the best across
+generations. Better algorithms emerge through guided search rather than manual
+trial and error.
+
+Your job with this skill: turn a user's problem into a **complete, runnable task
+package**, then verify it actually runs before handing it over.
+
+## What a task package is
+
+A task package is a self-contained directory with everything the platform needs to
+evolve algorithms for one problem:
+
+| File | Purpose |
+|---|---|
+| `config.yaml` | Master config for the whole pipeline (evolution params, providers, evaluator, dataset). This is what gets run. |
+| `<name>_evaluator.py` | A `BaseEvaluator` subclass that runs a candidate algorithm on test data and returns a score + metrics. Defines what "better" means. |
+| `<algo_dir>/<algo>.py` | The algorithm, with the function to evolve wrapped in `# EVOLVE_START` / `# EVOLVE_END`. Reads input as a JSON CLI arg, prints a JSON result. |
+| `debug_run.py` | Runs the full pipeline once (`LLM4AD("config.yaml").run()`) — a smoke test. |
+| `test_evaluator.py` | Loads the evaluator via the dispatcher to confirm it imports and is wired correctly. |
+| `data/sample/*.json` | 2-3 small test instances the evaluator scores algorithms against. |
+
+## The contracts each file must satisfy
+
+**Algorithm file** (`<algo_dir>/<algo>.py`):
+- The algorithm directory is the one named in `version_control.local_path`; the
+  platform copies it into a git worktree for each candidate and edits only the code
+  between the markers.
+- The function to evolve is wrapped exactly in `# EVOLVE_START` and `# EVOLVE_END`
+  comment markers (the platform only edits code between them).
+- It reads its input as a single JSON string from `sys.argv[1]`, and prints a JSON
+  result to stdout — so the evaluator can run it as a subprocess.
+- The file name must match the name the evaluator looks for (see below). In the TSP
+  example both sides use `solve.py`.
+
+**Evaluator** (`<name>_evaluator.py`):
+- Subclasses `BaseEvaluator`, decorated `@BaseEvaluator.register("<name>")`, with a
+  no-argument `__init__(self)` (the base `__init__` takes no config).
+- Implements `metrics` (list of `Metric(name, type=MINIMIZE|MAXIMIZE, weight, description)`),
+  `name`, and `async def evaluate(self, cfg: EvalContext) -> EvaluationResult`.
+- `cfg: EvalContext` carries `cfg.project_root` (the candidate's worktree dir),
+  `cfg.data_path` (the current data file), and `cfg.timeout` (seconds per instance).
+- `evaluate` locates the algorithm file **by hardcoded name** under
+  `cfg.project_root` (e.g. `Path(cfg.project_root) / "solve.py"`), runs it as a
+  subprocess on `cfg.data_path`, parses its JSON output, validates it, and returns
+  `EvaluationResult(score, metrics, success, ...)` (negative cost for a minimization
+  objective). That hardcoded name **must** equal the algorithm file's actual name —
+  this is the most common wiring mistake.
+
+**config.yaml** (10 sections — generated programmatically, not hand-written):
+- `providers` use `${LLM_BASE_URL}` / `${LLM_API_KEY}` / `${LLM_MODEL}` env
+  placeholders (the platform fills them in).
+- The evaluator `module` reference (`<file>.py:<ClassName>`), the `metrics` list,
+  the `dataset` path (`data/sample`), and the coder `prompt_template`'s EVOLVE block
+  must all be consistent with the other files.
+
+**debug_run.py** / **test_evaluator.py**: standard boilerplate that runs
+`config.yaml` end-to-end and loads the evaluator, respectively.
+
+See `reference/config-template.yaml` for the config shape and `reference/example-tsp.md`
+for a pointer to a complete, known-good package in this repo to adapt.
+
+## The information to gather before building
+
+A correct package needs these decided (ask the user; let the agent fill sensible
+defaults where the user has no preference):
+
+1. **Problem description** — what is being optimized. (Required — ask.)
+2. **Function/algorithm to evolve + input/output format** — ask if the user has any
+   constraints; if not, the agent designs it.
+3. **Evaluation metric(s)** — what to minimize/maximize. (Required — ask clearly.)
+4. **Reuse existing code/evaluator?** — user provides existing code, or generate from
+   scratch. (Ask.)
+5. **Data source** — user provides data, or generate sample instances. (Ask.)
+6. **Programming language** — default Python. (Offer as a choice.)
+7. **Project name** — the agent proposes one from the description; confirm with user.
+
+## Build workflow
+
+1. Understand the problem and the 7 items above (inspect any user-provided code/data).
+2. Write the algorithm file first; verify it runs standalone and prints valid JSON.
+3. Write 2-3 sample data files under `data/sample/`.
+4. Write the evaluator; keep its metrics consistent with `config.yaml`.
+5. Write `config.yaml`, `debug_run.py`, `test_evaluator.py`.
+6. **Self-test (required):** run `test_evaluator.py` (evaluator loads — no LLM, no
+   network, cheap and always runnable). Then run `debug_run.py`, which executes the
+   full pipeline and **does call the LLM**: it needs the `LLM_BASE_URL` /
+   `LLM_API_KEY` / `LLM_MODEL` env vars set (the config uses these placeholders) and
+   consumes tokens over the network. Read every error, fix the relevant file,
+   re-run. Not done until both run cleanly. If no provider credentials are available,
+   say so — a missing-credential failure of `debug_run.py` is not a package defect.
+
+<!-- PLATFORM-USAGE-DRAFT: 以下"如何在平台上使用"为草稿，待产品同学修订 -->
+## How the package is used on the LLM4AD platform
+
+Once the package exists, the user runs it to evolve their algorithm. Two paths:
+
+**CLI:**
+```bash
+llm4ad run path/to/config.yaml
+# resume an interrupted run: pass a real checkpoint file written under
+# ./runs/<project>/<run_id>/checkpoints/ (Island GA names them
+# iga_checkpoint_gen_<N>_<hash>.json; MEoH names them meoh_<N>.json).
+llm4ad run config.yaml --resume ./runs/<project>/<run_id>/checkpoints/iga_checkpoint_gen_5_a1b2c3d4.json
+```
+It launches the evolution pipeline and prints per-generation progress (best score
+each generation).
+
+**Web platform (this project's Web UI):**
+1. Create or open a task (the package's `config.yaml` + files back it).
+2. Configure an LLM provider (the user's own key/model — OpenAI-compatible or
+   Anthropic). The package's `config.yaml` references providers by the platform's
+   env placeholders; the platform injects the real credentials at run time.
+3. Start the evolution run; monitor progress in the browser — current generation,
+   best individual's score, metrics, and logs — in real time.
+4. When it finishes, inspect the best evolved algorithm and its score.
+
+**Tuning after generation (optional):** users often adjust `config.yaml` evolution
+parameters to trade cost vs. quality — e.g. `max_generations`, `num_islands`,
+`island_population_size`, `mutation_rate` / `crossover_rate`, `early_stop_patience`,
+the provider `model`, and `evaluator.timeout`.
+
+**Where results go:** each run writes to `./runs/{project}/{run_id}/`:
+- `best/code/` — the evolved algorithm source (the main deliverable)
+- `best/metadata.json`, `best/summary.txt` — score, generation, metrics
+- `state/evolution_state.json` — full generation history (drives the Web UI dashboards)
+- `logs/llm4ad.log` — full execution log for troubleshooting
+- `checkpoints/` — snapshots to resume from
+<!-- END PLATFORM-USAGE-DRAFT -->
+
+## Completion criteria
+
+The package is done only when `test_evaluator.py` loads the evaluator AND
+`debug_run.py` runs without raising. Then summarize what was built (files + the
+7 decisions) and the verification result.

--- a/src/llm4ad/agent/skills/llm4ad-task-builder/reference/config-template.yaml
+++ b/src/llm4ad/agent/skills/llm4ad-task-builder/reference/config-template.yaml
@@ -1,0 +1,96 @@
+# config.yaml — LLM4AD_Next task package configuration (reference template).
+#
+# 10 sections. Adapt project_name / paths / metrics / the coder prompt_template to
+# the task. Keep providers using the ${LLM_BASE_URL}/${LLM_API_KEY}/${LLM_MODEL}
+# env placeholders — the platform fills these in at run time. The evaluator `module`
+# reference, the `metrics` list, the dataset `path`, and the coder prompt_template's
+# EVOLVE_START/EVOLVE_END block must stay consistent with the other package files.
+
+# 1. General
+project_name: "example_task"
+description_en: "One-line English description for platform display."
+description_zh: "用于平台展示的一句话中文描述。"
+background: |
+  A short paragraph describing the problem, passed to the LLM for context.
+random_seed: 42
+base_dir: "./runs"
+
+# 2. Workspace
+workspace:
+  auto_create: true
+  subdirs: {output: "output", logs: "logs", checkpoints: "checkpoints",
+            generated: "generated", cache: "cache", temp: "temp"}
+
+# 3. Providers (env placeholders — do not hardcode real keys)
+providers:
+  - name: "default"
+    type: "openai_compatible"
+    base_url: ${LLM_BASE_URL}
+    api_key: ${LLM_API_KEY}
+    model: ${LLM_MODEL}
+    temperature: 0.7
+    max_tokens: 8192
+    timeout: 120.0
+
+# 4. Coder (materializes LLM proposals into code)
+coder:
+  type: "custom"
+  provider: "default"
+  timeout: 180.0
+  max_retries: 2
+  default_extension: "py"
+  prompt_template: |
+    Implement the function to evolve. Provide the function body between
+    EVOLVE_START and EVOLVE_END markers.
+
+# 5. Planner (proposes algorithm ideas)
+planner:
+  type: "llm_evolution"
+  provider: "default"
+  selection_strategy: "weighted"
+  parent_selection_strategy: "tournament"
+  build: {script: {}}
+  samplers:
+    - {name: "init_sampler"}
+    - {name: "mutation_sampler"}
+    - {name: "crossover_sampler"}
+
+# 6. Evaluator (module ref + metrics must match the evaluator .py file)
+evaluator:
+  type: "custom"
+  module: "example_evaluator.py:ExampleEvaluator"
+  timeout: 120.0
+  max_retries: 2
+  parallel: true
+  batch_size: 6
+  dataset: {mode: "directory", path: "data/sample", recursive: false}
+  metrics: ["objective", "valid"]
+
+# 7. Evolution (the params users most often tune after generation)
+evolution:
+  type: "island_ga"
+  max_generations: 5
+  num_islands: 2
+  island_population_size: 2
+  mutation_rate: 0.3
+  crossover_rate: 0.5
+  tournament_size: 3
+  early_stop_patience: 10
+
+# 8. Multimodal
+multimodal: {enabled: false}
+
+# 9. Logging
+logging: {level: "INFO", console: true}
+
+# 10. Version control + repo analyzer
+version_control:
+  enabled: true
+  type: "git_worktree"
+  local_path: "example_algorithm"
+  auto_initialize: true
+  default_branch: "main"
+repo_analyzer:
+  type: "evolve_detector"
+  include: ["*.py"]
+  exclude: [".git/**", "__pycache__/**"]

--- a/src/llm4ad/agent/skills/llm4ad-task-builder/reference/example-tsp.md
+++ b/src/llm4ad/agent/skills/llm4ad-task-builder/reference/example-tsp.md
@@ -1,0 +1,28 @@
+# Reference: a complete, known-good task package
+
+For a full, runnable example of an LLM4AD_Next task package, see the TSP benchmark
+in this repository:
+
+    examples/applications/tsp_benchmark_python/
+
+It contains every piece a package needs, and is the best concrete reference to
+adapt:
+
+- `config.yaml` — the 10-section pipeline config (see `../config-template.yaml`
+  here for an annotated skeleton).
+- `tsp_evaluator.py` — a `BaseEvaluator` subclass (`PythonTSPEvaluator`): runs the
+  algorithm as a subprocess, validates the tour, returns score + metrics.
+- `tsp_algorithm/solve.py` — the algorithm with `# EVOLVE_START` / `# EVOLVE_END`
+  around the function to evolve; reads a JSON CLI arg, prints a JSON result.
+- `debug_run.py` — runs the full pipeline once (smoke test).
+- `test_evaluator.py` — loads the evaluator via the dispatcher.
+- `data/` — sample instances the evaluator scores against.
+
+When building a new package, mirror this structure and the file contracts described
+in `../../SKILL.md`, adapting names, the algorithm, the metrics, and the dataset to
+the user's problem.
+
+Note: on the platform (Web UI / backend), the package is generated programmatically
+by the build engine and the same structure is produced automatically — this
+reference is the shape that engine targets and that any coding agent should
+reproduce.

--- a/src/llm4ad/frontend/cli.py
+++ b/src/llm4ad/frontend/cli.py
@@ -1187,6 +1187,230 @@ def evolve_clean(
         raise typer.Exit(code=1)
 
 
+@app.command("chatv2")
+def chat_agent_build(
+    provider_name: str | None = typer.Option(
+        None,
+        "--provider",
+        "-p",
+        help="Provider name defined in global settings (~/.llm4ad/settings.yaml). "
+        "Uses the first provider if not specified.",
+    ),
+    output: str = typer.Option(
+        "./",
+        "--output",
+        "-o",
+        help="Output directory where the built LLM4AD task package will be written.",
+    ),
+    prompt: str | None = typer.Option(
+        None,
+        "--prompt",
+        help="Problem description passed directly to the agent. "
+        "If omitted, the agent will ask you interactively.",
+    ),
+    max_iters: int = typer.Option(
+        40,
+        "--max-iters",
+        help="Maximum agent ReAct loop iterations.",
+    ),
+):
+    """Build an LLM4AD task package using an AI agent (beta).
+
+    Launches a single AgentScope ReAct agent that gathers your requirements,
+    generates a complete task package (evaluator, algorithm, config, test scripts)
+    via the proven build engine, and self-verifies the result by running the
+    generated scripts.
+
+    The agent reads and runs files inside the output directory; it cannot access
+    anything outside it. The generated code runs with your local user privileges —
+    intended for local developer use.
+
+    Requires the ``agent`` extra (Python >=3.11)::
+
+        pip install 'llm4ad[agent]'
+        # or: uv sync --extra agent
+
+    Configure a provider in ~/.llm4ad/settings.yaml, for example::
+
+        providers:
+          - name: deepseek
+            type: anthropic
+            base_url: https://api.deepseek.com/anthropic
+            auth_token: sk-...
+            model: deepseek-v4-pro
+    """
+    import asyncio
+    import contextlib
+    import sys
+    from pathlib import Path
+
+    # Reconfigure stdout/stderr to UTF-8 so streamed agent output (which may contain
+    # non-ASCII / emoji) does not crash on a legacy Windows cp1252 console.
+    for _stream in (sys.stdout, sys.stderr):
+        reconfigure = getattr(_stream, "reconfigure", None)
+        if reconfigure is not None:
+            with contextlib.suppress(ValueError, OSError):
+                reconfigure(encoding="utf-8", errors="replace")
+
+    # ---- Dependency check (friendly error before any import hang) ----
+    try:
+        import agentscope  # noqa: F401
+    except ImportError:
+        console.print(
+            "[bold red]Error:[/bold red] The [bold]agent[/bold] extra is not installed.\n"
+            "Install it with:\n\n"
+            "    [bold]pip install 'llm4ad[agent]'[/bold]\n\n"
+            "Note: Python >=3.11 is required for the agent extra.\n"
+            f"You are running Python {sys.version_info.major}.{sys.version_info.minor}."
+        )
+        raise typer.Exit(code=1) from None
+
+    from llm4ad.config.settings import load_global_settings
+    from llm4ad.infra.provider.base import BaseProvider
+
+    # ---- Provider resolution (same pattern as `chat`) ----
+    global_data = load_global_settings()
+    global_providers = global_data.get("providers", [])
+
+    if not global_providers:
+        console.print(
+            "[bold red]Error:[/bold red] No providers found in global settings.\n"
+            "Please configure a provider in [bold]~/.llm4ad/settings.yaml[/bold].\n"
+            "Example:\n"
+            "  providers:\n"
+            '    - name: "deepseek"\n'
+            '      type: "anthropic"\n'
+            '      base_url: "https://api.deepseek.com/anthropic"\n'
+            '      auth_token: "${DEEPSEEK_API_KEY}"\n'
+            '      model: "deepseek-v4-pro"'
+        )
+        raise typer.Exit(code=1)
+
+    providers_by_name = {p.get("name", "default"): p for p in global_providers}
+
+    if provider_name is None:
+        provider_cfg = global_providers[0]
+        provider_name = provider_cfg.get("name", "default")
+        console.print(f"[dim]Using provider: {provider_name}[/dim]")
+    else:
+        if provider_name not in providers_by_name:
+            console.print(
+                f"[bold red]Error:[/bold red] Provider '{provider_name}' not found.\n"
+                f"Available: {', '.join(providers_by_name.keys())}"
+            )
+            raise typer.Exit(code=1)
+        provider_cfg = providers_by_name[provider_name]
+
+    # Validate base_dir
+    base_dir = str(Path(output).resolve())
+    Path(base_dir).mkdir(parents=True, exist_ok=True)
+
+    # ---- Collect problem description ----
+    user_content = prompt or ""
+    if not user_content.strip():
+        console.print(
+            "[bold]AI Build (Beta)[/bold] — describe your optimization problem\n"
+            "(or press Ctrl-C to cancel)"
+        )
+        user_content = typer.prompt("Problem description")
+
+    # ---- Security notice ----
+    console.print(
+        f"\n[yellow]! The agent will run generated Python code inside "
+        f"[bold]{base_dir}[/bold] with your local privileges.[/yellow]\n"
+    )
+
+    # Need a BaseProvider for the build engine; agentscope model is built inside core.
+    BaseProvider.discover("llm4ad.infra.provider")
+
+    # ---- Run agent loop (multi-turn: gather -> confirm -> build) ----
+    from llm4ad.agent.runner import AgentBuildConfig, run_agent_build
+
+    console.print("[bold green]Starting agent...[/bold green]\n")
+
+    async def _run_turn(
+        turn_input: str,
+        *,
+        allow_build: bool,
+        prior_state: dict | None,
+        proposed: dict | None,
+    ) -> dict:
+        """Run one agent turn; return {state, proposed, built, project_name}."""
+        cfg = AgentBuildConfig(
+            provider_config=provider_cfg,
+            base_dir=base_dir,
+            user_content=turn_input,
+            allow_build=allow_build,
+            prior_state=prior_state,
+            proposed=proposed,
+            max_iters=max_iters,
+            surface="cli",
+        )
+        result: dict = {"state": prior_state, "proposed": None, "built": False, "project_name": ""}
+        async for event in run_agent_build(cfg):
+            etype = event.get("type")
+            if etype == "chunk":
+                # Straight to stdout (UTF-8 reconfigured above), bypassing rich's
+                # legacy-Windows console path which can crash on emoji.
+                sys.stdout.write(event.get("content", ""))
+                sys.stdout.flush()
+            elif etype == "payload":
+                result["proposed"] = event.get("proposed")
+            elif etype == "build_result":
+                bp = event.get("blueprint_data", {})
+                result["built"] = bool(bp.get("built"))
+                result["project_name"] = bp.get("project_name", "")
+            elif etype == "agent_state":
+                result["state"] = event.get("state")
+            elif etype == "error":
+                console.print(f"\n[bold red]Error:[/bold red] {event.get('error', '')}")
+        return result
+
+    async def _run() -> bool:
+        """Gather step-by-step, confirm, then build."""
+        prior_state: dict | None = None
+        turn_input = user_content
+        # Gather loop: keep talking until the agent proposes a plan the user accepts.
+        for _ in range(50):
+            r = await _run_turn(
+                turn_input, allow_build=False, prior_state=prior_state, proposed=None
+            )
+            prior_state = r["state"]
+            proposed = r["proposed"]
+            if proposed is None:
+                # Agent asked a question; get the user's answer and continue.
+                console.print()
+                turn_input = typer.prompt("You")
+                continue
+            # Agent proposed a build plan -> confirm.
+            console.print()
+            if typer.confirm("确认按此方案开始构建? (Confirm build?)", default=True):
+                br = await _run_turn(
+                    "", allow_build=True, prior_state=prior_state, proposed=proposed
+                )
+                if br["built"]:
+                    console.print(
+                        f"\n\n[bold green]Build complete![/bold green] "
+                        f"Project: [bold]{br['project_name'] or '?'}[/bold]\n"
+                        f"Output: {base_dir}"
+                    )
+                    return True
+                console.print("\n[yellow]Build finished but no package was produced.[/yellow]")
+                return False
+            # User declined -> keep adjusting.
+            console.print()
+            turn_input = typer.prompt("You (keep adjusting)")
+        console.print("\n[yellow]Reached max gather turns without building.[/yellow]")
+        return False
+
+    try:
+        ok = asyncio.run(_run())
+        raise typer.Exit(code=0 if ok else 1)
+    except KeyboardInterrupt:
+        console.print("\n[yellow]Cancelled.[/yellow]")
+        raise typer.Exit(code=1) from None
+
+
 def main():
     """Main entrypoint for the CLI."""
     app()

--- a/src/llm4ad/infra/provider/anthropic.py
+++ b/src/llm4ad/infra/provider/anthropic.py
@@ -68,12 +68,25 @@ class AnthropicProvider(BaseProvider):
         """
         super().__init__(config)
 
-        # Initialize async Anthropic client
-        client_kwargs = {
-            "api_key": self.api_key,
+        # Initialize async Anthropic client.
+        # Support both auth styles: ``api_key`` -> ``x-api-key`` header (official
+        # API) and ``auth_token`` -> ``Authorization: Bearer`` header (used by some
+        # Anthropic-compatible gateways, e.g. DeepSeek's /anthropic endpoint). Pass
+        # each only when set so the SDK can resolve a single method without the
+        # "Could not resolve authentication method" error.
+        auth_token = config.get("auth_token") or ""
+        client_kwargs: dict[str, Any] = {
             "timeout": self.timeout,
             "max_retries": self.max_retries,
         }
+        if self.api_key:
+            client_kwargs["api_key"] = self.api_key
+        if auth_token:
+            client_kwargs["auth_token"] = auth_token
+        if not self.api_key and not auth_token:
+            # Preserve prior behavior (SDK falls back to ANTHROPIC_API_KEY env)
+            # rather than silently sending no credential.
+            client_kwargs["api_key"] = self.api_key
         if self.base_url is not None:
             client_kwargs["base_url"] = self.base_url
 

--- a/uv.lock
+++ b/uv.lock
@@ -27,6 +27,41 @@ wheels = [
 ]
 
 [[package]]
+name = "agentscope"
+version = "2.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiofiles", marker = "python_full_version >= '3.11'" },
+    { name = "aioitertools", marker = "python_full_version >= '3.11'" },
+    { name = "anthropic", marker = "python_full_version >= '3.11'" },
+    { name = "dashscope", marker = "python_full_version >= '3.11'" },
+    { name = "docstring-parser", marker = "python_full_version >= '3.11'" },
+    { name = "filetype", marker = "python_full_version >= '3.11'" },
+    { name = "httpx", marker = "python_full_version >= '3.11'" },
+    { name = "jinja2", marker = "python_full_version >= '3.11'" },
+    { name = "json-repair", marker = "python_full_version >= '3.11'" },
+    { name = "json5", marker = "python_full_version >= '3.11'" },
+    { name = "jsonschema", marker = "python_full_version >= '3.11'" },
+    { name = "mcp", marker = "python_full_version >= '3.11'" },
+    { name = "numpy", marker = "python_full_version >= '3.11'" },
+    { name = "openai", marker = "python_full_version >= '3.11'" },
+    { name = "opentelemetry-api", marker = "python_full_version >= '3.11'" },
+    { name = "opentelemetry-exporter-otlp", marker = "python_full_version >= '3.11'" },
+    { name = "opentelemetry-sdk", marker = "python_full_version >= '3.11'" },
+    { name = "opentelemetry-semantic-conventions", marker = "python_full_version >= '3.11'" },
+    { name = "python-datauri", marker = "python_full_version >= '3.11'" },
+    { name = "python-frontmatter", marker = "python_full_version >= '3.11'" },
+    { name = "python-socketio", marker = "python_full_version >= '3.11'" },
+    { name = "shortuuid", marker = "python_full_version >= '3.11'" },
+    { name = "tree-sitter", marker = "python_full_version >= '3.11'" },
+    { name = "tree-sitter-bash", marker = "python_full_version >= '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/97/12/4ed72815f9bb06fd869eaf3c22765421ec263364ca52efc506fcad5cc997/agentscope-2.0.3.tar.gz", hash = "sha256:6359380e2dd0995a025d824468c4ab1b0464f92077d38333b561ab635c2956ce", size = 521636, upload-time = "2026-06-29T02:09:14.13Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/0b/9698adbd8b0887e8ce2162a356dc1be8f9f4d090be5255234ed8a2550edd/agentscope-2.0.3-py3-none-any.whl", hash = "sha256:070cc4cec54aa0fb0fc66afaaa41cde2c04b18af6c3755a075c4bc7853ab9766", size = 697856, upload-time = "2026-06-29T02:09:12.366Z" },
+]
+
+[[package]]
 name = "aiofiles"
 version = "25.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -162,6 +197,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/78/b7/15fb7a9d52e112a25b621c67b69c167805cb1f2ab8f1708a5c490d1b52fe/aiohttp-3.13.5-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:3b13560160d07e047a93f23aaa30718606493036253d5430887514715b67c9d9", size = 1772072, upload-time = "2026-03-31T22:00:07.494Z" },
     { url = "https://files.pythonhosted.org/packages/7e/df/57ba7f0c4a553fc2bd8b6321df236870ec6fd64a2a473a8a13d4f733214e/aiohttp-3.13.5-cp314-cp314t-win32.whl", hash = "sha256:9a0f4474b6ea6818b41f82172d799e4b3d29e22c2c520ce4357856fced9af2f8", size = 471819, upload-time = "2026-03-31T22:00:10.277Z" },
     { url = "https://files.pythonhosted.org/packages/62/29/2f8418269e46454a26171bfdd6a055d74febf32234e474930f2f60a17145/aiohttp-3.13.5-cp314-cp314t-win_amd64.whl", hash = "sha256:18a2f6c1182c51baa1d28d68fea51513cb2a76612f038853c0ad3c145423d3d9", size = 505441, upload-time = "2026-03-31T22:00:12.791Z" },
+]
+
+[[package]]
+name = "aioitertools"
+version = "0.13.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fd/3c/53c4a17a05fb9ea2313ee1777ff53f5e001aefd5cc85aa2f4c2d982e1e38/aioitertools-0.13.0.tar.gz", hash = "sha256:620bd241acc0bbb9ec819f1ab215866871b4bbd1f73836a55f799200ee86950c", size = 19322, upload-time = "2025-11-06T22:17:07.609Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/a1/510b0a7fadc6f43a6ce50152e69dbd86415240835868bb0bd9b5b88b1e06/aioitertools-0.13.0-py3-none-any.whl", hash = "sha256:0be0292b856f08dfac90e31f4739432f4cb6d7520ab9eb73e143f4f2fa5259be", size = 24182, upload-time = "2025-11-06T22:17:06.502Z" },
 ]
 
 [[package]]
@@ -304,6 +348,15 @@ wheels = [
 ]
 
 [[package]]
+name = "bidict"
+version = "0.23.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/6e/026678aa5a830e07cd9498a05d3e7e650a4f56a42f267a53d22bcda1bdc9/bidict-0.23.1.tar.gz", hash = "sha256:03069d763bc387bbd20e7d49914e75fc4132a41937fa3405417e1a5a2d006d71", size = 29093, upload-time = "2024-02-18T19:09:05.748Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/99/37/e8730c3587a65eb5645d4aba2d27aae48e8003614d6aaf15dda67f702f1f/bidict-0.23.1-py3-none-any.whl", hash = "sha256:5dae8d4d79b552a71cbabc7deb25dfe8ce710b17ff41711e13010ead2abfc3e5", size = 32764, upload-time = "2024-02-18T19:09:04.156Z" },
+]
+
+[[package]]
 name = "black"
 version = "26.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -389,6 +442,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/5a/e1/8a2560ef4756c9677fb0a0e10197dbdcb8ad04ca60e8a5070f828a3ab6fd/Box2D-2.3.10-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:27802979e12b904bdfd28373963020be0b42a0bc2f019e8f4f0dad30da71e506", size = 1336400, upload-time = "2024-11-29T18:28:10.431Z" },
     { url = "https://files.pythonhosted.org/packages/4a/4a/7231163bc86cd1f76561c2afde360f478d9ef3766295868059230c5c248e/Box2D-2.3.10-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d3c4f4d853e2f351fabb1ed113f1527b987ab1b944112090cf5fa5368a116455", size = 1295547, upload-time = "2024-11-29T18:28:23.296Z" },
     { url = "https://files.pythonhosted.org/packages/b8/c1/a4d8bd2f28466fb0f6973e3eff8c691bdfd5a7cb15bbe69afa2bcda271b0/Box2D-2.3.10-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:003456c0edb68cae3d7a0064d9564c6845f37285a42d75428cb4425567d569d9", size = 1315214, upload-time = "2024-11-29T18:28:24.702Z" },
+]
+
+[[package]]
+name = "cached-property"
+version = "2.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/76/4b/3d870836119dbe9a5e3c9a61af8cc1a8b69d75aea564572e385882d5aefb/cached_property-2.0.1.tar.gz", hash = "sha256:484d617105e3ee0e4f1f58725e72a8ef9e93deee462222dbd51cd91230897641", size = 10574, upload-time = "2024-10-25T15:43:55.667Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/11/0e/7d8225aab3bc1a0f5811f8e1b557aa034ac04bdf641925b30d3caf586b28/cached_property-2.0.1-py3-none-any.whl", hash = "sha256:f617d70ab1100b7bcf6e42228f9ddcb78c676ffa167278d9f730d1c2fba69ccb", size = 7428, upload-time = "2024-10-25T15:43:54.711Z" },
 ]
 
 [[package]]
@@ -1020,6 +1082,24 @@ wheels = [
 ]
 
 [[package]]
+name = "dashscope"
+version = "1.26.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp", marker = "python_full_version >= '3.11'" },
+    { name = "certifi", marker = "python_full_version >= '3.11'" },
+    { name = "cryptography", marker = "python_full_version >= '3.11'" },
+    { name = "requests", marker = "python_full_version >= '3.11'" },
+    { name = "rich", marker = "python_full_version >= '3.11'" },
+    { name = "typer", marker = "python_full_version >= '3.11'" },
+    { name = "websocket-client", marker = "python_full_version >= '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2b/b6/17b6b08ceb08f9ec2102db5a9c0afe0b5d61b63a972a4615c50252669c1e/dashscope-1.26.0.tar.gz", hash = "sha256:2c806c6e735a47f1f31814e700f5cc073cd101a860302562bd8eaa210bdef991", size = 1390453, upload-time = "2026-06-25T10:46:52.74Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fc/ec/6895fb7b8977014f8e0a009a5298ab4e6a31f06aaa07373890fee84348a3/dashscope-1.26.0-py3-none-any.whl", hash = "sha256:ddfbda55a0196ec4c1a3cfc6be610b53310dfdb95ed4a293f6cc699809500ba4", size = 1481554, upload-time = "2026-06-25T10:46:51.037Z" },
+]
+
+[[package]]
 name = "deprecated"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1068,6 +1148,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/2e/2c/8384832b7a6b1fd6ba95bbdcae26e7137bb3eedc955c42fd5cdcc086cfbf/Farama-Notifications-0.0.4.tar.gz", hash = "sha256:13fceff2d14314cf80703c8266462ebf3733c7d165336eee998fc58e545efd18", size = 2131, upload-time = "2023-02-27T18:28:41.047Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/05/2c/ffc08c54c05cdce6fbed2aeebc46348dbe180c6d2c541c7af7ba0aa5f5f8/Farama_Notifications-0.0.4-py3-none-any.whl", hash = "sha256:14de931035a41961f7c056361dc7f980762a143d05791ef5794a751a2caf05ae", size = 2511, upload-time = "2023-02-27T18:28:39.447Z" },
+]
+
+[[package]]
+name = "filetype"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bb/29/745f7d30d47fe0f251d3ad3dc2978a23141917661998763bebb6da007eb1/filetype-1.2.0.tar.gz", hash = "sha256:66b56cd6474bf41d8c54660347d37afcc3f7d1970648de365c102ef77548aadb", size = 998020, upload-time = "2022-11-02T17:34:04.141Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/79/1b8fa1bb3568781e84c9200f951c735f3f157429f44be0495da55894d620/filetype-1.2.0-py2.py3-none-any.whl", hash = "sha256:7ce71b6880181241cf7ac8697a2f1eb6a8bd9b429f7ad6d27b8db9ba5f1c2d25", size = 19970, upload-time = "2022-11-02T17:34:01.425Z" },
 ]
 
 [[package]]
@@ -1285,6 +1374,18 @@ wheels = [
 ]
 
 [[package]]
+name = "googleapis-common-protos"
+version = "1.75.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf", marker = "python_full_version >= '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b5/c8/f439cffde755cffa462bfbb156278fa6f9d09119719af9814b858fd4f81f/googleapis_common_protos-1.75.0.tar.gz", hash = "sha256:53a062ff3c32552fbd62c11fe23768b78e4ddf0494d5e5fd97d3f4689c75fbbd", size = 151035, upload-time = "2026-05-07T08:04:49.423Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/c8/e2645aa8ed02fd4c7a2f59d68783b65b1f3cbdfe39a6308e156509d1fee8/googleapis_common_protos-1.75.0-py3-none-any.whl", hash = "sha256:961ed60399c457ceb0ee8f285a84c870aabc9c6a832b9d37bb281b5bebde43ed", size = 300631, upload-time = "2026-05-07T08:03:30.345Z" },
+]
+
+[[package]]
 name = "graphemeu"
 version = "0.7.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1300,6 +1401,67 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/9d/82/74f4a3310cdabfbb10da554c3a672847f1ed33c6f61dd472681ce7f1fe67/griffelib-2.0.2.tar.gz", hash = "sha256:3cf20b3bc470e83763ffbf236e0076b1211bac1bc67de13daf494640f2de707e", size = 166461, upload-time = "2026-03-27T11:34:51.091Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/11/8c/c9138d881c79aa0ea9ed83cbd58d5ca75624378b38cee225dcf5c42cc91f/griffelib-2.0.2-py3-none-any.whl", hash = "sha256:925c857658fb1ba40c0772c37acbc2ab650bd794d9c1b9726922e36ea4117ea1", size = 142357, upload-time = "2026-03-27T11:34:46.275Z" },
+]
+
+[[package]]
+name = "grpcio"
+version = "1.81.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version >= '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b0/b5/1ff353970a87eda4c98251e34d2dfd214abd4982dc89119c9252a2a482d2/grpcio-1.81.1.tar.gz", hash = "sha256:6fa10a767143a5e82e8eaab53918af0cd8909a57a27f8cb2288b80a613ac671b", size = 13026582, upload-time = "2026-06-11T12:46:51.673Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/d5/f2b159d8eec08be2a855ef698f5b6f7f9fdda022e4dd9e4f5d968affd678/grpcio-1.81.1-cp310-cp310-linux_armv7l.whl", hash = "sha256:6f9a0c9c1cc15c112d1c053064fd032b64917062292c3d70aea280e02ae10b77", size = 6086868, upload-time = "2026-06-11T12:44:19.364Z" },
+    { url = "https://files.pythonhosted.org/packages/80/41/9c95232b94b219ed8b14029d9cd000e0381cafba869c451dda60af84f4ba/grpcio-1.81.1-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:69ef28e54fc85397f91b8c19592b8ef3d81952080366914823bd8572a2958120", size = 12062291, upload-time = "2026-06-11T12:44:27.142Z" },
+    { url = "https://files.pythonhosted.org/packages/83/8b/bd9284bdd665ddf877a3e8bc2930d1bcf6ebdbae7b0da5c783dc26bd6e33/grpcio-1.81.1-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:15641444eca4a29358107b3dceb74c1c6305c55c822fd199b458aaea4068a7fb", size = 6635242, upload-time = "2026-06-11T12:44:30.741Z" },
+    { url = "https://files.pythonhosted.org/packages/60/24/78fa025517a925f1a17da71c4ef9d5f1c6f9fa65af22dfb523c5c6317a21/grpcio-1.81.1-cp310-cp310-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:d4b2dddfc219f54f956ccd53cf76a1d338ffe68fc7f2849ec9c7feb9927ff692", size = 7332974, upload-time = "2026-06-11T12:44:33.72Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/11/402295b388dd35861007f8a26a37c2e2f284212d57bdf407c31f36043746/grpcio-1.81.1-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ca1cc11d82677b9662082e5478b7528e2b7db7beaa6bdff42bd62789d81be399", size = 6836597, upload-time = "2026-06-11T12:44:36.108Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/71/37b10fd4fd579ffade6e695c14e9df5e8cba9e2365b81c131da438b67c34/grpcio-1.81.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:aa2ba7d2ad6df4d80127cea65e5b8d5e2c3adbf153ff4804452836328aca7c54", size = 7440660, upload-time = "2026-06-11T12:44:38.664Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/d5/40203f828abc83d458b634666df6df13778032f178c03845ad5a93682388/grpcio-1.81.1-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:592b5fee597faa91cce2dd294dd7d9a1c83d76c4dbf877e33ec1adb866b2fbed", size = 8443171, upload-time = "2026-06-11T12:44:41.678Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/2c/0ed82ea35b5ec595e10444940c1db8c0e0ef57aa46bc8797d5ff838a219e/grpcio-1.81.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:62481553b1793a27e9b9c3cf9e5bd483ef045ca72462592074b46d42b0c4d9b9", size = 7868905, upload-time = "2026-06-11T12:44:44.854Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/1f/dcbdc1a68a07cc2b631c3098953794f17d75f93426a019240b90ce5423d6/grpcio-1.81.1-cp310-cp310-win32.whl", hash = "sha256:bb693b1e3d9a2f3fd228e2110daf4b5aeedb36761ca1e4282f74725f6d89f611", size = 4202215, upload-time = "2026-06-11T12:44:47.165Z" },
+    { url = "https://files.pythonhosted.org/packages/75/a1/d7ab9f1f42efcb7d9e6111d38be6b367737a72ea2c534e1f55c81e1b6436/grpcio-1.81.1-cp310-cp310-win_amd64.whl", hash = "sha256:88268ca418cacea64cecb0d1d600d3c6b3a8038fcba02e1e205178c5b1f47661", size = 4936582, upload-time = "2026-06-11T12:44:49.479Z" },
+    { url = "https://files.pythonhosted.org/packages/52/ea/1c2fa386b718ff493225e61cfc052ef400b4d6ffc54cbe261026432624b5/grpcio-1.81.1-cp311-cp311-linux_armv7l.whl", hash = "sha256:d71d30f2d92f67d944631c523713934fee37292469e182ebcd2c1dd8a64ce53f", size = 6093112, upload-time = "2026-06-11T12:44:52.131Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/18/acf45fa8bd1bc5d7b0c2fd3dc4c209379fbd5bb396b440b68a83342226b7/grpcio-1.81.1-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:b137f4bf3ada9dc44d411478decc6ff09a79ed30b306cd2abaa98408c3588137", size = 12074277, upload-time = "2026-06-11T12:44:55.354Z" },
+    { url = "https://files.pythonhosted.org/packages/48/d7/ee86a60699b7db039f772a2c4a7e4facc7138984ff42c0130933a0063884/grpcio-1.81.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:a3acb384427816dd5d470f47e62137b87f74da694faa8a50147012cf40df276a", size = 6640348, upload-time = "2026-06-11T12:44:59.223Z" },
+    { url = "https://files.pythonhosted.org/packages/26/ee/d2de5e47378ffc207d476c230fea3be4d2601edbce9995f4fe45535d4896/grpcio-1.81.1-cp311-cp311-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:f9a0ebbe45c29b5e5866593c12b78bd9035f0f0f0d4bc8361680cd580d99db49", size = 7331842, upload-time = "2026-06-11T12:45:02.001Z" },
+    { url = "https://files.pythonhosted.org/packages/23/d6/abeda5c2b896a0b341584fe5ac411bbf72e197a9a374c355fb90965e08d2/grpcio-1.81.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0a37165cc80b1a368384b383e63a4c38116a10467ae44c904d2d7468c4470ec2", size = 6842229, upload-time = "2026-06-11T12:45:04.76Z" },
+    { url = "https://files.pythonhosted.org/packages/10/1c/1f0da7d590b4aeee006826ba568d0e419ca14b23e18f901a3da3e9fba613/grpcio-1.81.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:6282caffb41ec326d4cb67ca9cf53b739d1b2f975a2acb498c7418e9f7d9a416", size = 7446096, upload-time = "2026-06-11T12:45:07.499Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/81/5c505d508f7c887aa7982d21443a4126597c80d34b0bcf40f9cec576d7f3/grpcio-1.81.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:a35009284d0d3d5c2c9601c164a911b8b4331608d98a9a66d47d97bb2f522b70", size = 8445238, upload-time = "2026-06-11T12:45:10.243Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/b2/524847365122ee509ca17bcc4e092198b700e94af7bfd5bb5e6dd9f3ee66/grpcio-1.81.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:1b22c80559854b789a01fd89e8929b3798a156c0829b5282a8939f33ad4115ad", size = 7873989, upload-time = "2026-06-11T12:45:13.102Z" },
+    { url = "https://files.pythonhosted.org/packages/18/fa/07c037c50b006909d1d13a5848774f8aa7b242f70dc03a035c64eea0e6db/grpcio-1.81.1-cp311-cp311-win32.whl", hash = "sha256:428bec0161b48d8cf583c068591bc0016d0d9cfff52462b72b3884861ea768c5", size = 4202223, upload-time = "2026-06-11T12:45:16.166Z" },
+    { url = "https://files.pythonhosted.org/packages/41/ed/6bff15376920942fac6b95b9802752b837437172c9e8fc2d3170546b89cc/grpcio-1.81.1-cp311-cp311-win_amd64.whl", hash = "sha256:30e825f6848d9f18bba350ed6c75c1b02a0b5184474a31db9a32b1fa66fd8c79", size = 4941303, upload-time = "2026-06-11T12:45:18.724Z" },
+    { url = "https://files.pythonhosted.org/packages/85/07/9a979c81738863a738dc23d65177056e71fbb2db817740ed870b33434e7a/grpcio-1.81.1-cp312-cp312-linux_armv7l.whl", hash = "sha256:8b39472beafc0bdcafc4c8c73ad082ebfdb449d566897a61e7acb4fa88089115", size = 6053264, upload-time = "2026-06-11T12:45:21.017Z" },
+    { url = "https://files.pythonhosted.org/packages/75/95/539706ca0d3bd40dbad583dc56fd883da941f37556b629132da5762781b9/grpcio-1.81.1-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:12b7524c88d4026d3dcb7b0ebe16b6714f3b4af402ddd0f0639ab064a00c87c3", size = 12052560, upload-time = "2026-06-11T12:45:23.652Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/44/f257b7e0bd69c93b06c6cb8ac8d1b901ccb42bedabd83c1a4c77a71f8810/grpcio-1.81.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:1e123f9b37edb8375fd74130d1f69c944bbf0a7b06761ae7211154b8759e94d2", size = 6595983, upload-time = "2026-06-11T12:45:26.963Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/f3/19782aa04c960968bef8c5539329d8e3bbc3364e2e46d19eb5e5cc5e43b7/grpcio-1.81.1-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:2c2e2ae6867c2966b8daccc836d54a13218e0007e9a490aeb81dd05be64d22d7", size = 7303455, upload-time = "2026-06-11T12:45:29.707Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/8c/dea020b6d91508cd84463917a63149ec196ee7db505d032ae43fcb3303b9/grpcio-1.81.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:766bc7c9a9c340342f4c864ccbda8e78111e4751f13b895812b9c148fb79e9d0", size = 6809167, upload-time = "2026-06-11T12:45:32.52Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/c7/3030dd940408083bd32cd95d634777a71605ade4887154d93e8a89244946/grpcio-1.81.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:b259a04a737cb3496be0901328eb8b7552ed8df4865d8c8f1cf1bffcfc0776a3", size = 7412536, upload-time = "2026-06-11T12:45:35.403Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/dd/1172a9e42b168edcafefad6115346ef619a3fc02158bb170e66ced24bcdd/grpcio-1.81.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:85b10a45b8993d195c4f3ff57025b8d1e11834909ee475c403bfa60cb4caefaf", size = 8408276, upload-time = "2026-06-11T12:45:37.78Z" },
+    { url = "https://files.pythonhosted.org/packages/25/7a/71437c7f3596e5246155c515852795a85a1a8d228190212432b13b97a95d/grpcio-1.81.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:8ea1936c26b99999b27479853039a7f34713f56c49375ad52b38535ec93a796c", size = 7849660, upload-time = "2026-06-11T12:45:40.627Z" },
+    { url = "https://files.pythonhosted.org/packages/65/40/7debc0da45d2efebafb82da75644be347497fe4ee250514b8cd3b86ae8bf/grpcio-1.81.1-cp312-cp312-win32.whl", hash = "sha256:a185a04039df6cae8648bc8ab6d6fde7bf94f7188ecf7828e76ac52eef1e41d6", size = 4185819, upload-time = "2026-06-11T12:45:43.027Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/b9/8fe3ba5ed462067774ebc1f9c7f26aa7ebcc280ddd476be107153de1339e/grpcio-1.81.1-cp312-cp312-win_amd64.whl", hash = "sha256:3ad74f8bb1a18963914c5452d289422830b39459e8776ebbcd207be1fbfb1d94", size = 4930461, upload-time = "2026-06-11T12:45:45.775Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/42/dcc2e4b600538ef18327c0839d56b7d3c3812337c5d710df5877dbb39b1e/grpcio-1.81.1-cp313-cp313-linux_armv7l.whl", hash = "sha256:b10e1ff4756ed27d5a29d7fc79cfce7ef1ff56ad20025b89bac7cf79e09abbbe", size = 6054466, upload-time = "2026-06-11T12:45:48.43Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/4a/a36e03210183a8a7d4c80c3936acee679f4bd77d5861f369db47b2cc5f05/grpcio-1.81.1-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:819edbdcb42ab8598b494bcf0222684bbb7a3c772bd1b1f0be7e029a6063c28e", size = 12048795, upload-time = "2026-06-11T12:45:54.011Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/d5/d68e30b29098f63beab6fe501100fe82674ff142b32c672532da86a99b3a/grpcio-1.81.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:c5bf2dc311127d91230cc79b92188c082634a06cf66c5234db49a43b910183b0", size = 6599094, upload-time = "2026-06-11T12:45:57.799Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/b3/e837954d279754f638a11cca5dcf6b24a005efb398984cefaf7735945a54/grpcio-1.81.1-cp313-cp313-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:e8ca6a1fcdb2943c9cbc1804a1baf3acb6071d72a471591678ded84218006e14", size = 7307182, upload-time = "2026-06-11T12:46:00.568Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/1e/b47957057e729adc6cdf519a47f8be2562b7140e280f1418443eb4022192/grpcio-1.81.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e64dd101d380a115cc5a0c7856788adb535f1a4e21fc543775602f8be95180ae", size = 6810962, upload-time = "2026-06-11T12:46:03.312Z" },
+    { url = "https://files.pythonhosted.org/packages/40/26/569868e364e05b19ec8f969da53d230bcd89c962cd198f7c29943155c4d3/grpcio-1.81.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:98a07f9bf591e3a8919797bee1c53f026ba4acd587e5a4404c8e57c9ec36b2a5", size = 7415698, upload-time = "2026-06-11T12:46:06.005Z" },
+    { url = "https://files.pythonhosted.org/packages/36/0c/5440a0582cb5653fc42a6e262eeb22700943313f8076f9dc927491b20a59/grpcio-1.81.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:c261d74b1a945cf895a9d6eccd1685a8e837531beaab782da4d630a8d12deffb", size = 8407779, upload-time = "2026-06-11T12:46:08.84Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/aa/66fe9f39871d766987d869a03ee0842a026f499c7b1e62decb9e78a8088e/grpcio-1.81.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:58ad1131c300d3c9b933802b3cc4dc69d380822935ba50b28703156ea826fbf7", size = 7844521, upload-time = "2026-06-11T12:46:12.171Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/9e/69bb7194861bcd28fb3193261d4f9c3831b4446993f002cf59068943e7ab/grpcio-1.81.1-cp313-cp313-win32.whl", hash = "sha256:78e29211f26da2fdd0e9c6d2b79f489476140cf7029b6a64808ade7ca4156a42", size = 4182786, upload-time = "2026-06-11T12:46:15.192Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/20/3da8bb0d637feccdc3e1e419bb511ce93651ce7d54164f95de22cc0b8b34/grpcio-1.81.1-cp313-cp313-win_amd64.whl", hash = "sha256:edb59506291b647a30884b1d51a599d605f40b20af4a7dc3d33786a47a31de60", size = 4928648, upload-time = "2026-06-11T12:46:17.823Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/58/19414622b1bf6981bc9c05a365bd548e71876c89000083b3af489251e9c0/grpcio-1.81.1-cp314-cp314-linux_armv7l.whl", hash = "sha256:506f48f2f9c29b143fca3dad7b0d518c188b6c9648c75a2ae6e2d9f2c13a060b", size = 6055336, upload-time = "2026-06-11T12:46:20.557Z" },
+    { url = "https://files.pythonhosted.org/packages/32/f1/2ec88adb92b0eba970dd0e0e7dd086341daa3c75eba4f735f9e44bf684b0/grpcio-1.81.1-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:d865db4a6318e1c1bea83292e0ed231090538fc4ca45425b0f0480eb338bbc6e", size = 12056279, upload-time = "2026-06-11T12:46:24.255Z" },
+    { url = "https://files.pythonhosted.org/packages/41/36/e8c5f8c6ec71de73733695ebc809e98b178b534ec6d8eaa31a7ebab4ad4c/grpcio-1.81.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:e2aa72e3ce1770317ef534f63d397b55e130725f5149bd36077c3b539019db27", size = 6608225, upload-time = "2026-06-11T12:46:27.601Z" },
+    { url = "https://files.pythonhosted.org/packages/30/22/96fc577a845ab093326d9ab1adb874bd4936c8cf98ac8ed2f3db13a0a2fb/grpcio-1.81.1-cp314-cp314-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:0490c30c261eded63f3f354979f9dc4502a9fb944cccb60cd9dc85f5a7349854", size = 7306576, upload-time = "2026-06-11T12:46:30.514Z" },
+    { url = "https://files.pythonhosted.org/packages/76/7b/61dab5d5969f28d97fb1009cead1df0a5cd987d3315e1b37f18a4449f8bc/grpcio-1.81.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:410482da976329fe5f4067270401b12cf2bd552ff8020f054ecfaddb5475f9d6", size = 6812165, upload-time = "2026-06-11T12:46:33.699Z" },
+    { url = "https://files.pythonhosted.org/packages/82/78/6e501929d4f5f96462fd82fd9f0f06e5f9612207582b862868d68757b27d/grpcio-1.81.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e3657301562ac3cb8018d30d0d3ebfa39932239f7b5703422057ef14b69949f5", size = 7422962, upload-time = "2026-06-11T12:46:36.511Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/7e/f2157589e66daa78ebb3165942d05a08bdea93b9d11c2bc1e172aef89685/grpcio-1.81.1-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:24c8e57504c8f45b237e40b99262d181071e5099a07053695b75d97bb53053a0", size = 8408176, upload-time = "2026-06-11T12:46:39.803Z" },
+    { url = "https://files.pythonhosted.org/packages/da/df/c6717fef716e00d235ffb96123baf6dce76d6004f6233fa767c502861460/grpcio-1.81.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:b427c19380991a4eaab2f6144b64b99b412043314c6bf4ab544f97bb31ee4190", size = 7846681, upload-time = "2026-06-11T12:46:43.013Z" },
+    { url = "https://files.pythonhosted.org/packages/36/84/3502e9f210a6a5c4438c8aca3f88edd2e04f6a27f3d41b26cf0a0024b096/grpcio-1.81.1-cp314-cp314-win32.whl", hash = "sha256:61233fe8951e5c85dff81c2458b6528624760166946b5b47ea150a589168411f", size = 4264615, upload-time = "2026-06-11T12:46:45.741Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/b0/4af731ff7492c68a96e4c71bfd0f4590acde92b31c6fe4894e6465c10ff6/grpcio-1.81.1-cp314-cp314-win_amd64.whl", hash = "sha256:3768a5ff1b2125e6f552e561b6b2dca0e64982d8949689b4df145cf8b98d7821", size = 5070275, upload-time = "2026-06-11T12:46:48.486Z" },
 ]
 
 [[package]]
@@ -1541,6 +1703,24 @@ name = "jsmin"
 version = "3.0.1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/5e/73/e01e4c5e11ad0494f4407a3f623ad4d87714909f50b17a06ed121034ff6e/jsmin-3.0.1.tar.gz", hash = "sha256:c0959a121ef94542e807a674142606f7e90214a2b3d1eb17300244bbb5cc2bfc", size = 13925, upload-time = "2022-01-16T20:35:59.13Z" }
+
+[[package]]
+name = "json-repair"
+version = "0.61.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7c/92/b46b19c400cdb87c634778cc7eec140c922f7ec0af3941d1e4a04ebeda81/json_repair-0.61.1.tar.gz", hash = "sha256:24a68de2891c696ad3bd9a94874e8d3ef2d309c56af2973094b8297c975b5b58", size = 50069, upload-time = "2026-06-29T12:09:55.104Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/36/0d/abd5fe1251c8588c6c8d441fab263734bcaa71dfd895ec4b88c202a86254/json_repair-0.61.1-py3-none-any.whl", hash = "sha256:7ab26583e4c73418b8b60cc61202f64f119984a9b5fed61087e84158fa29e7d0", size = 48543, upload-time = "2026-06-29T12:09:53.962Z" },
+]
+
+[[package]]
+name = "json5"
+version = "0.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/7d/05c46a96a78147ae3bf99c2f4169ce144a70220b8d6fcd56f6ec368b8ce9/json5-0.15.0.tar.gz", hash = "sha256:7424d1f1eb1d56da6e3d70643f53619862b4ce81440bdb8ecfd6f875e5ba4a71", size = 53278, upload-time = "2026-06-19T20:08:27.716Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/eb/be/59527c99478aade6bb33a68d72e6e18dd4e6ff6eacfc7d01bdb15bc76912/json5-0.15.0-py3-none-any.whl", hash = "sha256:56636a30c0e8a4665fe2179c0212f32eae3796dea89ea6f649b9436ecdb39618", size = 36570, upload-time = "2026-06-19T20:08:26.748Z" },
+]
 
 [[package]]
 name = "jsonschema"
@@ -1807,6 +1987,9 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+agent = [
+    { name = "agentscope", marker = "python_full_version >= '3.11'" },
+]
 all = [
     { name = "anthropic" },
     { name = "black" },
@@ -1902,6 +2085,7 @@ tsp = [
 
 [package.metadata]
 requires-dist = [
+    { name = "agentscope", marker = "python_full_version >= '3.11' and extra == 'agent'", specifier = ">=2.0,<3.0" },
     { name = "aiofiles", specifier = ">=25.1.0" },
     { name = "aiohttp", specifier = ">=3.9.0" },
     { name = "anthropic", marker = "extra == 'providers'", specifier = ">=0.19.0" },
@@ -1957,7 +2141,7 @@ requires-dist = [
     { name = "umap-learn", marker = "extra == 'eval'", specifier = ">=0.5.12" },
     { name = "xgboost", specifier = ">=3.2.0" },
 ]
-provides-extras = ["infra", "providers", "eval", "tsp", "lunarlander", "dyca", "meoh", "dev", "docs", "all"]
+provides-extras = ["infra", "providers", "eval", "tsp", "lunarlander", "dyca", "meoh", "dev", "docs", "agent", "all"]
 
 [[package]]
 name = "llvmlite"
@@ -2744,6 +2928,118 @@ wheels = [
 ]
 
 [[package]]
+name = "opentelemetry-api"
+version = "1.43.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version >= '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ae/cc/e4c9584181f86494df0f6bdec1a4f3280c50db44704dc2a407e994fc87bb/opentelemetry_api-1.43.0.tar.gz", hash = "sha256:107d0d03857ea8fc7c5fcbbbd83f800c281f0d560553d61c1d675fccfd1761c1", size = 73476, upload-time = "2026-06-24T15:19:55.323Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/17/83/6dba32b85f31868400440dc7ad2ca1eab94cbbf3a7b0459ed39f8311a9e2/opentelemetry_api-1.43.0-py3-none-any.whl", hash = "sha256:20acf45e9b21851926835292e4045d290acade1edd2ff3de86d2f069687ba1fd", size = 61912, upload-time = "2026-06-24T15:19:35.434Z" },
+]
+
+[[package]]
+name = "opentelemetry-exporter-otlp"
+version = "1.43.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-exporter-otlp-proto-grpc", marker = "python_full_version >= '3.11'" },
+    { name = "opentelemetry-exporter-otlp-proto-http", marker = "python_full_version >= '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ee/47/b77366bcbe719373a8cac2b4e8ad01f8ff3c9f2c223374d77ece280aae6f/opentelemetry_exporter_otlp-1.43.0.tar.gz", hash = "sha256:65aded6c50ee7dd2b9948c9d0e59ddb4ed4eea6e8532fba95cbe6a4a64a566ba", size = 6086, upload-time = "2026-06-24T15:19:58.003Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d9/26/d28cc854d2eb779f91351216c51ed0d54886f89f2dd56db9d493ba9fd429/opentelemetry_exporter_otlp-1.43.0-py3-none-any.whl", hash = "sha256:70f3fe740a64596d4157588a2ee7e4fd37d2acc0c0f522a2882b8c29316cd0f0", size = 6726, upload-time = "2026-06-24T15:19:38.437Z" },
+]
+
+[[package]]
+name = "opentelemetry-exporter-otlp-proto-common"
+version = "1.43.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-proto", marker = "python_full_version >= '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/c1/e8098490ab15abf116dcaf9fa89ededcb35547c7d08d4b5a62f573dc1e63/opentelemetry_exporter_otlp_proto_common-1.43.0.tar.gz", hash = "sha256:c4e32ba6d6b13bdb2b8f6764c4fd28d00192826561aa04f6d14eedfce7ac076f", size = 20197, upload-time = "2026-06-24T15:20:00.247Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d0/b2/41ebc74ae1d5859901f1b69305de58724bf043381103d6ef413521cbc35a/opentelemetry_exporter_otlp_proto_common-1.43.0-py3-none-any.whl", hash = "sha256:123c3f9cc87218562490c63b36f497bf3a722faf174a515d1443f31ababa6264", size = 17048, upload-time = "2026-06-24T15:19:41.264Z" },
+]
+
+[[package]]
+name = "opentelemetry-exporter-otlp-proto-grpc"
+version = "1.43.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "googleapis-common-protos", marker = "python_full_version >= '3.11'" },
+    { name = "grpcio", marker = "python_full_version >= '3.11'" },
+    { name = "opentelemetry-api", marker = "python_full_version >= '3.11'" },
+    { name = "opentelemetry-exporter-otlp-proto-common", marker = "python_full_version >= '3.11'" },
+    { name = "opentelemetry-proto", marker = "python_full_version >= '3.11'" },
+    { name = "opentelemetry-sdk", marker = "python_full_version >= '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version >= '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e2/1d/6336453716ca0a240d4417d19e6d5b77a5e7163e5670ec4f7ec4d3ede7bf/opentelemetry_exporter_otlp_proto_grpc-1.43.0.tar.gz", hash = "sha256:1b3e0627daa9bc21884d4a13946807c255eb558bfe5bdd543dffb6f4c9faee0d", size = 27213, upload-time = "2026-06-24T15:20:00.907Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6d/74/2700b5d5c946bf2dba87073fce3dfc198c46bc92ea3d5693f54bc51c90b1/opentelemetry_exporter_otlp_proto_grpc-1.43.0-py3-none-any.whl", hash = "sha256:6a10d1feacffffda19acacbf277b736094b1e2f4dbb98c90ccb2c6e1962e2ec6", size = 19626, upload-time = "2026-06-24T15:19:42.233Z" },
+]
+
+[[package]]
+name = "opentelemetry-exporter-otlp-proto-http"
+version = "1.43.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "googleapis-common-protos", marker = "python_full_version >= '3.11'" },
+    { name = "opentelemetry-api", marker = "python_full_version >= '3.11'" },
+    { name = "opentelemetry-exporter-otlp-proto-common", marker = "python_full_version >= '3.11'" },
+    { name = "opentelemetry-proto", marker = "python_full_version >= '3.11'" },
+    { name = "opentelemetry-sdk", marker = "python_full_version >= '3.11'" },
+    { name = "requests", marker = "python_full_version >= '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version >= '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fc/92/0b9f56412483a8891d4843890294796c9df8ab42417bd9bad8035d840cb3/opentelemetry_exporter_otlp_proto_http-1.43.0.tar.gz", hash = "sha256:fa8a42bb7d00ee5391f4c0b04d8e6a46c03caa437903296ab73a81dc11ba118f", size = 25406, upload-time = "2026-06-24T15:20:01.515Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/20/b685ed7af2e17c29ffc8af56f1fa8bc2033258fc30fb0d2b722f49d13ba0/opentelemetry_exporter_otlp_proto_http-1.43.0-py3-none-any.whl", hash = "sha256:647f603aa8efdbdb4dbff842e0729d0406a6fff26b295a72d3d60e7d963b2610", size = 21795, upload-time = "2026-06-24T15:19:43.164Z" },
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "1.43.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf", marker = "python_full_version >= '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e0/b9/d357faefb40bda1d4799913e6af611171ff22a2dedcb93576bc92242d056/opentelemetry_proto-1.43.0.tar.gz", hash = "sha256:224778df17e1f3fafeaaa21d874236ca5f6ffc2f86e0899298ec7351aac27924", size = 46481, upload-time = "2026-06-24T15:20:07.625Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ed/a7/3e5308cf548b8f72529c7db1afdb3a404211982376a12927fd7759f77bf3/opentelemetry_proto-1.43.0-py3-none-any.whl", hash = "sha256:c58f1f7ef84bc7dc2834016c0c37fe0081dde7ca9f6339be1970fbf9cdaaa90d", size = 72489, upload-time = "2026-06-24T15:19:51.164Z" },
+]
+
+[[package]]
+name = "opentelemetry-sdk"
+version = "1.43.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api", marker = "python_full_version >= '3.11'" },
+    { name = "opentelemetry-semantic-conventions", marker = "python_full_version >= '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version >= '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3e/eb/5041074274ac0956b03637cc039d434569112468e875eddfcc9a0674ce06/opentelemetry_sdk-1.43.0.tar.gz", hash = "sha256:d8187c81c162df9913e4003dd6485f7390d9a24fc17026ec7387b8b8218b08e9", size = 254744, upload-time = "2026-06-24T15:20:08.467Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/e3/b17be23af124201c9f52eececd4cc8ddfed1597d37b4ee771895d325805c/opentelemetry_sdk-1.43.0-py3-none-any.whl", hash = "sha256:d1323a547c1ce69d6a069a17a44b7da82bb8b332051ecb074041f87642c86823", size = 178852, upload-time = "2026-06-24T15:19:52.169Z" },
+]
+
+[[package]]
+name = "opentelemetry-semantic-conventions"
+version = "0.64b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api", marker = "python_full_version >= '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version >= '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5a/30/5f26df29509eccd86b99b481ac9ffa39da49ba9577cc69071c552ae30447/opentelemetry_semantic_conventions-0.64b0.tar.gz", hash = "sha256:72f76fb2d1582d9d033dd1fcd84532e961e6ff3d90d24ba6fabc72975a83864c", size = 148340, upload-time = "2026-06-24T15:20:09.267Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f2/ca/23ba87a221b574a7c5a99d48849d80bfe8b047624681357e2b002e566187/opentelemetry_semantic_conventions-0.64b0-py3-none-any.whl", hash = "sha256:ea77e85e354b8f604ddbe5f3d9135216f982fa4d77e5859ac30f6d8a50505aa6", size = 203713, upload-time = "2026-06-24T15:19:53.339Z" },
+]
+
+[[package]]
 name = "packaging"
 version = "26.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3160,6 +3456,21 @@ wheels = [
 ]
 
 [[package]]
+name = "protobuf"
+version = "7.35.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/da/01/9ef0afd7999eb9badb3a768b4aedd78c86d4c65cfaf1958ab276199e76b4/protobuf-7.35.1.tar.gz", hash = "sha256:ce115a26fe0c39a2c29973d914d327e516a6455464489fe3cd1e51a1b354f81a", size = 458717, upload-time = "2026-06-11T21:55:40.257Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/03/8aeeb7458d22546bf64b5250ca1daeb5ff757d900e8e4a7476c6f0db843e/protobuf-7.35.1-cp310-abi3-macosx_10_9_universal2.whl", hash = "sha256:24f857477359a85c0c235261b8ba905fd51b2562f4a64ca1df5473f29850cbf6", size = 433226, upload-time = "2026-06-11T21:55:31.719Z" },
+    { url = "https://files.pythonhosted.org/packages/37/4b/dfb89eb0e652a1ff073c39a59fb5e3a83cfe9b57a2c83fa6d78270101767/protobuf-7.35.1-cp310-abi3-manylinux2014_aarch64.whl", hash = "sha256:11d6b0ec246892d85215b0a13ca6e0233cf5284b68f0ac02646427f4ff88a799", size = 328847, upload-time = "2026-06-11T21:55:34.035Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/58/dc12f2cd484951524af6e3382c785869b9b3fb5e52ee95ae23add53ee8f9/protobuf-7.35.1-cp310-abi3-manylinux2014_s390x.whl", hash = "sha256:b73f9489a4b8b1c9cb1f8ed951c736392592edb24b9d6819f36d2e10b171d5b4", size = 344030, upload-time = "2026-06-11T21:55:34.941Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/be/5b3cfe508bfab6761414ff944e3366eb13be4fd71efcd69450f89ba39f43/protobuf-7.35.1-cp310-abi3-manylinux2014_x86_64.whl", hash = "sha256:74758715c53d7158fb76caf4f0cfdacc5329a4b1bb994f865d6cf302d413a1c4", size = 327130, upload-time = "2026-06-11T21:55:35.921Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/bc/6d6c7ba8709c85f8f2c390b2b118d6fb08a783676a572271851bf45a7d22/protobuf-7.35.1-cp310-abi3-win32.whl", hash = "sha256:353652e4efd0bca5b5fc2656abf8307ef351f0cf938c9eba09f0e09c20a25c30", size = 428945, upload-time = "2026-06-11T21:55:37.034Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/19/8d0cb6f20a1ef7b18f1c8986ad5783f22f84cce39c6ce9a6e645ea55192e/protobuf-7.35.1-cp310-abi3-win_amd64.whl", hash = "sha256:230a75ddfc2de4806e56696ce9640c1cdfdb6543b7cfce98d42a4c0a0e7bdb87", size = 439996, upload-time = "2026-06-11T21:55:38.123Z" },
+    { url = "https://files.pythonhosted.org/packages/19/c7/5f7c636ec43e0c545e28d1f1db71990108306f7bdcb89f069ba97e428e7f/protobuf-7.35.1-py3-none-any.whl", hash = "sha256:4bc97768d8fe4ad6743c8a19403e314511ed9f6d13205b687e52421c023ac1b9", size = 171659, upload-time = "2026-06-11T21:55:39.155Z" },
+]
+
+[[package]]
 name = "psutil"
 version = "7.2.2"
 source = { registry = "https://pypi.org/simple" }
@@ -3558,6 +3869,19 @@ wheels = [
 ]
 
 [[package]]
+name = "python-datauri"
+version = "3.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cached-property", marker = "python_full_version >= '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version >= '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7c/3b/8a9a2ec12424a8617678d663fa70de43d917d3590416d3a2b9c7fc065d5b/python_datauri-3.0.2.tar.gz", hash = "sha256:d77c37f1f734fc035de424e643464990b2b840e9b8c7c1817c11fca19b71eeb7", size = 9746, upload-time = "2025-01-03T16:22:56.143Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bc/b6/3332df034d7f322506f2267517b051cd3605e129ecc7f9d46a6fbd540279/python_datauri-3.0.2-py2.py3-none-any.whl", hash = "sha256:b365690a1d7d1b7777009eb11a86bd069db4f194e50f4f871a47302f0587c144", size = 5803, upload-time = "2025-01-03T16:22:53.899Z" },
+]
+
+[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 source = { registry = "https://pypi.org/simple" }
@@ -3579,12 +3903,49 @@ wheels = [
 ]
 
 [[package]]
+name = "python-engineio"
+version = "4.13.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "simple-websocket", marker = "python_full_version >= '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fb/a0/f75491f942184d9960b15e763270f765fe9f239745ca5f9e16289011aed4/python_engineio-4.13.3.tar.gz", hash = "sha256:572b7783e341fed21edbc7cea297ccd378dad79265fdde96aa4664420a7c06c9", size = 79734, upload-time = "2026-06-20T22:53:52.197Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5b/96/82f6328e410515fab21d5602ba35b9377a47b5a141a0c1f9efa00ce21eb4/python_engineio-4.13.3-py3-none-any.whl", hash = "sha256:1f60ecaf1358190f0e26c48c578a60428dc02a8f1295bc3dbf53d1b31116821f", size = 59993, upload-time = "2026-06-20T22:53:50.775Z" },
+]
+
+[[package]]
+name = "python-frontmatter"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyyaml", marker = "python_full_version >= '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9d/e8/79cbe69864d44f3b48e70ebee0a872a7d5a4e7150c9f8577ed7a5beefff0/python_frontmatter-1.3.0.tar.gz", hash = "sha256:acc73e477a568dc2a25c9e130c6c68ae8daa8c204c8f7e813db47d6a7280dcf2", size = 8322, upload-time = "2026-05-20T19:21:44.164Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a6/a3/17c284b4f4d8ad50f0f9ba70ad8fcc35c777aeafcdbbffdd91bbdc5ab379/python_frontmatter-1.3.0-py3-none-any.whl", hash = "sha256:9f7dd9260bec99044219159a329f64f039087f9d1a2124c9442556f2fe6f82ec", size = 10562, upload-time = "2026-05-20T19:21:43.323Z" },
+]
+
+[[package]]
 name = "python-multipart"
 version = "0.0.22"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/01/979e98d542a70714b0cb2b6728ed0b7c46792b695e3eaec3e20711271ca3/python_multipart-0.0.22.tar.gz", hash = "sha256:7340bef99a7e0032613f56dc36027b959fd3b30a787ed62d310e951f7c3a3a58", size = 37612, upload-time = "2026-01-25T10:15:56.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1b/d0/397f9626e711ff749a95d96b7af99b9c566a9bb5129b8e4c10fc4d100304/python_multipart-0.0.22-py3-none-any.whl", hash = "sha256:2b2cd894c83d21bf49d702499531c7bafd057d730c201782048f7945d82de155", size = 24579, upload-time = "2026-01-25T10:15:54.811Z" },
+]
+
+[[package]]
+name = "python-socketio"
+version = "5.16.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "bidict", marker = "python_full_version >= '3.11'" },
+    { name = "python-engineio", marker = "python_full_version >= '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/32/2d/ffce71017c106b75099fea569df6518c63fee5d6202ce0cfe7b01e6f22c3/python_socketio-5.16.3.tar.gz", hash = "sha256:89b136f677ae65607a84cecda9b4d6c5377b40a97582c504c25df89af16d520e", size = 128095, upload-time = "2026-06-15T22:07:04.003Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0a/38/8c5e72d53ff8eb27497c4f268a7f6d9121e727a50b65248288ad79a93053/python_socketio-5.16.3-py3-none-any.whl", hash = "sha256:e7ad14202a5e6448824c7c2f86161d04e13dec05992257df5c709e6a2798c041", size = 82087, upload-time = "2026-06-15T22:07:02.498Z" },
 ]
 
 [[package]]
@@ -4318,6 +4679,27 @@ wheels = [
 ]
 
 [[package]]
+name = "shortuuid"
+version = "1.0.13"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/e2/bcf761f3bff95856203f9559baf3741c416071dd200c0fc19fad7f078f86/shortuuid-1.0.13.tar.gz", hash = "sha256:3bb9cf07f606260584b1df46399c0b87dd84773e7b25912b7e391e30797c5e72", size = 9662, upload-time = "2024-03-11T20:11:06.879Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c0/44/21d6bf170bf40b41396480d8d49ad640bca3f2b02139cd52aa1e272830a5/shortuuid-1.0.13-py3-none-any.whl", hash = "sha256:a482a497300b49b4953e15108a7913244e1bb0d41f9d332f5e9925dba33a3c5a", size = 10529, upload-time = "2024-03-11T20:11:04.807Z" },
+]
+
+[[package]]
+name = "simple-websocket"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wsproto", marker = "python_full_version >= '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b0/d4/bfa032f961103eba93de583b161f0e6a5b63cebb8f2c7d0c6e6efe1e3d2e/simple_websocket-1.1.0.tar.gz", hash = "sha256:7939234e7aa067c534abdab3a9ed933ec9ce4691b0713c78acb195560aa52ae4", size = 17300, upload-time = "2024-10-10T22:39:31.412Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/52/59/0782e51887ac6b07ffd1570e0364cf901ebc36345fea669969d2084baebb/simple_websocket-1.1.0-py3-none-any.whl", hash = "sha256:4af6069630a38ed6c561010f0e11a5bc0d4ca569b36306eb257cd9a192497c8c", size = 13842, upload-time = "2024-10-10T22:39:29.645Z" },
+]
+
+[[package]]
 name = "six"
 version = "1.17.0"
 source = { registry = "https://pypi.org/simple" }
@@ -4573,6 +4955,22 @@ wheels = [
 ]
 
 [[package]]
+name = "tree-sitter-bash"
+version = "0.25.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/0e/f0108be910f1eef6499eabce517e79fe3b12057280ed398da67ce2426cba/tree_sitter_bash-0.25.1.tar.gz", hash = "sha256:bfc0bdaa77bc1e86e3c6652e5a6e140c40c0a16b84185c2b63ad7cd809b88f14", size = 419703, upload-time = "2025-12-02T17:01:08.849Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/30/8e/37e7364d9c9c58da89e05c510671d8c45818afd7b31c6939ab72f8dc6c04/tree_sitter_bash-0.25.1-cp310-abi3-macosx_10_9_x86_64.whl", hash = "sha256:0e6235f59e366d220dde7d830196bed597d01e853e44d8ccd1a82c5dd2500acf", size = 194160, upload-time = "2025-12-02T17:00:59.047Z" },
+    { url = "https://files.pythonhosted.org/packages/23/bb/2d2cfbb1f89aaeb1ec892624f069d92d058d06bb66f16b9ec9fb5873ab60/tree_sitter_bash-0.25.1-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:f4a34a6504c7c5b2a9b8c5c4065531dea19ca2c35026e706cf2eeeebe2c92512", size = 202659, upload-time = "2025-12-02T17:01:00.275Z" },
+    { url = "https://files.pythonhosted.org/packages/25/f0/1bb25519be27460255d3899db677313cfa1e6306988fbf456a3d7e211bbb/tree_sitter_bash-0.25.1-cp310-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e76c4cfb20b076552406782b7f8c2a3946835993df0a44df006de54b7030c7dc", size = 230596, upload-time = "2025-12-02T17:01:01.759Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/22/9f70bc3d3b942ab9fc0f89c1dc9e087519a3a94f64ae6b7377aae3a7a0f0/tree_sitter_bash-0.25.1-cp310-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3f484c4bb8796cde7a87ca351e6116f09653edac0eb3c6d238566359dd28b117", size = 231981, upload-time = "2025-12-02T17:01:02.859Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/c3/f1540e42cd41b323c6821e45e52e1aed6ed386209aad52db996f05703963/tree_sitter_bash-0.25.1-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:5e76af6df46d958c7f5b6d5884c9743218e3902a00ccb493ec92728b1084430b", size = 228364, upload-time = "2025-12-02T17:01:03.997Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/a0/c3050a6277dfcac8c480f514dc4fe49f3f65f0eac68b4702cbaca2584e85/tree_sitter_bash-0.25.1-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a3332d71c7b7d5f78259b19d02d0ea111fcb82b72712ee4a93aaa5b226d3f0a8", size = 230074, upload-time = "2025-12-02T17:01:05.05Z" },
+    { url = "https://files.pythonhosted.org/packages/71/0f/203fe6b27211387f4b9ba8c4a321567ca4ded2624dae6ccdbd2b6e940e17/tree_sitter_bash-0.25.1-cp310-abi3-win_amd64.whl", hash = "sha256:52a6802d9218f86278aa3e8b459c3abdad67eed0fde1f9f13aca5b6c634217a6", size = 195574, upload-time = "2025-12-02T17:01:06.412Z" },
+    { url = "https://files.pythonhosted.org/packages/47/75/4ca1a9fabd8fb5aea78cea70f7837ce4dbf2afae115f62051e5fa99cba1c/tree_sitter_bash-0.25.1-cp310-abi3-win_arm64.whl", hash = "sha256:59115057ec2bae319e8082ff29559861045002964c3431ccb0fc92aa4bc9bccb", size = 191196, upload-time = "2025-12-02T17:01:07.486Z" },
+]
+
+[[package]]
 name = "tree-sitter-python"
 version = "0.21.0"
 source = { registry = "https://pypi.org/simple" }
@@ -4715,6 +5113,15 @@ wheels = [
 ]
 
 [[package]]
+name = "websocket-client"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/41/aa4bf9664e4cda14c3b39865b12251e8e7d239f4cd0e3cc1b6c2ccde25c1/websocket_client-1.9.0.tar.gz", hash = "sha256:9e813624b6eb619999a97dc7958469217c3176312b3a16a4bd1bc7e08a46ec98", size = 70576, upload-time = "2025-10-07T21:16:36.495Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/34/db/b10e48aa8fff7407e67470363eac595018441cf32d5e1001567a7aeba5d2/websocket_client-1.9.0-py3-none-any.whl", hash = "sha256:af248a825037ef591efbf6ed20cc5faa03d3b47b9e5a2230a529eeee1c1fc3ef", size = 82616, upload-time = "2025-10-07T21:16:34.951Z" },
+]
+
+[[package]]
 name = "win32-setctime"
 version = "1.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -4807,6 +5214,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/82/dd/e5176e4b241c9f528402cebb238a36785a628179d7d8b71091154b3e4c9e/wrapt-2.1.2-cp314-cp314t-win_amd64.whl", hash = "sha256:08ffa54146a7559f5b8df4b289b46d963a8e74ed16ba3687f99896101a3990c5", size = 63969, upload-time = "2026-03-06T02:54:39Z" },
     { url = "https://files.pythonhosted.org/packages/5c/99/79f17046cf67e4a95b9987ea129632ba8bcec0bc81f3fb3d19bdb0bd60cd/wrapt-2.1.2-cp314-cp314t-win_arm64.whl", hash = "sha256:72aaa9d0d8e4ed0e2e98019cea47a21f823c9dd4b43c7b77bba6679ffcca6a00", size = 60554, upload-time = "2026-03-06T02:53:14.132Z" },
     { url = "https://files.pythonhosted.org/packages/1a/c7/8528ac2dfa2c1e6708f647df7ae144ead13f0a31146f43c7264b4942bf12/wrapt-2.1.2-py3-none-any.whl", hash = "sha256:b8fd6fa2b2c4e7621808f8c62e8317f4aae56e59721ad933bac5239d913cf0e8", size = 43993, upload-time = "2026-03-06T02:53:12.905Z" },
+]
+
+[[package]]
+name = "wsproto"
+version = "1.3.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "h11", marker = "python_full_version >= '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c7/79/12135bdf8b9c9367b8701c2c19a14c913c120b882d50b014ca0d38083c2c/wsproto-1.3.2.tar.gz", hash = "sha256:b86885dcf294e15204919950f666e06ffc6c7c114ca900b060d6e16293528294", size = 50116, upload-time = "2025-11-20T18:18:01.871Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a4/f5/10b68b7b1544245097b2a1b8238f66f2fc6dcaeb24ba5d917f52bd2eed4f/wsproto-1.3.2-py3-none-any.whl", hash = "sha256:61eea322cdf56e8cc904bd3ad7573359a242ba65688716b0710a5eb12beab584", size = 24405, upload-time = "2025-11-20T18:18:00.454Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
Adds an AI Build (Beta) flow alongside the existing AI build: an AgentScope-based
agent that gathers requirements step-by-step (clickable option cards), proposes a
structured plan for the user to confirm (soft-lock), then builds and self-verifies
an LLM4AD task package. Runs on the user's own provider (OpenAI-compatible /
Anthropic) through the existing LLM proxy, and is also runnable via `llm4ad chatv2`.
Gated by ENABLE_AI_AGENT_BUILD; the original AI build is unchanged.

## What's included
- core `llm4ad.agent`: two-phase (gather/build) ReAct agent, sandboxed path-fenced
  tools, ask_choice with inline [dir]/[file] upload tags, propose_plan, cross-turn
  memory, deterministic token-cost estimate. New optional `agent` extra.
- portable SKILL.md (skills/llm4ad-task-builder/) as single source of domain
  knowledge, reusable by Claude Code / Qwen Code.
- backend: AI_AGENT generation kind + _run_agent_build reusing the isolated
  chat-tune container; per-phase stage progress; /utils/features flag; /agent SSE
  endpoint; credentials via one-time proxy token.
- frontend: Beta entry gated by flag; choice/plan cards rendered as markdown;
  regenerated API client.
- CLI: `llm4ad chatv2` local multi-turn build.
- fix(provider): AnthropicProvider honors auth_token (fixes DeepSeek /anthropic auth).

## Notes for reviewers
- SKILL.md "how to use the platform" section is a draft (marked in-file), pending
  product review.
- Client regenerated with @hey-api/openapi-ts 0.73.0.