### PR TITLE
fix(frontend): restore EmbeddingProviderResponse types dropped by cli…

### DIFF
--- a/src/frontend/src/client/schemas.gen.ts
+++ b/src/frontend/src/client/schemas.gen.ts
@@ -911,8 +911,137 @@ export const EmbeddingProviderCreateSchema = {
 } as const;
 
 export const EmbeddingProviderResponseSchema = {
-    additionalProperties: true,
-    type: 'object'
+    properties: {
+        id: {
+            type: 'string',
+            format: 'uuid',
+            title: 'Id'
+        },
+        created_time: {
+            type: 'string',
+            format: 'date-time',
+            title: 'Created Time'
+        },
+        updated_time: {
+            type: 'string',
+            format: 'date-time',
+            title: 'Updated Time'
+        },
+        user_id: {
+            type: 'string',
+            format: 'uuid',
+            title: 'User Id'
+        },
+        name: {
+            type: 'string',
+            title: 'Name'
+        },
+        type: {
+            '$ref': '#/components/schemas/EmbeddingProviderType'
+        },
+        api_key: {
+            type: 'string',
+            title: 'Api Key'
+        },
+        auth_token: {
+            type: 'string',
+            title: 'Auth Token'
+        },
+        base_url: {
+            anyOf: [
+                {
+                    type: 'string'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Base Url'
+        },
+        mode: {
+            '$ref': '#/components/schemas/EmbeddingMode'
+        },
+        model: {
+            type: 'string',
+            title: 'Model'
+        },
+        dim: {
+            type: 'integer',
+            title: 'Dim'
+        },
+        timeout: {
+            type: 'number',
+            title: 'Timeout'
+        },
+        embedding_func_max_async: {
+            type: 'integer',
+            title: 'Embedding Func Max Async'
+        },
+        text_type: {
+            '$ref': '#/components/schemas/EmbeddingProviderType'
+        },
+        text_base_url: {
+            anyOf: [
+                {
+                    type: 'string'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Text Base Url'
+        },
+        text_api_key: {
+            type: 'string',
+            title: 'Text Api Key'
+        },
+        text_auth_token: {
+            type: 'string',
+            title: 'Text Auth Token'
+        },
+        text_model: {
+            type: 'string',
+            title: 'Text Model'
+        },
+        text_task: {
+            type: 'string',
+            title: 'Text Task'
+        },
+        code_type: {
+            '$ref': '#/components/schemas/EmbeddingProviderType'
+        },
+        code_base_url: {
+            anyOf: [
+                {
+                    type: 'string'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Code Base Url'
+        },
+        code_api_key: {
+            type: 'string',
+            title: 'Code Api Key'
+        },
+        code_auth_token: {
+            type: 'string',
+            title: 'Code Auth Token'
+        },
+        code_model: {
+            type: 'string',
+            title: 'Code Model'
+        },
+        code_task: {
+            type: 'string',
+            title: 'Code Task'
+        }
+    },
+    type: 'object',
+    required: ['id', 'created_time', 'updated_time', 'user_id', 'name', 'type', 'api_key', 'auth_token', 'base_url', 'mode', 'model', 'dim', 'timeout', 'embedding_func_max_async', 'text_type', 'text_base_url', 'text_api_key', 'text_auth_token', 'text_model', 'text_task', 'code_type', 'code_base_url', 'code_api_key', 'code_auth_token', 'code_model', 'code_task'],
+    title: 'EmbeddingProviderResponse',
+    description: 'Embedding 供应商响应，凭据不返回明文。'
 } as const;
 
 export const EmbeddingProviderTestByIdRequestSchema = {

--- a/src/frontend/src/client/types.gen.ts
+++ b/src/frontend/src/client/types.gen.ts
@@ -421,8 +421,36 @@ export type EmbeddingProviderCreate = {
     code_task?: string;
 };
 
+/**
+ * Embedding 供应商响应，凭据不返回明文。
+ */
 export type EmbeddingProviderResponse = {
-    [key: string]: unknown;
+    id: string;
+    created_time: string;
+    updated_time: string;
+    user_id: string;
+    name: string;
+    type: EmbeddingProviderType;
+    api_key: string;
+    auth_token: string;
+    base_url: (string | null);
+    mode: EmbeddingMode;
+    model: string;
+    dim: number;
+    timeout: number;
+    embedding_func_max_async: number;
+    text_type: EmbeddingProviderType;
+    text_base_url: (string | null);
+    text_api_key: string;
+    text_auth_token: string;
+    text_model: string;
+    text_task: string;
+    code_type: EmbeddingProviderType;
+    code_base_url: (string | null);
+    code_api_key: string;
+    code_auth_token: string;
+    code_model: string;
+    code_task: string;
 };
 
 /**


### PR DESCRIPTION
## Background
After PR #56 was merged, the Docker Hub image build failed at the frontend's
`bun run build` step. Root cause: the "regenerate API client" commit in #56
degraded `EmbeddingProviderResponse` into `[key: string]: unknown` (its schema
became `additionalProperties: true`), dropping the 26 fields defined by PR #53.
`EmbeddingProviderSettings.tsx` and `DefaultModelSettings.tsx` depend on those
fields, so `tsc` reported 30+ `TS2322` errors and the build failed. The backend
did not change the embedding schema, so the correct type equals the original
definition on `main`.

## Changes
- `types.gen.ts`: restore the full `EmbeddingProviderResponse` field definitions
- `schemas.gen.ts`: restore the full `EmbeddingProviderResponseSchema` properties

## Verification
- `tsc -p tsconfig.build.json --noEmit` passes locally (exit 0) — the same step
  that failed in Docker
- Degradation counts vs `main` are back to 0 net additions
  (`[key: string]: unknown` / `additionalProperties: true`)