### PR TITLE
feat: add MCTS-AHD, ReEvo, EoH algorithms and CVRP construct task

### DIFF
--- a/examples/applications/cvrp_construct_python/config.yaml
+++ b/examples/applications/cvrp_construct_python/config.yaml
@@ -1,0 +1,207 @@
+# ==============================================================================
+# LLM4AD Configuration for CVRP Construct (Python) - Island GA
+# Migrated from legacy LLM4AD task: llm4ad/task/optimization/cvrp_construct
+# ==============================================================================
+
+project_name: "cvrp_construct_python"
+
+description_en: "Evolve Python greedy route-construction heuristics for the Capacitated Vehicle Routing Problem (CVRP)."
+description_zh: "为带容量约束的车辆路径问题（CVRP）进化 Python 贪心路径构造启发式。"
+
+background: |
+  Given a set of customers with known demands and a fleet of capacity-limited
+  vehicles based at a central depot, the task is to design a heuristic that
+  selects the next node to visit at each construction step. The evolved
+  select_next_node function is called repeatedly to build complete routes;
+  returning the depot (node 0) closes the current vehicle trip. The objective
+  is to minimize total travel distance relative to a per-instance baseline.
+
+random_seed: 42
+base_dir: "./runs"
+
+# ==============================================================================
+# Workspace Configuration
+# ==============================================================================
+workspace:
+  auto_create: true
+  subdirs:
+    output: "output"
+    logs: "logs"
+    checkpoints: "checkpoints"
+    generated: "generated"
+    cache: "cache"
+    temp: "temp"
+
+# ==============================================================================
+# LLM Provider Configuration
+# ==============================================================================
+providers:
+  - name: "default"
+    type: "openai_compatible"
+    base_url: ${LLM_BASE_URL}
+    api_key: ${LLM_API_KEY}
+    model: ${LLM_MODEL}
+    temperature: 0.7
+    max_tokens: 8192
+    timeout: 120.0
+
+# ==============================================================================
+# Coder Configuration
+# ==============================================================================
+coder:
+  type: "custom"
+  provider: "default"
+  timeout: 180.0
+  max_retries: 2
+  temperature: 0.7
+  max_gen_tokens: 4096
+  context_max_tokens: 4096
+  default_extension: "py"
+  log_to_console: false
+
+  prompt_template: |
+    You are tasked with implementing a heuristic for the Capacitated Vehicle
+    Routing Problem (CVRP) in Python.
+
+    Problem Description:
+    A fleet of capacity-limited vehicles must serve all customers from a
+    central depot (node 0). At each step the route-construction driver calls
+    your function to pick the next node to visit.
+
+    Implement the select_next_node function between EVOLVE_START and EVOLVE_END:
+
+    ```python
+    import copy
+    import json
+    import sys
+    from typing import List
+    import numpy as np
+
+    # EVOLVE_START
+    def select_next_node(current_node: int, depot: int, unvisited_nodes: np.ndarray,
+                         rest_capacity: float, demands: np.ndarray,
+                         distance_matrix: np.ndarray) -> int:
+        '''Select the next node to visit (return depot id 0 to start a new trip).'''
+        best_score = -1.0
+        next_node = -1
+        for node in unvisited_nodes:
+            demand = demands[node]
+            distance = distance_matrix[current_node][node]
+            if demand <= rest_capacity:
+                score = demand / distance if distance > 0 else float('inf')
+                if score > best_score:
+                    best_score = score
+                    next_node = node
+        return next_node
+    # EVOLVE_END
+    ```
+
+    Requirements:
+    1. Implement select_next_node between the EVOLVE_START and EVOLVE_END markers.
+    2. Input: current_node (int), depot (int, always 0), unvisited_nodes
+       (np.ndarray of feasible unvisited node IDs), rest_capacity (float),
+       demands (np.ndarray), distance_matrix (2D np.ndarray).
+    3. Output: a single integer node ID. Returning 0 closes the current trip.
+    4. Goal: minimize total route distance (maximize normalized_gap).
+
+    Provide only the complete implementation of select_next_node between the
+    EVOLVE_START and EVOLVE_END markers.
+
+# ==============================================================================
+# Planner Configuration
+# ==============================================================================
+planner:
+  type: "llm_evolution"
+  provider: "default"
+  selection_strategy: "weighted"
+  parent_selection_strategy: "tournament"
+  build:
+    script: {}
+  samplers:
+    - name: "init_sampler"
+    - name: "mutation_sampler"
+    - name: "crossover_sampler"
+
+# ==============================================================================
+# Evaluator Configuration
+# ==============================================================================
+evaluator:
+  type: "custom"
+  module: "cvrp_evaluator.py:CVRPConstructEvaluator"
+  timeout: 60.0
+  max_retries: 2
+  parallel: true
+  batch_size: 4
+  dataset:
+    mode: "directory"
+    path: "data/instances"
+    recursive: false
+  metrics:
+    - "normalized_gap"
+    - "total_cost"
+    - "valid_route"
+
+# ==============================================================================
+# Evolution Configuration
+# ==============================================================================
+evolution:
+  type: "island_ga"
+  max_generations: 5
+  early_stop_patience: 10
+  early_stop_threshold: 0.000001
+  checkpoint_interval: 5
+  max_checkpoints: 3
+  elite_ratio: 0.1
+  mutation_rate: 0.3
+  crossover_rate: 0.5
+  parent_selection_strategy: "tournament"
+  survival_selection_strategy: "truncation"
+  tournament_size: 3
+  num_islands: 2
+  island_population_size: 4
+  migration_interval: 5
+  migration_rate: 0.1
+  migration_strategy: "random"
+  migration_topology: "full"
+  parallel_islands: true
+  human_readable_timing: true
+
+# ==============================================================================
+# Logging Configuration
+# ==============================================================================
+logging:
+  level: "INFO"
+  format: null
+  file: null
+  console: true
+  json_format: false
+
+# ==============================================================================
+# Version Control Configuration
+# ==============================================================================
+version_control:
+  enabled: true
+  type: "git_worktree"
+  local_path: "cvrp_algorithm"
+  remote_url: null
+  revision: null
+  auto_initialize: true
+  auto_cleanup: true
+  max_worktree_age_days: 7
+  max_worktrees: 100
+  default_branch: "main"
+  commit_message_template: "Algorithm {algorithm_id}: {description}"
+
+# ==============================================================================
+# Repository Analyzer Configuration
+# ==============================================================================
+repo_analyzer:
+  type: "evolve_detector"
+  context_lines_before: 5
+  context_lines_after: 5
+  include:
+    - "*.py"
+  exclude:
+    - ".git/**"
+    - "__pycache__/**"
+    - "*.pyc"

--- a/examples/applications/cvrp_construct_python/cvrp_algorithm/solve.py
+++ b/examples/applications/cvrp_construct_python/cvrp_algorithm/solve.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+"""CVRP greedy route-construction solver with EVOLVE markers for LLM4AD.
+
+Migrated from the legacy LLM4AD ``cvrp_construct`` task
+(https://github.com/Optima-CityU/LLM4AD, llm4ad/task/optimization/cvrp_construct).
+
+The evolvable heuristic ``select_next_node`` is repeatedly called by the
+route-construction driver to build a complete capacitated vehicle routing
+solution. The driver reads a JSON instance file (path passed as argv[1]) and
+prints the resulting route and total cost as JSON on stdout.
+"""
+
+import copy
+import json
+import sys
+
+import numpy as np
+
+
+# EVOLVE_START
+def select_next_node(
+    current_node: int,
+    depot: int,
+    unvisited_nodes: np.ndarray,
+    rest_capacity: float,
+    demands: np.ndarray,
+    distance_matrix: np.ndarray,
+) -> int:
+    """Design a novel algorithm to select the next node in each step.
+
+    Args:
+        current_node: ID of the current node.
+        depot: ID of the depot.
+        unvisited_nodes: Array of IDs of feasible unvisited nodes.
+        rest_capacity: Remaining capacity of the vehicle.
+        demands: Demands of all nodes.
+        distance_matrix: Distance matrix of nodes.
+
+    Returns:
+        ID of the next node to visit (return the depot ID to close the
+        current vehicle trip and start a new one).
+    """
+    best_score = -1.0
+    next_node = -1
+
+    for node in unvisited_nodes:
+        demand = demands[node]
+        distance = distance_matrix[current_node][node]
+
+        if demand <= rest_capacity:
+            # Avoid division by zero
+            score = demand / distance if distance > 0 else float("inf")
+            if score > best_score:
+                best_score = score
+                next_node = node
+
+    return next_node
+# EVOLVE_END
+
+
+def tour_cost(coordinates: np.ndarray, solution: list[int]) -> float:
+    """Compute total Euclidean distance of the route, closing back to the start.
+
+    Args:
+        coordinates: Node coordinates, shape (n_nodes, 2).
+        solution: Ordered list of node indices forming the full route.
+
+    Returns:
+        Total Euclidean distance of the route.
+    """
+    cost = 0.0
+    for j in range(len(solution) - 1):
+        cost += np.linalg.norm(
+            coordinates[int(solution[j])] - coordinates[int(solution[j + 1])]
+        )
+    cost += np.linalg.norm(
+        coordinates[int(solution[-1])] - coordinates[int(solution[0])]
+    )
+    return float(cost)
+
+
+def route_construct(
+    distance_matrix: np.ndarray,
+    demands: np.ndarray,
+    vehicle_capacity: int,
+    problem_size: int,
+) -> list[int] | None:
+    """Build a complete CVRP route using the evolved ``select_next_node``.
+
+    Faithfully ports the legacy driver logic: node 0 is the depot, the vehicle
+    greedily selects the next node until capacity forces a return, and the
+    route is invalid if not all customers are served.
+
+    Args:
+        distance_matrix: Pairwise distance matrix, shape (n, n).
+        demands: Demand per node (depot demand is 0).
+        vehicle_capacity: Maximum capacity per vehicle.
+        problem_size: Total number of nodes including the depot.
+
+    Returns:
+        The full route as a list of node indices, or ``None`` if the
+        constructed route fails to visit every node.
+    """
+    route: list[int] = []
+    current_load = 0
+    current_node = 0
+    route.append(current_node)
+
+    unvisited_nodes = set(range(1, problem_size))  # node 0 is the depot
+    all_nodes = np.array(list(unvisited_nodes))
+    feasible_unvisited_nodes = all_nodes
+
+    while unvisited_nodes:
+        next_node = select_next_node(
+            current_node,
+            0,
+            feasible_unvisited_nodes,
+            vehicle_capacity - current_load,
+            copy.deepcopy(demands),
+            copy.deepcopy(distance_matrix),
+        )
+
+        if next_node == 0:
+            route.append(next_node)
+            current_load = 0
+            current_node = 0
+        else:
+            route.append(next_node)
+            current_load += demands[next_node]
+            unvisited_nodes.remove(next_node)
+            current_node = next_node
+
+        feasible_nodes_capacity = np.array(
+            [
+                node
+                for node in all_nodes
+                if current_load + demands[node] <= vehicle_capacity
+            ]
+        )
+        feasible_unvisited_nodes = np.intersect1d(
+            feasible_nodes_capacity, list(unvisited_nodes)
+        )
+
+        if len(unvisited_nodes) > 0 and len(feasible_unvisited_nodes) < 1:
+            route.append(0)
+            current_load = 0
+            current_node = 0
+            feasible_unvisited_nodes = np.array(list(unvisited_nodes))
+
+    # Validate that every node has been visited
+    if len(set(route)) != problem_size:
+        return None
+    # Cast to native ints (route may contain numpy integers from intersect1d)
+    return [int(node) for node in route]
+
+
+def solve(input_data: dict) -> dict:
+    """Solve a CVRP instance using the greedy route-construction heuristic.
+
+    Args:
+        input_data: Dict with keys ``coordinates``, ``distances``,
+            ``demands``, ``capacity`` (and optionally ``label``).
+
+    Returns:
+        Dict with ``routes`` (list of node indices) and ``total_cost`` (float).
+        On an invalid construction, returns an empty route and infinite cost.
+    """
+    coordinates = np.array(input_data["coordinates"], dtype=float)
+    distance_matrix = np.array(input_data["distances"], dtype=float)
+    demands = np.array(input_data["demands"], dtype=float)
+    vehicle_capacity = int(input_data["capacity"])
+    problem_size = len(demands)
+
+    route = route_construct(distance_matrix, demands, vehicle_capacity, problem_size)
+
+    if route is None:
+        return {"routes": [], "total_cost": float("inf")}
+
+    total_cost = tour_cost(coordinates, route)
+    return {"routes": route, "total_cost": float(total_cost)}
+
+
+def main():
+    """Entry point: read an instance JSON file and print the solution JSON."""
+    if len(sys.argv) < 2:
+        print("Usage: python solve.py <input.json>", file=sys.stderr)
+        sys.exit(1)
+
+    with open(sys.argv[1], encoding="utf-8") as f:
+        input_data = json.load(f)
+
+    result = solve(input_data)
+    print(json.dumps(result))
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/applications/cvrp_construct_python/cvrp_evaluator.py
+++ b/examples/applications/cvrp_construct_python/cvrp_evaluator.py
@@ -1,0 +1,232 @@
+"""Custom evaluator for Python CVRP greedy route-construction solvers.
+
+Migrated from the legacy LLM4AD ``cvrp_construct`` task. The legacy
+``CVRPEvaluation.evaluate_program(program_str, callable_func)`` evaluated the
+heuristic in-process; here we follow the LLM4AD_Next contract: the evolved
+``select_next_node`` lives in a git worktree as ``solve.py``, and this
+evaluator runs it in a subprocess (so multiple instances evaluate in parallel
+via ``asyncio.gather``), then scores the result.
+
+Score is the negative normalized gap to a per-instance baseline
+(``-(cost - baseline) / baseline``); higher (closer to 0, or positive) is
+better. When no baseline label is present, the raw negative cost is used.
+"""
+
+import asyncio
+import json
+import sys
+import time
+from pathlib import Path
+
+from llm4ad.evaluator.base import (
+    BaseEvaluator,
+    EvalContext,
+    EvaluationResult,
+    Metric,
+    MetricType,
+)
+
+
+@BaseEvaluator.register("cvrp_construct_evaluator")
+class CVRPConstructEvaluator(BaseEvaluator):
+    """Evaluator for Python CVRP greedy route-construction solvers.
+
+    Runs the ``solve.py`` driver in the algorithm worktree against a single
+    instance file and computes the normalized gap to baseline.
+    """
+
+    def __init__(self):
+        """Initialize the CVRP evaluator with metric definitions."""
+        self._metrics = [
+            Metric(
+                name="normalized_gap",
+                type=MetricType.MAXIMIZE,
+                weight=1.0,
+                description=(
+                    "Negative normalized gap to baseline: "
+                    "-(total_cost - baseline) / baseline. Higher is better."
+                ),
+            ),
+            Metric(
+                name="total_cost",
+                type=MetricType.MINIMIZE,
+                weight=0.0,
+                description="Total route distance (monitoring only).",
+            ),
+            Metric(
+                name="valid_route",
+                type=MetricType.MAXIMIZE,
+                weight=0.0,
+                description="Whether the route is valid (1.0) or not (0.0).",
+            ),
+        ]
+
+    @property
+    def name(self) -> str:
+        """Get the evaluator name."""
+        return "cvrp_construct_evaluator"
+
+    @property
+    def metrics(self) -> list[Metric]:
+        """Get the list of supported metrics."""
+        return self._metrics
+
+    def _find_solver(self, project_root: Path) -> Path | None:
+        """Locate the ``solve.py`` driver in the worktree.
+
+        Supports both the nested ``cvrp_algorithm/solve.py`` layout and a flat
+        ``solve.py`` layout used by some worktree configurations.
+
+        Args:
+            project_root: Worktree root path.
+
+        Returns:
+            Path to ``solve.py`` if found, else ``None``.
+        """
+        candidates = [
+            project_root / "cvrp_algorithm" / "solve.py",
+            project_root / "solve.py",
+        ]
+        for candidate in candidates:
+            if candidate.exists():
+                return candidate
+        return None
+
+    async def evaluate(self, cfg: EvalContext) -> EvaluationResult:
+        """Evaluate a CVRP solver against a single instance.
+
+        Args:
+            cfg: Evaluation context with ``project_root``, ``data_path`` and
+                ``timeout``.
+
+        Returns:
+            Evaluation result with score and metrics.
+        """
+        start_time = time.time()
+
+        try:
+            project_root = Path(cfg.project_root)
+            data_path = Path(cfg.data_path)
+
+            if not data_path.exists():
+                return EvaluationResult(
+                    score=0.0,
+                    metrics={},
+                    success=False,
+                    error_message=f"Data file not found: {data_path}",
+                    duration_ms=(time.time() - start_time) * 1000,
+                )
+
+            solve_script = self._find_solver(project_root)
+            if solve_script is None:
+                return EvaluationResult(
+                    score=0.0,
+                    metrics={},
+                    success=False,
+                    error_message=(
+                        f"solve.py not found in {project_root} "
+                        f"(looked in cvrp_algorithm/ and root)"
+                    ),
+                    duration_ms=(time.time() - start_time) * 1000,
+                )
+
+            # Run the solver in a subprocess, passing the instance file path.
+            proc = await asyncio.create_subprocess_exec(
+                sys.executable,
+                str(solve_script),
+                str(data_path),
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            try:
+                stdout_bytes, stderr_bytes = await asyncio.wait_for(
+                    proc.communicate(), timeout=cfg.timeout
+                )
+            except TimeoutError:
+                proc.kill()
+                await proc.communicate()
+                return EvaluationResult(
+                    score=0.0,
+                    metrics={},
+                    success=False,
+                    error_message=f"Evaluation timed out after {cfg.timeout}s",
+                    duration_ms=cfg.timeout * 1000,
+                )
+
+            duration_ms = (time.time() - start_time) * 1000
+            stdout_text = stdout_bytes.decode("utf-8", errors="replace")
+            stderr_text = stderr_bytes.decode("utf-8", errors="replace")
+
+            if proc.returncode != 0:
+                return EvaluationResult(
+                    score=0.0,
+                    metrics={},
+                    success=False,
+                    error_message=(
+                        f"Solver failed (exit code {proc.returncode}): "
+                        f"{stderr_text[:500] or stdout_text[:500]}"
+                    ),
+                    duration_ms=duration_ms,
+                )
+
+            try:
+                output = json.loads(stdout_text.strip())
+            except json.JSONDecodeError:
+                return EvaluationResult(
+                    score=0.0,
+                    metrics={},
+                    success=False,
+                    error_message=f"Invalid JSON output: {stdout_text[:300]}",
+                    duration_ms=duration_ms,
+                )
+
+            total_cost = output.get("total_cost", float("inf"))
+            route = output.get("routes", [])
+
+            if total_cost == float("inf") or not route:
+                return EvaluationResult(
+                    score=0.0,
+                    metrics={"normalized_gap": -1.0, "valid_route": 0.0},
+                    success=False,
+                    error_message="Solver produced no valid route",
+                    duration_ms=duration_ms,
+                )
+
+            # Compute normalized gap using the per-instance baseline label.
+            with open(data_path, encoding="utf-8") as f:
+                instance_data = json.load(f)
+
+            baseline = float(instance_data.get("label", 0.0))
+            if baseline > 0:
+                normalized_gap = -(total_cost - baseline) / baseline
+            else:
+                # No baseline available: fall back to raw negative cost.
+                normalized_gap = -total_cost
+
+            metrics = {
+                "normalized_gap": normalized_gap,
+                "total_cost": float(total_cost),
+                "valid_route": 1.0,
+            }
+
+            return EvaluationResult(
+                score=normalized_gap,
+                metrics=metrics,
+                success=True,
+                duration_ms=duration_ms,
+                metadata={
+                    "dataset": str(data_path),
+                    "instance": data_path.stem,
+                    "total_cost": float(total_cost),
+                    "baseline": baseline,
+                },
+            )
+
+        except Exception as e:
+            return EvaluationResult(
+                score=0.0,
+                metrics={},
+                success=False,
+                error_message=f"Evaluation error: {e}",
+                duration_ms=(time.time() - start_time) * 1000,
+            )

--- a/examples/applications/cvrp_construct_python/generate_data.py
+++ b/examples/applications/cvrp_construct_python/generate_data.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""Generate CVRP instances as JSON files for the LLM4AD_Next evaluator.
+
+Migrated from the legacy LLM4AD ``cvrp_construct/get_instance.py``. Each
+instance keeps the same generation scheme (uniform coordinates in the unit
+square, integer demands in [1, 10)), scaled here to a 0-100 coordinate range
+for readability. A baseline ``label`` is computed with a simple
+demand-over-distance greedy heuristic so the evaluator's normalized gap is
+meaningful.
+
+Usage:
+    python generate_data.py                 # default 16 instances, 50 customers
+    python generate_data.py --n 8 --size 20 --out data/small
+"""
+
+import argparse
+import copy
+import json
+from pathlib import Path
+
+import numpy as np
+
+
+def _baseline_select_next_node(current_node, unvisited_nodes, rest_capacity, demands, distance_matrix):
+    """Reference greedy heuristic used to compute a per-instance baseline.
+
+    Mirrors the legacy default ``select_next_node`` (highest demand-to-distance
+    ratio among capacity-feasible unvisited nodes).
+    """
+    best_score = -1.0
+    next_node = -1
+    for node in unvisited_nodes:
+        demand = demands[node]
+        distance = distance_matrix[current_node][node]
+        if demand <= rest_capacity:
+            score = demand / distance if distance > 0 else float("inf")
+            if score > best_score:
+                best_score = score
+                next_node = node
+    return next_node
+
+
+def _baseline_cost(coordinates, distance_matrix, demands, capacity, problem_size):
+    """Construct a route with the baseline heuristic and return its cost."""
+    route = [0]
+    current_load = 0
+    current_node = 0
+    unvisited = set(range(1, problem_size))
+    all_nodes = np.array(list(unvisited))
+    feasible = all_nodes
+
+    while unvisited:
+        nxt = _baseline_select_next_node(
+            current_node, feasible, capacity - current_load,
+            copy.deepcopy(demands), copy.deepcopy(distance_matrix),
+        )
+        if nxt == 0:
+            route.append(0)
+            current_load = 0
+            current_node = 0
+        else:
+            route.append(nxt)
+            current_load += demands[nxt]
+            unvisited.remove(nxt)
+            current_node = nxt
+
+        feasible_cap = np.array(
+            [n for n in all_nodes if current_load + demands[n] <= capacity]
+        )
+        feasible = np.intersect1d(feasible_cap, list(unvisited))
+        if len(unvisited) > 0 and len(feasible) < 1:
+            route.append(0)
+            current_load = 0
+            current_node = 0
+            feasible = np.array(list(unvisited))
+
+    if len(set(route)) != problem_size:
+        return None
+
+    cost = 0.0
+    for j in range(len(route) - 1):
+        cost += np.linalg.norm(coordinates[route[j]] - coordinates[route[j + 1]])
+    cost += np.linalg.norm(coordinates[route[-1]] - coordinates[route[0]])
+    return float(cost)
+
+
+def generate_instances(n_instance: int, n_customers: int, capacity: int, seed: int = 2024):
+    """Generate CVRP instances.
+
+    Args:
+        n_instance: Number of instances to generate.
+        n_customers: Number of customers (the depot is added on top).
+        capacity: Vehicle capacity.
+        seed: Random seed for reproducibility (legacy used 2024).
+
+    Returns:
+        List of instance dicts with coordinates/distances/demands/capacity/label.
+    """
+    rng = np.random.RandomState(seed)
+    problem_size = n_customers + 1  # include depot
+    instances = []
+
+    for _ in range(n_instance):
+        coordinates = rng.rand(problem_size, 2) * 100.0
+        demands = rng.randint(1, 10, size=problem_size).astype(float)
+        demands[0] = 0.0  # depot has no demand
+        distances = np.linalg.norm(
+            coordinates[:, np.newaxis] - coordinates, axis=2
+        )
+
+        baseline = _baseline_cost(
+            coordinates, distances, demands, capacity, problem_size
+        )
+
+        instances.append(
+            {
+                "coordinates": np.round(coordinates, 4).tolist(),
+                "distances": np.round(distances, 4).tolist(),
+                "demands": [int(d) for d in demands],
+                "capacity": int(capacity),
+                "label": round(baseline, 4) if baseline is not None else 0.0,
+            }
+        )
+
+    return instances
+
+
+def main():
+    """Generate instances and write them as individual JSON files."""
+    parser = argparse.ArgumentParser(description="Generate CVRP instances")
+    parser.add_argument("--n", type=int, default=16, help="Number of instances")
+    parser.add_argument("--size", type=int, default=50, help="Number of customers")
+    parser.add_argument("--capacity", type=int, default=40, help="Vehicle capacity")
+    parser.add_argument("--seed", type=int, default=2024, help="Random seed")
+    parser.add_argument(
+        "--out",
+        type=str,
+        default="data/instances",
+        help="Output directory (relative to this script)",
+    )
+    args = parser.parse_args()
+
+    out_dir = Path(__file__).parent / args.out
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    instances = generate_instances(args.n, args.size, args.capacity, args.seed)
+    for i, inst in enumerate(instances):
+        out_path = out_dir / f"instance_{i:03d}.json"
+        with open(out_path, "w", encoding="utf-8") as f:
+            json.dump(inst, f)
+
+    print(f"Wrote {len(instances)} instances to {out_dir}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/applications/cvrp_construct_python/test_evaluator.py
+++ b/examples/applications/cvrp_construct_python/test_evaluator.py
@@ -1,0 +1,55 @@
+"""Direct test for the CVRP evaluator (no LLM required).
+
+Runs the baseline ``solve.py`` in ``cvrp_algorithm/`` against the generated
+instances and checks that the evaluator returns a valid, finite result. Since
+the baseline heuristic matches the instance ``label``, the normalized gap
+should be approximately 0.
+
+Usage:
+    uv run python test_evaluator.py
+"""
+
+import asyncio
+from pathlib import Path
+
+# Import to trigger registration
+import cvrp_evaluator  # noqa: F401
+
+from llm4ad.config.schema import EvalContext
+from llm4ad.evaluator.base import BaseEvaluator
+
+HERE = Path(__file__).parent
+
+
+async def main():
+    """Evaluate the baseline solver against all generated instances."""
+    evaluator = BaseEvaluator.create("cvrp_construct_evaluator")
+    print(f"Evaluator: {evaluator.name}")
+    print(f"Metrics: {[m.name for m in evaluator.metrics]}")
+
+    data_dir = HERE / "data" / "instances"
+    instances = sorted(data_dir.glob("*.json"))
+    if not instances:
+        print("No instances found. Run: uv run python generate_data.py first.")
+        return
+
+    project_root = str(HERE)  # solve.py is under cvrp_algorithm/ here
+
+    for inst in instances:
+        cfg = EvalContext(
+            project_root=project_root,
+            data_path=str(inst),
+            timeout=30.0,
+        )
+        result = await evaluator.evaluate(cfg)
+        status = "OK" if result.success else "FAIL"
+        print(
+            f"[{status}] {inst.name}: score={result.score:.4f} "
+            f"cost={result.metrics.get('total_cost', float('nan')):.2f} "
+            f"gap={result.metrics.get('normalized_gap', float('nan')):.4f}"
+            + ("" if result.success else f" err={result.error_message}")
+        )
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/src/llm4ad/config/app.py
+++ b/src/llm4ad/config/app.py
@@ -12,7 +12,7 @@ from pydantic import BaseModel, Field, field_validator, model_validator
 
 from llm4ad.config.coder import ClaudeCodeConfig, CustomCoderConfig, OpenCodeConfig
 from llm4ad.config.evaluator import CustomEvaluatorConfig, ExecutableEvaluatorConfig
-from llm4ad.config.evolution import DyCAConfig, IslandGAConfig, MEoHConfig
+from llm4ad.config.evolution import DyCAConfig, IslandGAConfig, MCTSAHDConfig, MEoHConfig
 from llm4ad.config.memory import MemoryConfig
 from llm4ad.config.planner import PlannerConfig
 from llm4ad.config.ui import ui
@@ -442,7 +442,7 @@ class AppConfig(BaseModel):
             desc_en="Configure how algorithms are evaluated; supports custom or executable evaluators",
         ),
     )
-    evolution: IslandGAConfig | DyCAConfig | MEoHConfig = Field(
+    evolution: IslandGAConfig | DyCAConfig | MEoHConfig | MCTSAHDConfig = Field(
         default_factory=DyCAConfig,
         discriminator="type",
         json_schema_extra=ui(

--- a/src/llm4ad/config/evolution.py
+++ b/src/llm4ad/config/evolution.py
@@ -592,3 +592,75 @@ class DyCAConfig(EvolutionConfig):
     )
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
+
+
+class MCTSAHDConfig(IslandGAConfig):
+    """Configuration for the MCTS-AHD orchestrator.
+
+    Migrated from legacy LLM4AD MCTS-AHD. Inherits IslandGAConfig so the shared
+    IslandGA individual-generation pipeline keeps its fields (num_islands,
+    max_llm_concurrency, etc.), and adds MCTS tree-search parameters. Note the
+    MCTS-AHD orchestrator runs a single tree (num_islands is effectively 1).
+    """
+
+    type: Literal["mcts_ahd"] = Field(  # type: ignore[assignment]
+        default="mcts_ahd",
+        json_schema_extra=ui(
+            label_zh="进化类型", label_en="Evolution Type",
+            desc_zh="蒙特卡洛树搜索启发式设计，用 UCT 平衡探索与利用",
+            desc_en="Monte Carlo Tree Search for heuristic design; balances exploration/exploitation with UCT",
+            hidden=True,
+        ),
+    )
+
+    planner_type: str = Field(
+        default="llm_evolution",
+        json_schema_extra=ui(
+            label_zh="规划器类型", label_en="Planner Type",
+            desc_zh="MCTS-AHD 使用的规划器类型",
+            desc_en="Planner type used by MCTS-AHD",
+            hidden=True,
+        ),
+    )
+    lambda0: float = Field(
+        default=0.1, ge=0.0,
+        json_schema_extra=ui(
+            label_zh="探索常数 λ₀", label_en="Exploration Constant λ₀",
+            desc_zh="UCT 探索项的基础系数，越大越偏向探索",
+            desc_en="Base coefficient of the UCT exploration term; larger favors exploration",
+        ),
+    )
+    alpha: float = Field(
+        default=0.5, ge=0.0,
+        json_schema_extra=ui(
+            label_zh="渐进扩展参数 α", label_en="Progressive Widening α",
+            desc_zh="控制节点扩展节奏的参数（预留）",
+            desc_en="Parameter controlling node expansion cadence (reserved)",
+        ),
+    )
+    max_depth: int = Field(
+        default=10, ge=1,
+        json_schema_extra=ui(
+            label_zh="最大树深度", label_en="Max Tree Depth",
+            desc_zh="MCTS 树的最大深度，限制搜索路径长度",
+            desc_en="Maximum depth of the MCTS tree, bounding search path length",
+        ),
+    )
+    init_size: int = Field(
+        default=4, ge=1,
+        json_schema_extra=ui(
+            label_zh="初始子节点数", label_en="Initial Children",
+            desc_zh="根节点下初始生成的子节点（初始种群）数量",
+            desc_en="Number of first-level children generated under the root (initial population)",
+        ),
+    )
+    max_sample_nums: int = Field(
+        default=100, ge=1,
+        json_schema_extra=ui(
+            label_zh="最大采样数", label_en="Max Sample Numbers",
+            desc_zh="整个搜索过程中允许的最大评估次数（终止条件）",
+            desc_en="Maximum number of evaluations allowed across the search (termination condition)",
+        ),
+    )
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)

--- a/src/llm4ad/orchestrator/__init__.py
+++ b/src/llm4ad/orchestrator/__init__.py
@@ -26,6 +26,7 @@ from llm4ad.orchestrator.island_ga import (
     MigrationStrategy,
     MigrationTopology,
 )
+from llm4ad.orchestrator.mcts_ahd import MCTSAHDOrchestrator
 from llm4ad.orchestrator.meoh import MEoHOrchestrator
 from llm4ad.orchestrator.meoh_population import MEoHPopulation
 
@@ -48,6 +49,8 @@ __all__ = [
     # MEoH
     "MEoHOrchestrator",
     "MEoHPopulation",
+    # MCTS-AHD
+    "MCTSAHDOrchestrator",
     # State tracking
     "StateTracker",
     "StateTrackerConfig",

--- a/src/llm4ad/orchestrator/mcts_ahd.py
+++ b/src/llm4ad/orchestrator/mcts_ahd.py
@@ -1,0 +1,209 @@
+"""MCTS-AHD orchestrator: Monte Carlo Tree Search for automatic heuristic design.
+
+Migrated from legacy LLM4AD MCTS-AHD method (llm4ad/method/mcts_ahd/). Instead
+of a generational population, MCTS-AHD organizes candidate algorithms as a tree
+and uses UCT to balance exploration and exploitation.
+
+Design choice: this orchestrator **inherits** ``IslandGAOrchestrator`` to reuse
+its verified ``generate_new_individual`` pipeline (worktree -> plan -> implement
+-> build -> commit -> evaluate) and its checkpoint/status helpers. Only the
+search control flow (``run``/``step``/``initialize_population``/
+``evolve_generation``) is overridden with tree-search semantics.
+
+The tree structure (``MCTS``/``MCTSNode``) lives in ``mcts_ahd_tree``.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+from loguru import logger
+
+from llm4ad.infra.state import EvolutionState
+from llm4ad.orchestrator.base import BaseOrchestrator, EvolutionResult
+from llm4ad.orchestrator.island_ga import IslandGAOrchestrator
+from llm4ad.orchestrator.mcts_ahd_tree import MCTS, MCTSNode
+from llm4ad.planner.base import Algorithm
+
+
+@BaseOrchestrator.register("mcts_ahd")
+class MCTSAHDOrchestrator(IslandGAOrchestrator):
+    """MCTS-AHD orchestrator using UCT-guided tree search.
+
+    Reuses the IslandGA individual-generation pipeline but replaces the
+    generational loop with MCTS selection/expansion/backpropagation.
+    """
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        """Initialize the MCTS-AHD orchestrator and its search tree."""
+        super().__init__(*args, **kwargs)
+        # MCTS parameters (read from config with legacy defaults).
+        self._lambda0 = float(self._cfg("lambda0", 0.1))
+        self._alpha = float(self._cfg("alpha", 0.5))
+        self._max_depth = int(self._cfg("max_depth", 10))
+        self._init_size = int(self._cfg("init_size", 4))
+        self._max_sample_nums = int(self._cfg("max_sample_nums", 100))
+
+        self.mcts = MCTS(
+            root_algorithm=None,
+            lambda0=self._lambda0,
+            alpha=self._alpha,
+            max_depth=self._max_depth,
+        )
+        self._sample_count = 0
+
+    def _cfg(self, key: str, default: Any) -> Any:
+        """Read a config value (works for dict or pydantic config)."""
+        if isinstance(self.config, dict):
+            return self.config.get(key, default)
+        return getattr(self.config, key, default)
+
+    async def initialize_population(self) -> list[Algorithm]:
+        """Create the initial tree children under the root.
+
+        Generates ``init_size`` individuals as first-level children of the
+        root node.
+
+        Returns:
+            The initial population of evaluated algorithms.
+        """
+        logger.info(f"[MCTS-AHD] Initializing {self._init_size} root children")
+        population: list[Algorithm] = []
+        for _ in range(self._init_size):
+            algorithm = await self.generate_new_individual(
+                parents=[], island_id=0, generation=0
+            )
+            if algorithm is None or not algorithm.is_evaluated():
+                continue
+            node = MCTSNode(algorithm=algorithm, depth=1, parent=self.mcts.root)
+            node.Q = algorithm.score
+            node.reward = algorithm.score
+            self.mcts.root.add_child(node)
+            self.mcts.backpropagate(node)
+            population.append(algorithm)
+            self._sample_count += 1
+            self._track_best(algorithm)
+        self.population = population
+        return population
+
+    def _select_node(self) -> MCTSNode:
+        """Select a node to expand by descending UCT from the root.
+
+        Returns:
+            The selected node (root if the tree only has the root).
+        """
+        eval_remain = max(0.0, 1.0 - self._sample_count / max(1, self._max_sample_nums))
+        node = self.mcts.root
+        while node.children and node.depth < self._max_depth:
+            node = max(
+                node.children, key=lambda child: self.mcts.uct(child, eval_remain)
+            )
+        return node
+
+    async def evolve_generation(self, parent_population: list[Algorithm]) -> list[Algorithm]:
+        """Run one MCTS expansion step.
+
+        Selects a node via UCT, expands it by generating a child algorithm from
+        the selected node's algorithm as parent, evaluates it, and
+        backpropagates the reward.
+
+        Args:
+            parent_population: Current population (unused directly; the tree
+                holds parent state).
+
+        Returns:
+            The updated population including the new child, if any.
+        """
+        node = self._select_node()
+        parents = [node.algorithm] if node.algorithm is not None else []
+
+        child_algorithm = await self.generate_new_individual(
+            parents=parents, island_id=0, generation=self.current_generation
+        )
+        if child_algorithm is None or not child_algorithm.is_evaluated():
+            return self.population
+
+        child_node = MCTSNode(
+            algorithm=child_algorithm,
+            depth=node.depth + 1,
+            parent=node,
+        )
+        child_node.Q = child_algorithm.score
+        child_node.reward = child_algorithm.score
+        node.add_child(child_node)
+        self.mcts.backpropagate(child_node)
+
+        self.population.append(child_algorithm)
+        self._sample_count += 1
+        self._track_best(child_algorithm)
+        return self.population
+
+    def _track_best(self, algorithm: Algorithm) -> None:
+        """Update the global best individual."""
+        if algorithm is None or not algorithm.is_evaluated():
+            return
+        if self.global_best_individual is None or algorithm.score > self.global_best_individual.score:
+            self.global_best_individual = algorithm
+            self.best_individual = algorithm
+
+    async def step(self) -> tuple[bool, Algorithm | None]:
+        """Execute one MCTS step (one expansion).
+
+        Returns:
+            Tuple of (should_continue, current_best_individual).
+        """
+        await self.evolve_generation(self.population)
+        self.current_generation += 1
+        should_continue = self._sample_count < self._max_sample_nums
+        self.history.append(
+            {
+                "generation": self.current_generation,
+                "samples": self._sample_count,
+                "best_score": self.global_best_individual.score
+                if self.global_best_individual
+                else 0.0,
+            }
+        )
+        return should_continue, self.global_best_individual
+
+    async def run(self) -> EvolutionResult:
+        """Run the full MCTS-AHD search loop.
+
+        Returns:
+            EvolutionResult with the best individual and final tree population.
+        """
+        self.state = EvolutionState.RUNNING
+        self.start_time = time.time()
+        logger.info(
+            f"[MCTS-AHD] Starting search: max_samples={self._max_sample_nums}, "
+            f"init_size={self._init_size}, lambda0={self._lambda0}"
+        )
+
+        await self.initialize_population()
+
+        while self._sample_count < self._max_sample_nums:
+            should_continue, _ = await self.step()
+            if not should_continue:
+                break
+            if self.should_checkpoint():
+                await self.save_checkpoint()
+                self._last_checkpoint_gen = self.current_generation
+
+        await self._finish_embedding_tasks()
+        self.state = EvolutionState.COMPLETED
+        duration = time.time() - self.start_time
+        logger.info(
+            f"[MCTS-AHD] Search complete: {self._sample_count} samples, "
+            f"best score={self.global_best_individual.score if self.global_best_individual else 0.0:.4f}"
+        )
+
+        return EvolutionResult(
+            state=self.state,
+            best_individual=self.global_best_individual,
+            final_population=self.population,
+            final_generation=self.current_generation,
+            total_evaluations=self._sample_count,
+            history=self.history,
+            duration_seconds=duration,
+        )

--- a/src/llm4ad/orchestrator/mcts_ahd_tree.py
+++ b/src/llm4ad/orchestrator/mcts_ahd_tree.py
@@ -1,0 +1,138 @@
+"""MCTS tree structures for the MCTS-AHD orchestrator.
+
+Migrated from legacy LLM4AD MCTS-AHD method (llm4ad/method/mcts_ahd/mcts.py).
+Provides the ``MCTSNode`` and ``MCTS`` classes implementing UCT selection and
+backpropagation over a tree of candidate algorithms.
+"""
+
+from __future__ import annotations
+
+import math
+
+from llm4ad.planner.base import Algorithm
+
+
+class MCTSNode:
+    """MCTS tree node representing an algorithm design.
+
+    Each node stores an algorithm, its Q-value (accumulated reward), and
+    parent/children links for tree traversal.
+    """
+
+    def __init__(
+        self,
+        algorithm: Algorithm | None = None,
+        depth: int = 0,
+        parent: MCTSNode | None = None,
+        is_root: bool = False,
+    ):
+        """Initialize an MCTS node.
+
+        Args:
+            algorithm: Algorithm individual (None for the root placeholder).
+            depth: Tree depth (0 for root).
+            parent: Parent node.
+            is_root: Whether this is the root node.
+        """
+        self.algorithm = algorithm
+        self.depth = depth
+        self.parent = parent
+        self.is_root = is_root
+
+        self.children: list[MCTSNode] = []
+        self.visits: int = 0
+        self.Q: float = 0.0  # Accumulated reward (higher is better)
+        self.reward: float = 0.0  # Immediate reward from evaluation
+        self.subtree: list[MCTSNode] = []
+
+    def add_child(self, child_node: MCTSNode) -> None:
+        """Add a child node and set its parent to this node."""
+        self.children.append(child_node)
+        child_node.parent = self
+
+
+class MCTS:
+    """MCTS tree for algorithm-design exploration.
+
+    Implements UCT selection and backpropagation following the legacy MCTS-AHD
+    design (scores are in "higher is better" space).
+    """
+
+    def __init__(
+        self,
+        root_algorithm: Algorithm | None = None,
+        lambda0: float = 0.1,
+        alpha: float = 0.5,
+        max_depth: int = 10,
+    ):
+        """Initialize the MCTS tree.
+
+        Args:
+            root_algorithm: Root algorithm (usually None placeholder).
+            lambda0: Base exploration constant λ₀.
+            alpha: Progressive-widening parameter (reserved).
+            max_depth: Maximum tree depth.
+        """
+        self.exploration_constant_0 = lambda0
+        self.alpha = alpha
+        self.max_depth = max_depth
+
+        self.discount_factor = 1.0  # Legacy uses 1.0 (no discount)
+        self.q_min = 0.0
+        self.q_max = -10000.0
+        self.rank_list: list[float] = []
+
+        self.root = MCTSNode(algorithm=root_algorithm, depth=0, is_root=True)
+
+    def backpropagate(self, node: MCTSNode) -> None:
+        """Backpropagate a node's reward up to the root.
+
+        Updates Q-value bounds and, for each ancestor, sets Q to the max child
+        Q (discount_factor=1) and increments the visit count.
+
+        Args:
+            node: Leaf node to backpropagate from.
+        """
+        if node.Q not in self.rank_list:
+            self.rank_list.append(node.Q)
+            self.rank_list.sort()
+        self.q_min = min(self.q_min, node.Q)
+        self.q_max = max(self.q_max, node.Q)
+
+        parent = node.parent
+        while parent:
+            if parent.children:
+                best_child_q = max(child.Q for child in parent.children)
+                parent.Q = (
+                    parent.Q * (1 - self.discount_factor)
+                    + best_child_q * self.discount_factor
+                )
+            parent.visits += 1
+            if not node.is_root and parent.parent and parent.parent.is_root:
+                parent.subtree.append(node)
+            parent = parent.parent
+
+    def uct(self, node: MCTSNode, eval_remain: float) -> float:
+        """Compute the UCT value of a node.
+
+        UCT = (Q - Q_min)/(Q_max - Q_min) + λ·sqrt(log(parent_visits+1)/visits),
+        where λ = λ₀·eval_remain.
+
+        Args:
+            node: Node to score.
+            eval_remain: Remaining evaluation budget ratio in [0, 1].
+
+        Returns:
+            The UCT value (``inf`` for unvisited nodes).
+        """
+        if node.visits == 0:
+            return float("inf")
+
+        exploration_constant = self.exploration_constant_0 * eval_remain
+        q_range = self.q_max - self.q_min
+        q_normalized = 0.5 if q_range < 1e-10 else (node.Q - self.q_min) / q_range
+        parent_visits = node.parent.visits if node.parent else 1
+        exploration_bonus = exploration_constant * math.sqrt(
+            math.log(parent_visits + 1) / node.visits
+        )
+        return q_normalized + exploration_bonus

--- a/src/llm4ad/orchestrator/meoh_population.py
+++ b/src/llm4ad/orchestrator/meoh_population.py
@@ -176,40 +176,34 @@ class MEoHPopulation(BaseModel):
         return random.choices(valid, weights=weights, k=count)
 
     def has_duplicate(self, candidate: Algorithm) -> bool:
-        """Check whether a candidate should be treated as duplicate or dominated clone.
+        """Check whether a candidate is a duplicate of an existing individual.
 
-        A candidate is duplicate if its code is identical to an existing
-        individual, or if both share the same fully-valid objective vector
-        (no missing metrics) and the existing individual scores at least
-        as high.
+        A candidate is a duplicate only when its code is byte-for-byte identical
+        to an existing individual's code. This matches the legacy MEoH behaviour
+        (``has_duplicate_function`` compared ``str(f) == str(func)`` only).
+
+        Note: objective-vector deduplication was intentionally removed. Many
+        semantically distinct heuristics can produce the identical objective
+        vector (e.g. multiple different implementations that both degenerate to
+        the per-instance baseline cost). Rejecting them by objective vector
+        collapses the population — observed on CVRP where 31/32 candidates were
+        wrongly rejected, leaving a single baseline individual. Diversity among
+        equal-scoring individuals is instead handled downstream by the AST
+        similarity penalty in ``_dominance_scores``.
         """
         candidate_code = self._code_signature(candidate)
-        candidate_vector = self.get_objective_vector(candidate)
-        candidate_evaluated = candidate.is_evaluated()
-        # Skip objective-vector comparison when any metric is missing (-inf)
-        vector_valid = all(v != float("-inf") for v in candidate_vector)
+        if not candidate_code:
+            # No code to compare against — treat as unique so evolution proceeds.
+            return False
 
         code_len = len(candidate_code)
         has_artifacts = bool(candidate.code_artifacts)
         for existing in self.population + self.next_pop + self.elitist_archive:
             existing_code = self._code_signature(existing)
-            if candidate_code and candidate_code == existing_code:
+            if candidate_code == existing_code:
                 logger.debug(
                     f"[Dup-Code] candidate={candidate.id} matches={existing.id} "
                     f"code_len={code_len} artifacts={has_artifacts}"
-                )
-                return True
-            if not candidate_evaluated or not existing.is_evaluated():
-                continue
-            if not vector_valid:
-                continue
-            existing_vector = self.get_objective_vector(existing)
-            if any(v == float("-inf") for v in existing_vector):
-                continue
-            if candidate_vector == existing_vector and existing.score >= candidate.score:
-                logger.debug(
-                    f"[Dup-Vector] candidate={candidate.id} matches={existing.id} "
-                    f"vector={candidate_vector}"
                 )
                 return True
         return False

--- a/src/llm4ad/planner/__init__.py
+++ b/src/llm4ad/planner/__init__.py
@@ -16,6 +16,7 @@ from llm4ad.planner.memory import (
     MemoryType,
 )
 from llm4ad.planner.meoh_evolution import MEoHEvolutionPlanner
+from llm4ad.planner.reevo_evolution import ReEvoEvolutionPlanner
 from llm4ad.planner.selector import BaseSelector, SamplerSelector
 
 __all__ = [
@@ -24,6 +25,7 @@ __all__ = [
     "InsightType",
     "LLMEvolutionPlanner",
     "MEoHEvolutionPlanner",
+    "ReEvoEvolutionPlanner",
     "Memory",
     "MemoryEntry",
     "MemoryType",

--- a/src/llm4ad/planner/reevo_evolution.py
+++ b/src/llm4ad/planner/reevo_evolution.py
@@ -1,0 +1,184 @@
+"""ReEvo-specific planner implementation with reflection state management.
+
+Migrated from legacy LLM4AD ReEvo method (llm4ad/method/reevo/reevo.py).
+
+The legacy ReEvo main loop maintained reflection state across generations:
+- Each crossover produces a *short-term reflection* (why the better parent wins).
+- Every ``pop_size`` crossovers, the accumulated short-term reflections are
+  distilled into a *long-term reflection*.
+- Elite mutations are then guided by that long-term reflection.
+
+New-platform samplers are stateless, so this planner carries the reflection
+state. It extends ``LLMEvolutionPlanner`` (reusing its sampler wiring and
+``implement``/``build`` behaviour) and overrides ``plan`` to:
+1. Route generation-0 / empty-population requests to the init sampler.
+2. Alternate between crossover (with short-term reflection capture) and
+   long-term-reflection-guided mutation on a ``pop_size`` cadence.
+
+The orchestrator does not need to know about reflections — it simply calls
+``plan(population, generation)`` as usual. This planner works with the existing
+``island_ga`` orchestrator.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+from loguru import logger
+
+from llm4ad.planner.base import Algorithm, BasePlanner
+from llm4ad.planner.llm_evolution import LLMEvolutionPlanner
+
+
+@BasePlanner.register("reevo_evolution")
+class ReEvoEvolutionPlanner(LLMEvolutionPlanner):
+    """Planner that manages ReEvo short-term and long-term reflection state.
+
+    Expects three samplers to be configured (by registered name):
+    ``reevo_init_sampler``, ``reevo_crossover_sampler``,
+    ``reevo_mutation_sampler``. Any missing sampler degrades gracefully
+    (e.g. no mutation sampler -> crossover only).
+    """
+
+    #: How many recent short-term reflections feed a long-term reflection.
+    MAX_SHORT_TERM: int = 5
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        """Initialize the ReEvo planner and reflection state."""
+        super().__init__(*args, **kwargs)
+        self._short_term_reflections: list[str] = []
+        self._long_term_reflection: str = ""
+        self._crossover_count: int = 0
+        # ``pop_size`` controls the long-term reflection cadence; read from
+        # the planner config with a sensible default.
+        self._pop_size: int = int(self._config_value("pop_size", default=10))
+        self._mutation_rate: float = float(self._config_value("mutation_rate", default=0.5))
+
+    def _config_value(self, key: str, default: Any) -> Any:
+        """Read a value from the planner config (dict or PlannerConfig)."""
+        if isinstance(self.config, dict):
+            return self.config.get(key, default)
+        return getattr(self.config, key, default)
+
+    def _get_sampler(self, name: str):
+        """Return a configured sampler by registered name, or None."""
+        return self.sampler_map.get(name)
+
+    async def plan(
+        self,
+        population: list[Algorithm],
+        generation: int,
+        **kwargs: Any,
+    ) -> Algorithm:
+        """Plan the next ReEvo individual with reflection-guided operators.
+
+        Args:
+            population: Current population of algorithms.
+            generation: Current generation number.
+            **kwargs: Additional planning parameters (background, etc.).
+
+        Returns:
+            New algorithm individual with an insight description.
+        """
+        start_time = time.time()
+
+        init_sampler = self._get_sampler("reevo_init_sampler")
+        crossover_sampler = self._get_sampler("reevo_crossover_sampler")
+        mutation_sampler = self._get_sampler("reevo_mutation_sampler")
+
+        # Generation 0 or empty population -> initialization.
+        if len(population) == 0 or generation == 0:
+            sampler = init_sampler or crossover_sampler or self.samplers[0]
+            algorithm = await sampler.sample(
+                parents=[], generation=generation, **kwargs
+            )
+            self._record_plan_timing(start_time, algorithm)
+            return algorithm
+
+        # Decide operator: mutation on the long-term-reflection cadence,
+        # crossover otherwise.
+        use_mutation = (
+            mutation_sampler is not None
+            and self._long_term_reflection
+            and self._crossover_count > 0
+            and self._crossover_count % max(1, int(self._pop_size * self._mutation_rate)) == 0
+        )
+
+        if use_mutation:
+            elite = max(population, key=lambda a: a.score)
+            algorithm = await mutation_sampler.sample(
+                parents=[elite],
+                generation=generation,
+                long_term_reflection=self._long_term_reflection,
+                **kwargs,
+            )
+        else:
+            sampler = crossover_sampler or self.samplers[0]
+            parents = self.select_parents(
+                population, sampler.n_parents, self.config_parent_selection_strategy()
+            )
+            algorithm = await sampler.sample(
+                parents=parents, generation=generation, **kwargs
+            )
+            self._crossover_count += 1
+            # Capture the short-term reflection the crossover sampler stored.
+            reflection = algorithm.custom_metadata.get("short_term_reflection", "")
+            if reflection:
+                self._short_term_reflections.append(reflection)
+
+            # Refresh the long-term reflection on the pop_size cadence.
+            if self._crossover_count % self._pop_size == 0:
+                await self._update_long_term_reflection(kwargs.get("background", ""))
+
+        self._record_plan_timing(start_time, algorithm)
+        return algorithm
+
+    def config_parent_selection_strategy(self) -> str:
+        """Return the parent selection strategy from config."""
+        if isinstance(self.config, dict):
+            return self.config.get("parent_selection_strategy", "tournament")
+        return getattr(self.config, "parent_selection_strategy", "tournament")
+
+    async def _update_long_term_reflection(self, background: str) -> None:
+        """Distill recent short-term reflections into a long-term reflection.
+
+        Args:
+            background: Task background for prompt context.
+        """
+        if not self._short_term_reflections:
+            return
+
+        recent = self._short_term_reflections[-self.MAX_SHORT_TERM :]
+        joined = "\n".join(f"- {r}" for r in recent)
+        prompt = (
+            "You are an expert in optimization heuristics. Give constructive "
+            "hints for designing better heuristics (under 50 words).\n"
+            f"Task: {background}\n"
+            f"Prior long-term reflection:\n{self._long_term_reflection or '(none)'}\n"
+            f"Newly gained insights:\n{joined}\n"
+            "Write concise constructive hints combining prior reflection and "
+            "the new insights."
+        )
+        try:
+            response = await self.provider.generate(
+                prompt,
+                temperature=0.5,
+                max_tokens=192,
+                request_stage="planner",
+            )
+            text = (response.text or "").strip()
+            if text:
+                self._long_term_reflection = text
+                logger.info("[ReEvo] Updated long-term reflection.")
+        except Exception as exc:  # noqa: BLE001 - reflection is best-effort
+            logger.warning(f"[ReEvo] Long-term reflection update failed: {exc}")
+
+    def _record_plan_timing(self, start_time: float, algorithm: Algorithm) -> None:
+        """Record plan timing into the state tracker."""
+        plan_time_ms = (time.time() - start_time) * 1000
+        self.state_tracker.record_timing("planner.plan", plan_time_ms)
+        if algorithm.timing.llm_planning_ms > 0:
+            self.state_tracker.record_timing(
+                "provider.chat.planner", algorithm.timing.llm_planning_ms
+            )

--- a/src/llm4ad/planner/sampler/__init__.py
+++ b/src/llm4ad/planner/sampler/__init__.py
@@ -7,6 +7,11 @@ the evolution process.
 
 from llm4ad.planner.sampler.base import BaseSampler
 from llm4ad.planner.sampler.crossover_sampler import CrossoverSampler
+from llm4ad.planner.sampler.eoh_e1_sampler import EoHE1Sampler
+from llm4ad.planner.sampler.eoh_e2_sampler import EoHE2Sampler
+from llm4ad.planner.sampler.eoh_i1_sampler import EoHI1Sampler
+from llm4ad.planner.sampler.eoh_m1_sampler import EoHM1Sampler
+from llm4ad.planner.sampler.eoh_m2_sampler import EoHM2Sampler
 from llm4ad.planner.sampler.init_sampler import InitSampler
 from llm4ad.planner.sampler.multimodal_crossover_sampler import (
     MultimodalCrossoverSampler,
@@ -20,6 +25,9 @@ from llm4ad.planner.sampler.prompt_templates import (
     INITIAL_ALGORITHM_FROM_BLOCK,
     MUTATE_ALGORITHM_FROM_BLOCK,
 )
+from llm4ad.planner.sampler.reevo_crossover_sampler import ReEvoCrossoverSampler
+from llm4ad.planner.sampler.reevo_init_sampler import ReEvoInitSampler
+from llm4ad.planner.sampler.reevo_mutation_sampler import ReEvoMutationSampler
 
 __all__ = [
     "BaseSampler",
@@ -28,6 +36,14 @@ __all__ = [
     "CrossoverSampler",
     "MultimodalMutationSampler",
     "MultimodalCrossoverSampler",
+    "EoHI1Sampler",
+    "EoHE1Sampler",
+    "EoHE2Sampler",
+    "EoHM1Sampler",
+    "EoHM2Sampler",
+    "ReEvoInitSampler",
+    "ReEvoCrossoverSampler",
+    "ReEvoMutationSampler",
     "INITIAL_ALGORITHM_FROM_BLOCK",
     "MUTATE_ALGORITHM_FROM_BLOCK",
     "CROSSOVER_ALGORITHM",

--- a/src/llm4ad/planner/sampler/eoh_e1_sampler.py
+++ b/src/llm4ad/planner/sampler/eoh_e1_sampler.py
@@ -1,0 +1,87 @@
+"""EoH E1 sampler: create a new algorithm distinct from parents.
+
+Migrated from legacy LLM4AD EoH method (llm4ad/method/eoh/prompt.py). The E1
+operator asks the LLM to design a new algorithm with a totally different form
+from the given parent algorithms.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from llm4ad.planner.base import Algorithm, InsightType
+from llm4ad.planner.sampler.base import BaseSampler
+from llm4ad.planner.sampler.eoh_i1_sampler import _BaseEoHSampler
+
+
+@BaseSampler.register("eoh_e1_sampler")
+class EoHE1Sampler(_BaseEoHSampler):
+    """EoH E1 sampler: totally different form from the parents.
+
+    Uses one or more parents as reference and asks the LLM to create a new
+    algorithm with a fundamentally different structure.
+    """
+
+    def __init__(self, provider, memory, config, analyzed_repository=None) -> None:
+        """Initialize the E1 sampler."""
+        super().__init__(provider, memory, config, analyzed_repository)
+        self._parent_count = max(1, int(self._get_config_value("selection_num", config, default=2)))
+
+    @property
+    def n_parents(self) -> int:
+        """Number of parent algorithms required (>=1, default 2 for E1)."""
+        return self._parent_count
+
+    @property
+    def name(self) -> str:
+        """Get the sampler name."""
+        return "eoh_e1_sampler"
+
+    async def sample(
+        self,
+        parents: list[Algorithm],
+        generation: int,
+        **kwargs: Any,
+    ) -> Algorithm:
+        """Generate a new algorithm with a totally different form.
+
+        Args:
+            parents: One or more parent algorithms.
+            generation: Current generation number.
+            **kwargs: Additional parameters (background, template_function).
+
+        Returns:
+            Algorithm with a distinct new insight.
+        """
+        if not parents:
+            raise ValueError("EoH E1 requires at least one parent")
+
+        background = kwargs.get("background", "")
+        template_text = self._template_text(kwargs)
+
+        indivs_prompt = ""
+        for i, parent in enumerate(parents):
+            indivs_prompt += (
+                f"No. {i + 1} algorithm and the corresponding code are:\n"
+                f"{parent.description}\n{self._get_parent_code(parent)}\n"
+            )
+
+        prompt = (
+            f"{background}\n"
+            f"I have {len(parents)} existing algorithms with their codes as follows:\n"
+            f"{indivs_prompt}\n"
+            "Please help me create a new algorithm that has a totally different "
+            "form from the given ones.\n"
+            "1. First, describe your new algorithm and main steps in one sentence.\n"
+            "2. Next, design a Python implementation for the following function:\n"
+            f"{template_text}\n"
+            "Return a concise algorithm name and a one-sentence description."
+        )
+
+        return await self._generate(
+            prompt,
+            generation=generation,
+            insight_type=InsightType.CROSSOVER,
+            operator="e1",
+            parent_ids=[parent.id for parent in parents],
+        )

--- a/src/llm4ad/planner/sampler/eoh_e2_sampler.py
+++ b/src/llm4ad/planner/sampler/eoh_e2_sampler.py
@@ -1,0 +1,89 @@
+"""EoH E2 sampler: create a new algorithm from a shared backbone idea.
+
+Migrated from legacy LLM4AD EoH method (llm4ad/method/eoh/prompt.py). The E2
+operator asks the LLM to identify a common backbone idea across the parents
+and design a new algorithm motivated by it.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from llm4ad.planner.base import Algorithm, InsightType
+from llm4ad.planner.sampler.base import BaseSampler
+from llm4ad.planner.sampler.eoh_i1_sampler import _BaseEoHSampler
+
+
+@BaseSampler.register("eoh_e2_sampler")
+class EoHE2Sampler(_BaseEoHSampler):
+    """EoH E2 sampler: backbone-inspired new algorithm.
+
+    Identifies the shared backbone idea across parents and designs a new
+    algorithm that differs in form but is motivated by that backbone.
+    """
+
+    def __init__(self, provider, memory, config, analyzed_repository=None) -> None:
+        """Initialize the E2 sampler."""
+        super().__init__(provider, memory, config, analyzed_repository)
+        self._parent_count = max(1, int(self._get_config_value("selection_num", config, default=2)))
+
+    @property
+    def n_parents(self) -> int:
+        """Number of parent algorithms required (>=1, default 2 for E2)."""
+        return self._parent_count
+
+    @property
+    def name(self) -> str:
+        """Get the sampler name."""
+        return "eoh_e2_sampler"
+
+    async def sample(
+        self,
+        parents: list[Algorithm],
+        generation: int,
+        **kwargs: Any,
+    ) -> Algorithm:
+        """Generate a backbone-inspired new algorithm.
+
+        Args:
+            parents: One or more parent algorithms.
+            generation: Current generation number.
+            **kwargs: Additional parameters (background, template_function).
+
+        Returns:
+            Algorithm with a backbone-motivated new insight.
+        """
+        if not parents:
+            raise ValueError("EoH E2 requires at least one parent")
+
+        background = kwargs.get("background", "")
+        template_text = self._template_text(kwargs)
+
+        indivs_prompt = ""
+        for i, parent in enumerate(parents):
+            indivs_prompt += (
+                f"No. {i + 1} algorithm and the corresponding code are:\n"
+                f"{parent.description}\n{self._get_parent_code(parent)}\n"
+            )
+
+        prompt = (
+            f"{background}\n"
+            f"I have {len(parents)} existing algorithms with their codes as follows:\n"
+            f"{indivs_prompt}\n"
+            "Please help me create a new algorithm that has a totally different "
+            "form from the given ones but can be motivated from them.\n"
+            "1. Firstly, identify the common backbone idea in the provided algorithms.\n"
+            "2. Secondly, based on the backbone idea describe your new algorithm "
+            "in one sentence.\n"
+            "3. Thirdly, design a Python implementation for the following function:\n"
+            f"{template_text}\n"
+            "Return a concise algorithm name and a one-sentence description."
+        )
+
+        return await self._generate(
+            prompt,
+            generation=generation,
+            insight_type=InsightType.CROSSOVER,
+            operator="e2",
+            parent_ids=[parent.id for parent in parents],
+        )

--- a/src/llm4ad/planner/sampler/eoh_i1_sampler.py
+++ b/src/llm4ad/planner/sampler/eoh_i1_sampler.py
@@ -1,0 +1,263 @@
+"""EoH I1 sampler: initial population generation.
+
+Migrated from legacy LLM4AD EoH method (llm4ad/method/eoh/prompt.py).
+The I1 operator generates an initial algorithm insight from the task
+description and template function, with no parent algorithms for reference.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+from llm4ad.infra.provider.base import BaseProvider
+from llm4ad.infra.repo_analyzer.base import AnalyzedRepository
+from llm4ad.infra.timing import ExecutionTiming
+from llm4ad.planner.base import Algorithm, GenerationMetadata, InsightType
+from llm4ad.planner.memory import Memory
+from llm4ad.planner.sampler.base import BaseSampler
+
+
+class EoHAlgorithmSchema(BaseModel):
+    """Structured response for EoH insight generation.
+
+    The legacy EoH prompt asks the LLM to describe the algorithm in one
+    sentence inside boxed ``{}`` and then implement the function. Here we ask
+    the model to return a structured name + description; the coder generates
+    the actual code in a later stage.
+    """
+
+    name: str | None = Field(default=None, description="Concise algorithm name")
+    description: str = Field(..., description="One-sentence algorithm description")
+
+
+class _BaseEoHSampler(BaseSampler):
+    """Shared helper for EoH samplers.
+
+    Provides temperature/max_tokens resolution, EVOLVE-block access, parent
+    code extraction, and a common LLM-call + Algorithm-construction routine so
+    each operator only needs to build its prompt.
+    """
+
+    def __init__(
+        self,
+        provider: BaseProvider,
+        memory: Memory,
+        config: dict[str, Any],
+        analyzed_repository: AnalyzedRepository | None = None,
+    ) -> None:
+        """Initialize the base EoH sampler.
+
+        Args:
+            provider: LLM provider for generating insights.
+            memory: Memory system (unused by EoH operators).
+            config: Sampler configuration dict.
+            analyzed_repository: Analyzed repository with EVOLVE blocks.
+        """
+        super().__init__(provider, memory, config, analyzed_repository)
+        provider_cfg = getattr(provider, "config", None) or {}
+        self.temperature = self._get_config_value(
+            "temperature", config, provider_cfg, default=0.7
+        )
+        self.max_tokens = self._get_config_value(
+            "max_tokens", config, provider_cfg, default=4096
+        )
+
+    def _first_block(self):
+        """Return the first EVOLVE block if available, else None."""
+        if self.analyzed_repository and self.analyzed_repository.evolvable_blocks:
+            return self.analyzed_repository.evolvable_blocks[0]
+        return None
+
+    def _template_text(self, kwargs: dict[str, Any]) -> str:
+        """Resolve the function template text for the prompt.
+
+        Prefers an explicit ``template_function`` kwarg, then falls back to the
+        first EVOLVE block's content, then to an empty placeholder.
+        """
+        template = kwargs.get("template_function", "")
+        if template:
+            return template
+        block = self._first_block()
+        if block is not None:
+            return block.original_content
+        return "# Implement the target function."
+
+    @staticmethod
+    def _get_parent_code(parent: Algorithm) -> str:
+        """Extract a parent's code from artifacts or generation metadata.
+
+        Args:
+            parent: Parent algorithm.
+
+        Returns:
+            Parent code as a string, or a placeholder when unavailable.
+        """
+        if parent.code_artifacts:
+            for artifact in parent.code_artifacts:
+                if artifact.is_entrypoint:
+                    return artifact.content
+            return parent.code_artifacts[0].content
+        # Fall back to any raw response captured in custom_metadata.
+        raw = parent.custom_metadata.get("full_response", "") if parent.custom_metadata else ""
+        if raw:
+            return raw
+        return "# Code not available"
+
+    @staticmethod
+    def _derive_name(description: str, operator: str) -> str:
+        """Derive a fallback algorithm name from the description."""
+        words = [
+            word.strip(" ,.:;()[]{}")
+            for word in description.split()
+            if word.strip(" ,.:;()[]{}")
+        ]
+        if not words:
+            return f"EoH_{operator.upper()}"
+        return " ".join(words[:6])
+
+    async def _generate(
+        self,
+        prompt: str,
+        *,
+        generation: int,
+        insight_type: InsightType,
+        operator: str,
+        parent_ids: list[str],
+    ) -> Algorithm:
+        """Call the LLM and build an Algorithm from the response.
+
+        Args:
+            prompt: Fully formatted prompt string.
+            generation: Current generation number.
+            insight_type: Insight type for the new algorithm.
+            operator: Operator name (e.g. ``i1``, ``e1``).
+            parent_ids: IDs of parent algorithms.
+
+        Returns:
+            New Algorithm with description and generation metadata.
+
+        Raises:
+            ValueError: If the model output cannot be parsed.
+        """
+        start_time = time.time()
+        response = await self.provider.generate(
+            prompt,
+            temperature=self.temperature,
+            max_tokens=self.max_tokens,
+            schema=EoHAlgorithmSchema,
+            request_stage="planner",
+        )
+
+        payload: EoHAlgorithmSchema | None = response.parsed  # type: ignore[assignment]
+        if payload is None:
+            # Fallback: derive a description from the raw boxed text.
+            description = self._extract_boxed_description(response.text or "")
+            payload = EoHAlgorithmSchema(name=None, description=description)
+
+        algorithm_name = payload.name or self._derive_name(payload.description, operator)
+        algorithm = Algorithm(
+            insight_type=insight_type,
+            name=algorithm_name,
+            description=payload.description,
+            generation=generation,
+            parent_ids=parent_ids,
+        )
+        algorithm.update_timing(
+            response.timing
+            or ExecutionTiming.from_llm_stage("planner", (time.time() - start_time) * 1000)
+        )
+        algorithm.generation_meta = GenerationMetadata(
+            operator=operator,
+            llm_provider=self.provider.__class__.__name__,
+            llm_model=getattr(self.provider, "model", "unknown"),
+            temperature=self.temperature,
+            generation_time_ms=(time.time() - start_time) * 1000,
+            tokens_used=response.total_tokens,
+            agent_name=self.__class__.__name__,
+            change_description=payload.description,
+            targeted_files=[self._first_block().file_path] if self._first_block() else [],
+        )
+        algorithm.custom_metadata["eoh_operator"] = operator
+        if response.text:
+            algorithm.custom_metadata["full_response"] = response.text
+        return algorithm
+
+    @staticmethod
+    def _extract_boxed_description(text: str) -> str:
+        """Extract the algorithm description from boxed ``{...}`` markers.
+
+        Args:
+            text: Full LLM response text.
+
+        Returns:
+            Extracted description, or the first non-empty line if no box found.
+        """
+        start = text.find("{")
+        end = text.find("}", start)
+        if start != -1 and end != -1 and end > start:
+            inner = text[start + 1 : end].strip()
+            if inner:
+                return inner
+        for line in text.split("\n"):
+            stripped = line.strip()
+            if stripped and not stripped.startswith("#"):
+                return stripped[:200]
+        return "Initial algorithm"
+
+
+@BaseSampler.register("eoh_i1_sampler")
+class EoHI1Sampler(_BaseEoHSampler):
+    """EoH I1 sampler for initial population generation.
+
+    Generates initial algorithm insights with no parent context, only the task
+    description and template function signature.
+    """
+
+    @property
+    def n_parents(self) -> int:
+        """Number of parent algorithms required (0 for initial generation)."""
+        return 0
+
+    @property
+    def name(self) -> str:
+        """Get the sampler name."""
+        return "eoh_i1_sampler"
+
+    async def sample(
+        self,
+        parents: list[Algorithm],
+        generation: int,
+        **kwargs: Any,
+    ) -> Algorithm:
+        """Generate an initial algorithm insight.
+
+        Args:
+            parents: Empty list (I1 has no parents).
+            generation: Current generation number (should be 0).
+            **kwargs: Additional parameters (background, template_function).
+
+        Returns:
+            Algorithm with initial insight description.
+        """
+        background = kwargs.get("background", "")
+        template_text = self._template_text(kwargs)
+
+        prompt = (
+            f"{background}\n"
+            "1. First, describe your new algorithm and main steps in one sentence.\n"
+            "2. Next, design a Python implementation for the following function:\n"
+            f"{template_text}\n"
+            "Return a concise algorithm name and a one-sentence description of "
+            "your approach."
+        )
+
+        return await self._generate(
+            prompt,
+            generation=generation,
+            insight_type=InsightType.INITIAL,
+            operator="i1",
+            parent_ids=[],
+        )

--- a/src/llm4ad/planner/sampler/eoh_m1_sampler.py
+++ b/src/llm4ad/planner/sampler/eoh_m1_sampler.py
@@ -1,0 +1,78 @@
+"""EoH M1 sampler: create a modified version of one algorithm.
+
+Migrated from legacy LLM4AD EoH method (llm4ad/method/eoh/prompt.py). The M1
+operator asks the LLM to create a new algorithm that is a modified version of
+a single parent, with a different form.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from llm4ad.planner.base import Algorithm, InsightType
+from llm4ad.planner.sampler.base import BaseSampler
+from llm4ad.planner.sampler.eoh_i1_sampler import _BaseEoHSampler
+
+
+@BaseSampler.register("eoh_m1_sampler")
+class EoHM1Sampler(_BaseEoHSampler):
+    """EoH M1 sampler: structural modification of one parent.
+
+    Creates a new algorithm that is a modified version of the parent with a
+    different form.
+    """
+
+    @property
+    def n_parents(self) -> int:
+        """Number of parent algorithms required (1 for M1)."""
+        return 1
+
+    @property
+    def name(self) -> str:
+        """Get the sampler name."""
+        return "eoh_m1_sampler"
+
+    async def sample(
+        self,
+        parents: list[Algorithm],
+        generation: int,
+        **kwargs: Any,
+    ) -> Algorithm:
+        """Generate a modified version of the parent algorithm.
+
+        Args:
+            parents: List containing exactly 1 parent algorithm.
+            generation: Current generation number.
+            **kwargs: Additional parameters (background, template_function).
+
+        Returns:
+            Algorithm with a modified insight.
+        """
+        if len(parents) != 1:
+            raise ValueError(f"EoH M1 requires exactly 1 parent, got {len(parents)}")
+
+        parent = parents[0]
+        background = kwargs.get("background", "")
+        template_text = self._template_text(kwargs)
+
+        prompt = (
+            f"{background}\n"
+            "I have one algorithm with its code as follows. Algorithm description:\n"
+            f"{parent.description}\n"
+            "Code:\n"
+            f"{self._get_parent_code(parent)}\n"
+            "Please assist me in creating a new algorithm that has a different "
+            "form but can be a modified version of the algorithm provided.\n"
+            "1. First, describe your new algorithm and main steps in one sentence.\n"
+            "2. Next, design a Python implementation for the following function:\n"
+            f"{template_text}\n"
+            "Return a concise algorithm name and a one-sentence description."
+        )
+
+        return await self._generate(
+            prompt,
+            generation=generation,
+            insight_type=InsightType.MUTATION,
+            operator="m1",
+            parent_ids=[parent.id],
+        )

--- a/src/llm4ad/planner/sampler/eoh_m2_sampler.py
+++ b/src/llm4ad/planner/sampler/eoh_m2_sampler.py
@@ -1,0 +1,79 @@
+"""EoH M2 sampler: create a new algorithm with different parameters.
+
+Migrated from legacy LLM4AD EoH method (llm4ad/method/eoh/prompt.py). The M2
+operator asks the LLM to identify the main parameters of one parent and create
+a new algorithm with different parameter settings.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from llm4ad.planner.base import Algorithm, InsightType
+from llm4ad.planner.sampler.base import BaseSampler
+from llm4ad.planner.sampler.eoh_i1_sampler import _BaseEoHSampler
+
+
+@BaseSampler.register("eoh_m2_sampler")
+class EoHM2Sampler(_BaseEoHSampler):
+    """EoH M2 sampler: parameter mutation of one parent.
+
+    Identifies the main algorithm parameters and creates a new algorithm with
+    different parameter settings of the score function.
+    """
+
+    @property
+    def n_parents(self) -> int:
+        """Number of parent algorithms required (1 for M2)."""
+        return 1
+
+    @property
+    def name(self) -> str:
+        """Get the sampler name."""
+        return "eoh_m2_sampler"
+
+    async def sample(
+        self,
+        parents: list[Algorithm],
+        generation: int,
+        **kwargs: Any,
+    ) -> Algorithm:
+        """Generate a parameter-mutated version of the parent algorithm.
+
+        Args:
+            parents: List containing exactly 1 parent algorithm.
+            generation: Current generation number.
+            **kwargs: Additional parameters (background, template_function).
+
+        Returns:
+            Algorithm with a parameter-mutated insight.
+        """
+        if len(parents) != 1:
+            raise ValueError(f"EoH M2 requires exactly 1 parent, got {len(parents)}")
+
+        parent = parents[0]
+        background = kwargs.get("background", "")
+        template_text = self._template_text(kwargs)
+
+        prompt = (
+            f"{background}\n"
+            "I have one algorithm with its code as follows. Algorithm description:\n"
+            f"{parent.description}\n"
+            "Code:\n"
+            f"{self._get_parent_code(parent)}\n"
+            "Please identify the main algorithm parameters and assist me in "
+            "creating a new algorithm that has a different parameter settings of "
+            "the score function provided.\n"
+            "1. First, describe your new algorithm and main steps in one sentence.\n"
+            "2. Next, design a Python implementation for the following function:\n"
+            f"{template_text}\n"
+            "Return a concise algorithm name and a one-sentence description."
+        )
+
+        return await self._generate(
+            prompt,
+            generation=generation,
+            insight_type=InsightType.MUTATION,
+            operator="m2",
+            parent_ids=[parent.id],
+        )

--- a/src/llm4ad/planner/sampler/reevo_crossover_sampler.py
+++ b/src/llm4ad/planner/sampler/reevo_crossover_sampler.py
@@ -1,0 +1,128 @@
+"""ReEvo crossover sampler with short-term reflection.
+
+Migrated from legacy LLM4AD ReEvo method. The crossover operator first
+generates a short-term reflection by comparing a good and a bad parent, then
+uses that reflection to guide the crossover. The reflection is stored in
+``custom_metadata`` so a ReEvo-aware planner can aggregate it into long-term
+reflection.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from llm4ad.planner.base import Algorithm, InsightType
+from llm4ad.planner.sampler.base import BaseSampler
+from llm4ad.planner.sampler.eoh_i1_sampler import _BaseEoHSampler
+
+
+@BaseSampler.register("reevo_crossover_sampler")
+class ReEvoCrossoverSampler(_BaseEoHSampler):
+    """ReEvo crossover sampler with short-term reflection.
+
+    Compares two parents (better + worse) to generate a short reflection, then
+    uses that reflection to guide the crossover.
+    """
+
+    @property
+    def n_parents(self) -> int:
+        """Number of parent algorithms required (2 for crossover)."""
+        return 2
+
+    @property
+    def name(self) -> str:
+        """Get the sampler name."""
+        return "reevo_crossover_sampler"
+
+    async def sample(
+        self,
+        parents: list[Algorithm],
+        generation: int,
+        **kwargs: Any,
+    ) -> Algorithm:
+        """Generate a crossover guided by short-term reflection.
+
+        Args:
+            parents: List of 2 parents.
+            generation: Current generation number.
+            **kwargs: Additional parameters (background, template_function).
+
+        Returns:
+            Algorithm whose insight is guided by the short-term reflection.
+        """
+        if len(parents) != 2:
+            raise ValueError(f"ReEvo crossover requires 2 parents, got {len(parents)}")
+
+        # Order parents by score: better first.
+        ordered = sorted(parents, key=lambda p: p.score, reverse=True)
+        good_parent, bad_parent = ordered[0], ordered[1]
+
+        background = kwargs.get("background", "")
+        template_text = self._template_text(kwargs)
+
+        # Step 1: short-term reflection (a separate, un-schema'd LLM call).
+        reflection = await self._short_term_reflection(background, good_parent, bad_parent)
+
+        # Step 2: crossover guided by the reflection.
+        prompt = (
+            "You are an expert in optimization heuristics.\n"
+            f"{background}\n"
+            "[Reflection on why the better algorithm wins]\n"
+            f"{reflection}\n"
+            "[Better algorithm]\n"
+            f"{good_parent.description}\n{self._get_parent_code(good_parent)}\n"
+            "[Worse algorithm]\n"
+            f"{bad_parent.description}\n{self._get_parent_code(bad_parent)}\n"
+            "Please design a new algorithm that combines the strengths of both, "
+            "guided by the reflection above, for the following function:\n"
+            f"{template_text}\n"
+            "Return a concise algorithm name and a one-sentence description."
+        )
+
+        algorithm = await self._generate(
+            prompt,
+            generation=generation,
+            insight_type=InsightType.CROSSOVER,
+            operator="reevo_crossover",
+            parent_ids=[good_parent.id, bad_parent.id],
+        )
+        # Persist the reflection so a ReEvo-aware planner can aggregate it.
+        algorithm.custom_metadata["short_term_reflection"] = reflection
+        return algorithm
+
+    async def _short_term_reflection(
+        self, background: str, good_parent: Algorithm, bad_parent: Algorithm
+    ) -> str:
+        """Generate a short reflection comparing the better vs worse parent.
+
+        Args:
+            background: Task background.
+            good_parent: Better-performing parent.
+            bad_parent: Worse-performing parent.
+
+        Returns:
+            A short reflection string (truncated to ~25 words).
+        """
+        prompt = (
+            "You are an expert in optimization heuristics. Provide concise "
+            "insights (under 20 words).\n"
+            f"{background}\n"
+            f"[Better algorithm, score={good_parent.score:.4f}]\n"
+            f"{self._get_parent_code(good_parent)}\n"
+            f"[Worse algorithm, score={bad_parent.score:.4f}]\n"
+            f"{self._get_parent_code(bad_parent)}\n"
+            "In one sentence (under 20 words), explain why the better algorithm "
+            "outperforms the worse one."
+        )
+
+        response = await self.provider.generate(
+            prompt,
+            temperature=min(self.temperature, 0.5),
+            max_tokens=128,
+            request_stage="planner",
+        )
+        reflection = (response.text or "").strip()
+        words = reflection.split()
+        if len(words) > 25:
+            reflection = " ".join(words[:25]) + "..."
+        return reflection or "The better algorithm balances cost and feasibility more effectively."

--- a/src/llm4ad/planner/sampler/reevo_init_sampler.py
+++ b/src/llm4ad/planner/sampler/reevo_init_sampler.py
@@ -1,0 +1,71 @@
+"""ReEvo init sampler: initial population generation.
+
+Migrated from legacy LLM4AD ReEvo method (llm4ad/method/reevo/prompt.py).
+ReEvo's init prompt asks the LLM to improve a baseline version. Reuses the
+shared EoH sampler base for provider handling and Algorithm construction.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from llm4ad.planner.base import Algorithm, InsightType
+from llm4ad.planner.sampler.base import BaseSampler
+from llm4ad.planner.sampler.eoh_i1_sampler import _BaseEoHSampler
+
+
+@BaseSampler.register("reevo_init_sampler")
+class ReEvoInitSampler(_BaseEoHSampler):
+    """ReEvo init sampler for initial population generation.
+
+    Generates initial algorithms by asking the LLM to improve a baseline
+    version (the classic ReEvo v1 -> v2 pattern).
+    """
+
+    @property
+    def n_parents(self) -> int:
+        """Number of parent algorithms required (0 for init)."""
+        return 0
+
+    @property
+    def name(self) -> str:
+        """Get the sampler name."""
+        return "reevo_init_sampler"
+
+    async def sample(
+        self,
+        parents: list[Algorithm],
+        generation: int,
+        **kwargs: Any,
+    ) -> Algorithm:
+        """Generate an initial algorithm with an improvement prompt.
+
+        Args:
+            parents: Empty list (init has no parents).
+            generation: Current generation number.
+            **kwargs: Additional parameters (background, template_function).
+
+        Returns:
+            Algorithm with initial insight.
+        """
+        background = kwargs.get("background", "")
+        template_text = self._template_text(kwargs)
+
+        prompt = (
+            "You are an expert in the domain of optimization heuristics. Your "
+            "task is to design heuristics that can effectively solve "
+            "optimization problems.\n"
+            f"{background}\n"
+            f"{template_text}\n"
+            "Improve this function to give a better version.\n"
+            "Return a concise algorithm name and a one-sentence description of "
+            "your improved approach."
+        )
+
+        return await self._generate(
+            prompt,
+            generation=generation,
+            insight_type=InsightType.INITIAL,
+            operator="reevo_init",
+            parent_ids=[],
+        )

--- a/src/llm4ad/planner/sampler/reevo_mutation_sampler.py
+++ b/src/llm4ad/planner/sampler/reevo_mutation_sampler.py
@@ -1,0 +1,80 @@
+"""ReEvo mutation sampler with long-term reflection.
+
+Migrated from legacy LLM4AD ReEvo method. The mutation operator uses
+accumulated long-term reflection (passed via kwargs by a ReEvo-aware planner)
+to guide elite mutation.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from llm4ad.planner.base import Algorithm, InsightType
+from llm4ad.planner.sampler.base import BaseSampler
+from llm4ad.planner.sampler.eoh_i1_sampler import _BaseEoHSampler
+
+
+@BaseSampler.register("reevo_mutation_sampler")
+class ReEvoMutationSampler(_BaseEoHSampler):
+    """ReEvo mutation sampler with long-term reflection.
+
+    Mutates an elite parent using accumulated long-term reflection as guidance.
+    The long-term reflection is supplied via the ``long_term_reflection``
+    kwarg; when absent it falls back to an empty reflection.
+    """
+
+    @property
+    def n_parents(self) -> int:
+        """Number of parent algorithms required (1 for mutation)."""
+        return 1
+
+    @property
+    def name(self) -> str:
+        """Get the sampler name."""
+        return "reevo_mutation_sampler"
+
+    async def sample(
+        self,
+        parents: list[Algorithm],
+        generation: int,
+        **kwargs: Any,
+    ) -> Algorithm:
+        """Generate a mutation guided by long-term reflection.
+
+        Args:
+            parents: List containing 1 elite parent.
+            generation: Current generation number.
+            **kwargs: Additional parameters (background, template_function,
+                long_term_reflection).
+
+        Returns:
+            Algorithm whose insight is guided by the long-term reflection.
+        """
+        if len(parents) != 1:
+            raise ValueError(f"ReEvo mutation requires 1 parent, got {len(parents)}")
+
+        parent = parents[0]
+        background = kwargs.get("background", "")
+        template_text = self._template_text(kwargs)
+        long_term_reflection = kwargs.get("long_term_reflection", "")
+
+        prompt = (
+            "You are an expert in optimization heuristics.\n"
+            f"{background}\n"
+            "[Prior long-term reflection]\n"
+            f"{long_term_reflection}\n"
+            "[Current algorithm]\n"
+            f"{parent.description}\n{self._get_parent_code(parent)}\n"
+            "Please design a mutated version of this algorithm, guided by the "
+            "prior reflection, for the following function:\n"
+            f"{template_text}\n"
+            "Return a concise algorithm name and a one-sentence description."
+        )
+
+        return await self._generate(
+            prompt,
+            generation=generation,
+            insight_type=InsightType.MUTATION,
+            operator="reevo_mutation",
+            parent_ids=[parent.id],
+        )


### PR DESCRIPTION
- Add MCTS-AHD orchestrator with UCT tree search (mcts_ahd, mcts_ahd_tree)
- Add ReEvo evolution planner and its init/crossover/mutation samplers
- Add EoH five operators (I1/E1/E2/M1/M2) as samplers
- Add MCTSAHDConfig and wire it into the AppConfig evolution union
- Register new orchestrator/planner/samplers in package exports
- Fix MEoH has_duplicate to dedupe by code string only (drop objective-vector dedup)
- Add CVRP construct-heuristic example task (config, evaluator, solver, data gen, test)