### PR TITLE
fix: sanitize non-finite floats to null in JSON streams

### DIFF
--- a/src/backend/app/core/redis.py
+++ b/src/backend/app/core/redis.py
@@ -84,9 +84,16 @@ def push_log_entry(task_id: str | uuid.UUID, entry: dict) -> None:
         entry: 待写入的日志条目字典，会被 JSON 序列化后存入。
     """
     try:
+        # Sanitize non-finite floats (inf/-inf/nan) to None so the Redis stream
+        # holds strict JSON. Otherwise json.dumps (allow_nan=True by default)
+        # emits `Infinity`/`NaN`, which crashes the frontend's JSON.parse and
+        # pollutes in-flight score statistics read back from Redis.
+        # Imported lazily to avoid a core -> utils import cycle.
+        from app.utils.log_persist import sanitize_for_json
+
         r = get_sync_redis()
         key = task_logs_key(task_id)
-        payload = json.dumps(entry, ensure_ascii=False, default=str)
+        payload = json.dumps(sanitize_for_json(entry), ensure_ascii=False, default=str)
         r.xadd(key, {"data": payload}, maxlen=settings.TASK_LOGS_MAXLEN, approximate=True)
         if r.ttl(key) == -1:
             r.expire(key, TASK_LOGS_TTL)

--- a/src/backend/app/services/task_service/stats.py
+++ b/src/backend/app/services/task_service/stats.py
@@ -4,6 +4,7 @@
 的生成与缓存。
 """
 
+import math
 import uuid
 from typing import TYPE_CHECKING
 
@@ -64,7 +65,10 @@ def get_task_stats(
         if not isinstance(evaluation, dict):
             continue
         score = evaluation.get("score")
-        if isinstance(score, (int, float)) and not isinstance(score, bool):
+        # Filter out non-finite floats (inf/-inf/nan) to defend against stale
+        # Redis data written before the sanitize fix. DB-persisted logs already
+        # have sanitize_for_json applied, but in-flight tasks read from Redis.
+        if isinstance(score, (int, float)) and not isinstance(score, bool) and math.isfinite(score):
             scores.append(float(score))
 
     solution_count = len(entries)

--- a/src/backend/app/tasks/container_runner.py
+++ b/src/backend/app/tasks/container_runner.py
@@ -10,6 +10,7 @@ tail；stdout/stderr 仅承载依赖安装、用户 print 与未捕获 traceback
 
 import asyncio
 import json
+import math
 import os
 import subprocess
 import sys
@@ -34,6 +35,24 @@ FINAL_STATE_FILENAME = ".final_state.json"
 EVENTS_FILENAME = ".events.jsonl"  # 须与 app.core.constants.EVENTS_FILENAME 一致
 GENERATED_DIR = os.path.join(DATA_DIR, "llm4ad", "run", "generated")
 _GENERATED_SCAN_INTERVAL = 2.0  # 扫描 generated 目录的间隔（秒）
+
+
+def _sanitize_non_finite(obj):
+    """Replace non-finite floats (inf, -inf, nan) with None for strict JSON.
+
+    Lightweight helper that avoids importing app.utils to keep container_runner
+    decoupled from the backend package. Semantics match sanitize_for_json.
+    """
+    if isinstance(obj, float):
+        if math.isinf(obj) or math.isnan(obj):
+            return None
+        return obj
+    if isinstance(obj, dict):
+        return {k: _sanitize_non_finite(v) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [_sanitize_non_finite(item) for item in obj]
+    return obj
+
 
 
 class EventsSink:
@@ -113,11 +132,14 @@ def _scan_generated(generated_dir: str, emit, seen: dict[str, float]) -> None:
                 content = json.load(f)
         except Exception:
             continue
+        # Sanitize non-finite floats before emitting so Redis/SSE stream is
+        # strict JSON; otherwise Algorithm.write's json.dump (allow_nan=True)
+        # puts -Infinity in the file, which crashes frontend's JSON.parse.
         emit({
             "type": "generated",
             "timestamp": datetime.now(UTC).isoformat(),
             "file_name": name,
-            "data": content,
+            "data": _sanitize_non_finite(content),
         })
 
 

--- a/src/backend/tests/tasks/test_container_runner_events.py
+++ b/src/backend/tests/tasks/test_container_runner_events.py
@@ -2,7 +2,7 @@ import json
 
 from loguru import logger
 
-from app.tasks.container_runner import EventsSink
+from app.tasks.container_runner import EventsSink, _sanitize_non_finite
 
 
 def test_events_sink_writes_structured_memory_events(tmp_path):
@@ -26,3 +26,30 @@ def test_events_sink_writes_structured_memory_events(tmp_path):
     assert event["task_id"] == "task-1"
     assert event["memory_id"] == "memory-1"
     assert "timestamp" in event
+
+
+def test_sanitize_non_finite_replaces_inf_nan_with_none():
+    """Test that _sanitize_non_finite converts inf/-inf/nan to None recursively."""
+    # Scalars
+    assert _sanitize_non_finite(42.5) == 42.5
+    assert _sanitize_non_finite(float("inf")) is None
+    assert _sanitize_non_finite(float("-inf")) is None
+    assert _sanitize_non_finite(float("nan")) is None
+    assert _sanitize_non_finite("text") == "text"
+    assert _sanitize_non_finite(None) is None
+
+    # Nested structures (matching generated event payload shape)
+    payload = {
+        "evaluation": {
+            "score": float("-inf"),
+            "metrics": {"time_ms": 123.4, "cost": float("nan")},
+        },
+        "name": "algo",
+        "nested_list": [1, float("inf"), {"x": float("-inf")}],
+    }
+    result = _sanitize_non_finite(payload)
+    assert result["evaluation"]["score"] is None
+    assert result["evaluation"]["metrics"]["time_ms"] == 123.4
+    assert result["evaluation"]["metrics"]["cost"] is None
+    assert result["name"] == "algo"
+    assert result["nested_list"] == [1, None, {"x": None}]


### PR DESCRIPTION
1. Sanitize inf/-inf/nan to null in push_log_entry before writing to Redis stream
2. Sanitize generated file content in container_runner before emitting events
3. Filter non-finite scores in get_task_stats to defend against stale Redis data
4. Add test coverage for non-finite float handling in container runner events