### PR TITLE
feat: agent i18n support and evolution method knowledge

### DIFF
--- a/skills/llm4ad-task-builder/SKILL.md
+++ b/skills/llm4ad-task-builder/SKILL.md
@@ -103,6 +103,118 @@ defaults where the user has no preference):
    re-run. Not done until both run cleanly. If no provider credentials are available,
    say so — a missing-credential failure of `debug_run.py` is not a package defect.
 
+## Automated algorithm design methods (reference — only when the user asks)
+
+Always build new task packages with the default **Island GA** method. Do NOT
+proactively suggest switching to another method — let the user bring it up.
+
+When the user asks about methods or explicitly requests a switch, help them
+using the reference below. After applying a switch, ask whether they want to
+continue adjusting parameters or are satisfied.
+
+Each method requires a matching pair of `evolution.type` + `planner.type`.
+Switching methods means **replacing the entire `evolution` section` (parameters
+differ per method) and updating `planner.type`. A fresh run is required — you
+cannot resume a prior run after changing the evolution type.
+
+---
+
+**Island GA** (default — use this for all new builds)
+
+```yaml
+evolution:
+  type: "island_ga"
+  max_generations: 50
+  num_islands: 5              # number of parallel populations
+  island_population_size: 20  # individuals per island
+  mutation_rate: 0.3
+  crossover_rate: 0.5
+  tournament_size: 3
+  early_stop_patience: 10
+  migration_interval: 5       # gens between cross-island exchanges
+  migration_rate: 0.1         # fraction of individuals migrated
+  migration_strategy: "best"  # best | random | elite | worst
+  migration_topology: "ring"  # ring | fully_connected | hierarchical | mesh
+  parallel_islands: true      # run islands concurrently
+planner:
+  type: "llm_evolution"
+```
+
+**EoH** — Evolution of Heuristics *(ICML 2024)*  
+Single-objective, rank-based truncation. Runs E1 (and optionally E2/M1/M2)
+operators each generation.
+
+```yaml
+evolution:
+  type: "eoh"
+  max_generations: 50
+  population_size: 5          # top-k individuals kept after truncation
+  selection_num: 2            # parents selected per E1/E2 crossover
+  max_sample_nums: 100        # LLM call budget cap for the run
+  num_samplers: 1             # parallel candidates per operator per gen
+  use_e2_operator: true       # enable E2 (backbone-motivated crossover)
+  use_m1_operator: true       # enable M1 (structural mutation)
+  use_m2_operator: true       # enable M2 (parameter mutation)
+  seed_path: null             # optional path to a seed heuristic file
+planner:
+  type: "eoh_evolution"
+```
+
+**ReEvo** — Reflective Evolution *(NeurIPS 2024)*  
+Adds two reflection signals to genetic search: short-term (comparing worse/better
+parent pairs → better crossover) and long-term (accumulated history → better
+elite mutation).
+
+```yaml
+evolution:
+  type: "reevo"
+  max_generations: 50
+  population_size: 8          # individuals in the population
+  mutation_rate: 0.5          # fraction of pop used for elite mutations per gen
+  max_sample_nums: 100        # LLM call budget cap for the run
+  num_samplers: 1             # parallel crossover candidates per step
+  seed_path: null             # optional path to a seed heuristic file
+planner:
+  type: "reevo_evolution"
+```
+
+**MCTS-AHD** — Monte Carlo Tree Search for AHD *(ICML 2025)*  
+Tree search over algorithm space: selects nodes via UCT, expands with
+e1/e2/m1/m2/s1 operators. Not generational; `max_generations` is interpreted
+as MCTS iterations.
+
+```yaml
+evolution:
+  type: "mcts_ahd"
+  max_generations: 1000       # MCTS iterations (not generations)
+  init_size: 4                # initial child nodes expanded under root
+  population_size: 10         # active algorithm pool size
+  selection_num: 2            # parents per e1/e2 operator
+  max_sample_nums: 100        # LLM call budget cap for the search
+  alpha: 0.5                  # UCT progressive-widening parameter
+  lambda_0: 0.1               # UCT exploration constant (decays with budget)
+  max_depth: 10               # maximum tree depth
+  seed_path: null             # optional path to a seed heuristic file
+planner:
+  type: "mcts_ahd_evolution"
+```
+
+### Switching checklist (only when the user actively requests it)
+
+1. **Replace `evolution` section** — remove the old method's specific params,
+   write the new method's complete section from the templates above. Do NOT
+   carry over params that don't exist in the new method's schema (e.g.
+   `num_islands` is IGA-only).
+2. **Update `planner.type`** — must match the new method.
+3. **Keep everything else** — `providers`, `evaluator`, `coder`, `dataset`,
+   `version_control` stay unchanged.
+4. **Warn the user** — switching evolution type means a fresh run; you cannot
+   resume an old checkpoint under a different method.
+5. **Re-verify** — after editing `config.yaml`, re-run `debug_run.py` to
+   confirm the new method loads correctly.
+6. **Ask whether to continue** — after the switch is applied and verified, ask
+   the user if they want to adjust any parameters further or are satisfied.
+
 <!-- PLATFORM-USAGE-DRAFT: 以下"如何在平台上使用"为草稿，待产品同学修订 -->
 ## How the package is used on the LLM4AD platform
 
@@ -146,3 +258,12 @@ the provider `model`, and `evaluator.timeout`.
 The package is done only when `test_evaluator.py` loads the evaluator AND
 `debug_run.py` runs without raising. Then summarize what was built (files + the
 7 decisions) and the verification result.
+
+After a successful build, always close by conveying this message (translate to the
+user's language; do NOT proactively recommend a specific method — just mention
+that the option exists):
+
+> The task package has been built and verified. I can help you choose the
+> evolution method (such as EoH, ReEvo, or MCTS-AHD), and adjust evolution
+> parameters (such as max_generations, population size, etc.), or feel free
+> to let me know if you have other needs!

--- a/src/llm4ad/agent/runner.py
+++ b/src/llm4ad/agent/runner.py
@@ -232,7 +232,9 @@ def _fmt_tokens(n: int) -> str:
     return str(n)
 
 
-def build_config_summary_md(base_dir: str, project_name: str) -> str:
+def build_config_summary_md(
+    base_dir: str, project_name: str, language: str = "zh"
+) -> str:
     """Read the produced config.yaml and render an evolution-params + cost summary.
 
     Returns a markdown block (heading + params table + token estimate) to append
@@ -241,6 +243,7 @@ def build_config_summary_md(base_dir: str, project_name: str) -> str:
     Args:
         base_dir: Workspace root.
         project_name: Produced project directory name.
+        language: ``"zh"`` or ``"en"``.
 
     Returns:
         A markdown string, or "" on failure (the caller still reports success).
@@ -257,28 +260,39 @@ def build_config_summary_md(base_dir: str, project_name: str) -> str:
         return ""
     est = estimate_evolution_cost(evo)
     etype = evo.get("type", "island_ga")
+    _zh = language == "zh"
     lines = [
-        "### ⚙️ 进化参数配置",
+        "### ⚙️ 进化参数配置" if _zh else "### ⚙️ Evolution Parameters",
         "",
-        "| 参数 | 值 |",
+        "| 参数 | 值 |" if _zh else "| Parameter | Value |",
         "|---|---|",
-        f"| 进化算法 | {etype} |",
-        f"| 迭代代数 (max_generations) | {est['max_generations']} |",
-        f"| 岛屿数 (num_islands) | {est['num_islands']} |",
-        f"| 每岛种群 (island_population_size) | {est['island_population_size']} |",
-        f"| 变异率 (mutation_rate) | {evo.get('mutation_rate', '—')} |",
-        f"| 交叉率 (crossover_rate) | {evo.get('crossover_rate', '—')} |",
-        f"| 精英比例 (elite_ratio) | {evo.get('elite_ratio', '—')} |",
+        f"| {'进化算法' if _zh else 'Evolution algorithm'} | {etype} |",
+        f"| {'迭代代数 (max_generations)' if _zh else 'Max generations'} | {est['max_generations']} |",
+        f"| {'岛屿数 (num_islands)' if _zh else 'Number of islands'} | {est['num_islands']} |",
+        f"| {'每岛种群 (island_population_size)' if _zh else 'Island population size'} | {est['island_population_size']} |",
+        f"| {'变异率 (mutation_rate)' if _zh else 'Mutation rate'} | {evo.get('mutation_rate', '—')} |",
+        f"| {'交叉率 (crossover_rate)' if _zh else 'Crossover rate'} | {evo.get('crossover_rate', '—')} |",
+        f"| {'精英比例 (elite_ratio)' if _zh else 'Elite ratio'} | {evo.get('elite_ratio', '—')} |",
         "",
-        "### 💰 预计 token 消耗（粗略上限）",
+        "### 💰 预计 token 消耗（粗略上限）" if _zh else "### 💰 Estimated Token Usage (rough upper bound)",
         "",
         f"- 预计生成候选算法：约 **{est['total_candidates']}** 个"
-        f"（每个含 planner + coder 两次 LLM 调用，共约 **{est['llm_calls']}** 次调用）",
+        f"（每个含 planner + coder 两次 LLM 调用，共约 **{est['llm_calls']}** 次调用）"
+        if _zh else
+        f"- Estimated candidate algorithms: ~**{est['total_candidates']}** "
+        f"(each with 2 LLM calls — planner + coder — totalling ~**{est['llm_calls']}** calls)",
         f"- 预计输出 token：约 **{_fmt_tokens(est['tokens_low'])} ~ "
+        f"{_fmt_tokens(est['tokens_high'])}**"
+        if _zh else
+        f"- Estimated output tokens: ~**{_fmt_tokens(est['tokens_low'])} – "
         f"{_fmt_tokens(est['tokens_high'])}**",
         "",
-        "> 这是**按迭代代数满跑**估算的上限；实际会因早停（early stopping）而更少，"
-        "且不含输入 token。可通过调小 `max_generations` / `island_population_size` 降低消耗。",
+        ("> 这是**按迭代代数满跑**估算的上限；实际会因早停（early stopping）而更少，"
+         "且不含输入 token。可通过调小 `max_generations` / `island_population_size` 降低消耗。"
+         if _zh else
+         "> This is a rough upper bound assuming **all generations run to completion**; "
+         "actual usage will be lower due to early stopping, and input tokens are not "
+         "included. Reduce `max_generations` / `island_population_size` to lower costs."),
     ]
     return "\n".join(lines)
 
@@ -312,6 +326,7 @@ def make_tools(
     state: _BuildState,
     *,
     allow_build: bool = False,
+    language: str = "zh",
 ) -> list[Any]:
     """Build the agent's tools for the current phase.
 
@@ -346,6 +361,11 @@ def make_tools(
     from llm4ad.consultant.needs import NeedsProfile
 
     base = Path(base_dir).resolve()
+
+    # Save UI language under a distinct name so inner functions (which have
+    # their own ``language`` parameter for the programming language) don't
+    # accidentally shadow the closure variable.
+    _ui_lang = language
 
     def _tool(func: Callable[..., Any], **kwargs: Any) -> FunctionTool:
         """Wrap a workspace tool function as an agentscope ``FunctionTool``.
@@ -676,7 +696,7 @@ def make_tools(
             for p in (base / blueprint.project_name).rglob("*")
             if p.is_file()
         )
-        cfg_summary = build_config_summary_md(str(base), blueprint.project_name)
+        cfg_summary = build_config_summary_md(str(base), blueprint.project_name, _ui_lang)
         return (
             f"Build succeeded and passed the validation gate.\n"
             f"Project: {blueprint.project_name}\n"
@@ -825,8 +845,12 @@ def make_tools(
         }
         state.summary_text = summary.strip()
         return (
-            "Plan recorded. The user is now shown a confirmation card with the 7 "
-            "plan items. Stop here and wait for their decision — do nothing else."
+            "方案已记录。用户现在看到一张包含 7 个规划项的确认卡片。"
+            "请停止并等待用户决定——不要做任何其他操作。"
+            if _ui_lang == "zh"
+            else "Plan recorded. The user is now shown a confirmation card with "
+            "the 7 plan items. Stop here and wait for their decision — "
+            "do nothing else."
         )
 
     def ask_choice(
@@ -843,11 +867,13 @@ def make_tools(
 
         Attaching upload to a specific option (PREFERRED): put a ``[dir]`` or
         ``[file]`` tag at the START of that option's text. Clicking THAT option
-        then opens a directory / file picker. Example:
-        ``["由你来设计 — 我帮你设计求解函数",
-          "[dir] 进化我现有的代码 — 上传我的项目目录让 LLM 优化"]``
+        then opens a directory / file picker. Example:""" + (
+            ' ``["由你来设计 — 我帮你设计求解函数", "[dir] 进化我现有的代码 — 上传我的项目目录让 LLM 优化"]``'
+            if _ui_lang == "zh"
+            else ' ``["Let you design it — I\'ll create the solver", "[dir] Evolve my existing code — Upload my project for LLM optimization"]``'
+        ) + """
         This is better than a separate "upload" option because the upload lives on
-        the semantically meaningful choice ("evolve my code"), so one click does it.
+        the semantically meaningful choice, so one click does it.
 
         Args:
             question: The single question to ask.
@@ -855,8 +881,12 @@ def make_tools(
                 ``"Label — short description"`` (em dash separates label from hint).
                 Prefix an option with ``[dir]`` or ``[file]`` to make clicking it
                 open a directory / file picker.
-            allow_custom: If True (default), a "自行输入 / Enter your own" free-text
-                option is appended so the user isn't boxed in.
+            allow_custom: If True (default), a free-text option is appended so
+                the user is not boxed in.""" + (
+                ' (Shown as "自行输入 / Enter your own".)'
+                if _ui_lang == "zh"
+                else ' (Shown as "Enter your own".)'
+            ) + """
             upload: Legacy fallback: ``"file"`` / ``"dir"`` appends a standalone
                 upload option. Prefer the inline ``[dir]``/``[file]`` tag instead.
 
@@ -895,21 +925,21 @@ def make_tools(
         if upload == "file":
             opts.append({
                 "value": "__upload_file__",
-                "label": "上传文件 / Upload a file",
-                "description": "选择本地文件提供给助手",
+                "label": "上传文件 / Upload a file" if _ui_lang == "zh" else "Upload a file",
+                "description": "选择本地文件提供给助手" if _ui_lang == "zh" else "Select a local file for the assistant",
                 "ask_for_path": True,
             })
         elif upload == "dir":
             opts.append({
                 "value": "__upload_dir__",
-                "label": "上传目录 / Upload a directory",
-                "description": "选择本地项目目录提供给助手",
+                "label": "上传目录 / Upload a directory" if _ui_lang == "zh" else "Upload a directory",
+                "description": "选择本地项目目录提供给助手" if _ui_lang == "zh" else "Select a local project directory for the assistant",
                 "ask_for_dir": True,
             })
         if allow_custom:
             opts.append({
                 "value": "__custom__",
-                "label": "自行输入 / Enter your own",
+                "label": "自行输入 / Enter your own" if _ui_lang == "zh" else "Enter your own",
                 "description": "",
                 "is_custom": True,
             })
@@ -993,7 +1023,11 @@ def _detect_project_dir(base_dir: str) -> str:
     return ""
 
 
-def _confirm_build_card(summary: str, proposed: dict[str, Any] | None = None) -> dict[str, Any]:
+def _confirm_build_card(
+    summary: str,
+    proposed: dict[str, Any] | None = None,
+    language: str = "zh",
+) -> dict[str, Any]:
     """Build the confirm/decline card shown after a gather proposal.
 
     Renders the structured 7-item Plan in the card prompt (the frontend displays
@@ -1005,6 +1039,7 @@ def _confirm_build_card(summary: str, proposed: dict[str, Any] | None = None) ->
     Args:
         summary: The agent's one-paragraph task recap.
         proposed: The structured plan dict recorded by ``propose_plan``.
+        language: ``"zh"`` or ``"en"``.
 
     Returns:
         The payload dict for a ``{"type": "payload", "data": ...}`` event.
@@ -1015,6 +1050,7 @@ def _confirm_build_card(summary: str, proposed: dict[str, Any] | None = None) ->
         """Escape a value for use inside a markdown table cell."""
         return str(text).replace("|", "\\|").replace("\n", " ")
 
+    _zh = language == "zh"
     lines: list[str] = []
     if proposed:
         # Render the plan as markdown (heading + table), the SAME style the agent
@@ -1024,40 +1060,55 @@ def _confirm_build_card(summary: str, proposed: dict[str, Any] | None = None) ->
             f"复用已有代码 `{proposed['code_path']}`"
             if proposed.get("code_path")
             else "从零生成"
+        ) if _zh else (
+            f"Reuse existing code `{proposed['code_path']}`"
+            if proposed.get("code_path")
+            else "Generate from scratch"
         )
         eval_src = (
             f"复用已有评估器 `{proposed['existing_evaluator_path']}`"
             if proposed.get("use_existing_evaluator")
             else "自动生成"
+        ) if _zh else (
+            f"Reuse existing evaluator `{proposed['existing_evaluator_path']}`"
+            if proposed.get("use_existing_evaluator")
+            else "Auto-generate"
         )
         data_src = (
             f"使用已有数据 `{proposed['data_path']}`"
             if proposed.get("data_path")
             else "自动生成样本"
+        ) if _zh else (
+            f"Use existing data `{proposed['data_path']}`"
+            if proposed.get("data_path")
+            else "Generate sample data"
         )
-        fn = proposed.get("function_to_evolve") or "由助手设计"
-        io = proposed.get("io_format") or "由助手设计"
-        metric = proposed.get("metrics_hints") or proposed.get("evaluation_hints") or "(未填)"
+        fn = proposed.get("function_to_evolve") or ("由助手设计" if _zh else "Designed by assistant")
+        io = proposed.get("io_format") or ("由助手设计" if _zh else "Designed by assistant")
+        metric_default = "(未填)" if _zh else "(not specified)"
+        metric = proposed.get("metrics_hints") or proposed.get("evaluation_hints") or metric_default
         lines = [
-            "## 📋 构建方案确认",
+            "## 📋 构建方案确认" if _zh else "## 📋 Build Plan Confirmation",
             "",
-            "| # | 项目 | 内容 |",
+            "| # | 项目 | 内容 |" if _zh else "| # | Item | Details |",
             "|---|---|---|",
-            f"| 1 | 问题描述 | {_md_cell(proposed.get('description') or '(未填)')} |",
-            f"| 2 | 进化目标 | {_md_cell(fn)} |",
-            f"| 3 | 输入 / 输出 | {_md_cell(io)} |",
-            f"| 4 | 评估指标 | {_md_cell(metric)} |",
-            f"| 5 | 代码来源 | {_md_cell(code_src)}（评估器：{_md_cell(eval_src)}） |",
-            f"| 6 | 数据来源 | {_md_cell(data_src)} |",
-            f"| 7 | 语言 / 项目名 | {_md_cell(proposed.get('language') or 'python')} / "
-            f"`{_md_cell(proposed.get('project_name') or '自动')}` |",
+            f"| 1 | {'问题描述' if _zh else 'Problem description'} | {_md_cell(proposed.get('description') or ('(未填)' if _zh else '(not specified)'))} |",
+            f"| 2 | {'进化目标' if _zh else 'Evolution target'} | {_md_cell(fn)} |",
+            f"| 3 | {'输入 / 输出' if _zh else 'Input / Output'} | {_md_cell(io)} |",
+            f"| 4 | {'评估指标' if _zh else 'Evaluation metric'} | {_md_cell(metric)} |",
+            f"| 5 | {'代码来源' if _zh else 'Code source'} | {_md_cell(code_src)}（{'评估器' if _zh else 'Evaluator'}：{_md_cell(eval_src)}） |",
+            f"| 6 | {'数据来源' if _zh else 'Data source'} | {_md_cell(data_src)} |",
+            f"| 7 | {'语言 / 项目名' if _zh else 'Language / Project'} | {_md_cell(proposed.get('language') or 'python')} / "
+            f"`{_md_cell(proposed.get('project_name') or ('自动' if _zh else 'auto'))}` |",
             "",
-            "还有要补充或修改的吗？**确认无误我就开始构建** 🚀",
+            "还有要补充或修改的吗？**确认无误我就开始构建** 🚀"
+            if _zh else
+            "Anything to add or revise? **I'll start building once confirmed** 🚀",
         ]
     elif summary:
         lines.append(summary.strip())
 
-    prompt = "\n".join(lines) if lines else "需求已明确，是否开始构建？"
+    prompt = "\n".join(lines) if lines else ("需求已明确，是否开始构建？" if _zh else "Requirements are clear — shall I start building?")
     return {
         "cardId": f"card-{uuid.uuid4().hex[:8]}",
         "kind": "choice",
@@ -1067,13 +1118,13 @@ def _confirm_build_card(summary: str, proposed: dict[str, Any] | None = None) ->
         "options": [
             {
                 "value": "confirm_build",
-                "label": "确认构建",
-                "description": "按上述方案开始构建任务",
+                "label": "确认构建" if _zh else "Confirm Build",
+                "description": "按上述方案开始构建任务" if _zh else "Start building the task as specified above",
             },
             {
                 "value": "decline_build",
-                "label": "继续调整",
-                "description": "继续对话补充或修改需求",
+                "label": "继续调整" if _zh else "Keep Adjusting",
+                "description": "继续对话补充或修改需求" if _zh else "Continue the conversation to refine requirements",
             },
         ],
     }
@@ -1238,19 +1289,20 @@ async def run_agent_build(config: AgentBuildConfig) -> AsyncIterator[dict[str, A
     try:
         state = _BuildState()
         model = build_model(config.provider_config)
+        language = (config.gathering_context or {}).get("language", "zh")
         toolkit = Toolkit(
             tools=make_tools(
                 config.base_dir,
                 config.provider_config,
                 state,
                 allow_build=config.allow_build,
+                language=language,
             )
         )
-
         system_prompt = (
-            build_system_prompt(config.base_dir, config.surface)
+            build_system_prompt(config.base_dir, config.surface, language)
             if config.allow_build
-            else build_gather_system_prompt(config.base_dir)
+            else build_gather_system_prompt(config.base_dir, language)
         )
 
         # Restore prior conversation memory if present (resume across turns).
@@ -1343,7 +1395,7 @@ async def run_agent_build(config: AgentBuildConfig) -> AsyncIterator[dict[str, A
         elif not config.allow_build and state.proposed is not None:
             yield {
                 "type": "payload",
-                "data": _confirm_build_card(state.summary_text, state.proposed),
+                "data": _confirm_build_card(state.summary_text, state.proposed, language),
                 "proposed": state.proposed,
             }
 

--- a/src/llm4ad/agent/skill.py
+++ b/src/llm4ad/agent/skill.py
@@ -74,7 +74,9 @@ def _with_skill_knowledge(prompt: str) -> str:
     )
 
 
-def build_gather_system_prompt(workspace_dir: str) -> str:
+def build_gather_system_prompt(
+    workspace_dir: str, language: str = "zh"
+) -> str:
     """System prompt for the GATHER phase: step-by-step requirement gathering.
 
     The agent asks one question at a time and, when ready, calls ``propose_build``
@@ -83,10 +85,50 @@ def build_gather_system_prompt(workspace_dir: str) -> str:
 
     Args:
         workspace_dir: The sandbox root (informational; tool paths are fenced here).
+        language: ``"zh"`` or ``"en"``, from the frontend language toggle.
 
     Returns:
         The full system prompt string.
     """
+    lang_name = "Chinese" if language == "zh" else "English"
+    _problem_cats = (
+        '"运筹优化 / Operations Research — TSP、背包、调度", '
+        '"数学求解 / Mathematical — 数值优化、方程、回归", '
+        '"AI/ML 策略演化 / AI-ML strategy — 网络架构、超参数、RL策略"'
+        if language == "zh"
+        else
+        '"Operations Research — TSP, Knapsack, Scheduling", '
+        '"Mathematical — Numerical Optimization, Equations, Regression", '
+        '"AI/ML Strategy — Neural Architecture, Hyperparameters, RL Policy"'
+    )
+    _code_opts = (
+        '"由你设计 / Let you design it", '
+        '"[dir] 进化我现有的代码 / Evolve my existing code"'
+        if language == "zh"
+        else
+        '"Let you design it", '
+        '"[dir] Evolve my existing code"'
+    )
+    _data_opts = (
+        '"由你生成样本数据 / Generate sample data", '
+        '"[dir] 上传我的数据 / Upload my data"'
+        if language == "zh"
+        else
+        '"Generate sample data", '
+        '"[dir] Upload my data"'
+    )
+    _plan_confirm_example = (
+        '"需求已明确，请确认下面的方案："'
+        if language == "zh"
+        else
+        '"Requirements are clear — please review the plan below:"'
+    )
+    _ready_examples = (
+        '"开始构建吧", "就这样", "OK 构建", "go ahead"'
+        if language == "zh"
+        else
+        '"Start building", "Go ahead", "Build it", "OK"'
+    )
     prompt = f"""You are a friendly, proactive assistant helping a user specify an \
 LLM4AD task before it is built. LLM4AD evolves a marked block of code (between \
 EVOLVE_START / EVOLVE_END) to optimize a problem, scored by a custom evaluator.
@@ -117,12 +159,10 @@ function design). Do not call early.
 WHAT TO GATHER (ask ONE at a time, using ask_choice with preset options wherever \
 possible; mirror and exceed the classic wizard):
 1. **Problem description** (required — ask) — what is being optimized. UNLESS the \
-first message already makes it concrete, open with ask_choice offering: "运筹优化 / \
-Operations Research — TSP、背包、调度", "数学求解 / Mathematical — 数值优化、方程、回归", \
-"AI/ML 策略演化 / AI-ML strategy — 网络架构、超参数、RL策略". If already concrete, skip.
+first message already makes it concrete, open with ask_choice offering: \
+{_problem_cats}. If already concrete, skip.
 2. **What code to evolve** — ask what algorithm/function they want to evolve, and \
-offer via ask_choice TWO options: "由你设计 / Let you design it" AND \
-"[dir] 进化我现有的代码 / Evolve my existing code" — note the ``[dir]`` prefix, which \
+offer via ask_choice TWO options: {_code_opts} — note the ``[dir]`` prefix, which \
 makes clicking THAT option open a directory picker (do NOT add a separate "upload" \
 option). ONLY if they upload: inspect it with read_file/list_dir, and if you find \
 an evaluator script (``*evaluator.py``), ask whether to reuse it (set \
@@ -131,9 +171,8 @@ metrics). If they let you design it, YOU choose the function and I/O format — 
 record them in function_to_evolve / io_format.
 3. **Evaluation metric(s)** (required — ask clearly) — what to minimize/maximize. \
 Offer likely options via ask_choice when you can infer them.
-4. **Data source** — ask_choice with two options: "由你生成样本数据 / Generate sample \
-data" AND "[dir] 上传我的数据 / Upload my data" (the ``[dir]`` prefix makes that \
-option open a picker). Record data_path only if they upload.
+4. **Data source** — ask_choice with two options: {_data_opts} (the ``[dir]`` \
+prefix makes that option open a picker). Record data_path only if they upload.
 5. **Programming language** — ask_choice with Python as the default option.
 6. **Project name** — propose one from the description and ask the user to confirm \
 or rename.
@@ -149,7 +188,7 @@ over the old fixed wizard; use it.
 ``summary`` and every field filled. Keep your own text before the card SHORT — do \
 NOT re-list the plan in prose and do NOT mention how many items there are; the card \
 renders the structured plan and asks the user whether anything needs adjusting. A \
-single brief sentence like "需求已明确，请确认下面的方案：" is enough.
+single brief sentence like {_plan_confirm_example} is enough.
 
 CRITICAL — the confirm card (propose_plan) is the ONLY way the user can enter the \
 build phase, so you MUST re-call propose_plan whenever the plan could have changed \
@@ -160,15 +199,15 @@ data, metric, seeds, algorithm, project name, etc.) — re-propose so the card \
 reflects the change and the user can confirm the UPDATED plan.
 - The user asks a question about, or points out something missing in, the plan — \
 answer briefly, then re-call propose_plan so a fresh confirm card is shown.
-- The user expresses readiness in free text (e.g. "开始构建吧", "就这样", "OK 构建", \
-"go ahead") — do NOT reply that you "cannot build" or "have no write tool"; instead \
-re-call propose_plan so the confirm card reappears for them to click. Building \
-starts only after they confirm via the card; your job in this phase is to keep the \
-confirm card available and current.
+- The user expresses readiness in free text (e.g. {_ready_examples}) — do NOT \
+reply that you "cannot build" or "have no write tool"; instead re-call \
+propose_plan so the confirm card reappears for them to click. Building starts only \
+after they confirm via the card; your job in this phase is to keep the confirm \
+card available and current.
 Never leave the user in a state where the plan is settled but no confirm card is on \
 screen — that traps them, because plain text cannot start the build.
 
-Respond in the user's language."""
+Respond in {lang_name}."""
     return _with_skill_knowledge(prompt)
 
 
@@ -189,22 +228,29 @@ def _closing_for_surface(surface: str) -> str:
         return (
             "CLOSING (CLI): after the build is verified, tell the user they can run "
             "it with `llm4ad run <project>/config.yaml` (it needs LLM_BASE_URL / "
-            "LLM_API_KEY / LLM_MODEL env vars set), and that they may tune "
-            "config.yaml evolution parameters. Offer to keep helping."
+            "LLM_API_KEY / LLM_MODEL env vars set). Also say (translate to the "
+            "user's language): \"The task package has been built and verified. I "
+            "can help you choose the evolution method (such as EoH, ReEvo, or "
+            "MCTS-AHD), and adjust evolution parameters (such as max_generations, "
+            "population size, etc.), or feel free to let me know if you have other "
+            "needs!\""
         )
     return (
         "CLOSING (platform): the user is on the web platform — they do NOT run any "
         "CLI command and do NOT set environment variables; the platform runs the "
-        "task for them. So do NOT mention `llm4ad run` or LLM_* env vars. Instead, "
-        "after the build is verified, tell them the task package is ready and offer "
-        "to keep helping — e.g. tuning evolution parameters (max_generations, "
-        "num_islands, mutation_rate, ...), adjusting the algorithm or evaluator, or "
-        "answering any questions. Say something like: “任务包已构建完成并通过验证。我"
-        "可以继续帮你调整演化参数，或者你有别的需求也可以随时告诉我，我都能为你解答。”"
+        "task for them. So do NOT mention `llm4ad run` or LLM_* env vars. "
+        "After the build is verified, always close with exactly this line "
+        "(translate to the user's language as needed): \"The task package has been "
+        "built and verified. I can help you choose the evolution method (such as "
+        "EoH, ReEvo, or MCTS-AHD), and adjust evolution parameters (such as "
+        "max_generations, population size, etc.), or feel free to let me know if "
+        "you have other needs!\""
     )
 
 
-def build_system_prompt(workspace_dir: str, surface: str = "platform") -> str:
+def build_system_prompt(
+    workspace_dir: str, surface: str = "platform", language: str = "zh"
+) -> str:
     """System prompt for the BUILD phase: build + self-verify (post-confirmation).
 
     Reached only after the user confirmed the proposal. The requirements are
@@ -216,10 +262,12 @@ def build_system_prompt(workspace_dir: str, surface: str = "platform") -> str:
         surface: ``"platform"`` (Web UI — the platform runs the package for the
             user; do NOT tell them to run the CLI or set env vars) or ``"cli"``
             (the user runs ``llm4ad run`` themselves).
+        language: ``"zh"`` or ``"en"``, from the frontend language toggle.
 
     Returns:
         The full system prompt string.
     """
+    lang_name = "Chinese" if language == "zh" else "English"
     prompt = f"""You are an expert assistant that builds runnable LLM4AD task \
 packages. The user has ALREADY confirmed the requirements (given below); build \
 the task now — do not re-ask for requirements.
@@ -287,7 +335,7 @@ tried to leave the workspace — stay within it.
 
 {_closing_for_surface(surface)}
 
-Respond in the user's language."""
+Respond in {lang_name}."""
     return _with_skill_knowledge(prompt)
 
 

--- a/src/llm4ad/agent/skills/llm4ad-task-builder/SKILL.md
+++ b/src/llm4ad/agent/skills/llm4ad-task-builder/SKILL.md
@@ -103,6 +103,118 @@ defaults where the user has no preference):
    re-run. Not done until both run cleanly. If no provider credentials are available,
    say so — a missing-credential failure of `debug_run.py` is not a package defect.
 
+## Automated algorithm design methods (reference — only when the user asks)
+
+Always build new task packages with the default **Island GA** method. Do NOT
+proactively suggest switching to another method — let the user bring it up.
+
+When the user asks about methods or explicitly requests a switch, help them
+using the reference below. After applying a switch, ask whether they want to
+continue adjusting parameters or are satisfied.
+
+Each method requires a matching pair of `evolution.type` + `planner.type`.
+Switching methods means **replacing the entire `evolution` section` (parameters
+differ per method) and updating `planner.type`. A fresh run is required — you
+cannot resume a prior run after changing the evolution type.
+
+---
+
+**Island GA** (default — use this for all new builds)
+
+```yaml
+evolution:
+  type: "island_ga"
+  max_generations: 50
+  num_islands: 5              # number of parallel populations
+  island_population_size: 20  # individuals per island
+  mutation_rate: 0.3
+  crossover_rate: 0.5
+  tournament_size: 3
+  early_stop_patience: 10
+  migration_interval: 5       # gens between cross-island exchanges
+  migration_rate: 0.1         # fraction of individuals migrated
+  migration_strategy: "best"  # best | random | elite | worst
+  migration_topology: "ring"  # ring | fully_connected | hierarchical | mesh
+  parallel_islands: true      # run islands concurrently
+planner:
+  type: "llm_evolution"
+```
+
+**EoH** — Evolution of Heuristics *(ICML 2024)*  
+Single-objective, rank-based truncation. Runs E1 (and optionally E2/M1/M2)
+operators each generation.
+
+```yaml
+evolution:
+  type: "eoh"
+  max_generations: 50
+  population_size: 5          # top-k individuals kept after truncation
+  selection_num: 2            # parents selected per E1/E2 crossover
+  max_sample_nums: 100        # LLM call budget cap for the run
+  num_samplers: 1             # parallel candidates per operator per gen
+  use_e2_operator: true       # enable E2 (backbone-motivated crossover)
+  use_m1_operator: true       # enable M1 (structural mutation)
+  use_m2_operator: true       # enable M2 (parameter mutation)
+  seed_path: null             # optional path to a seed heuristic file
+planner:
+  type: "eoh_evolution"
+```
+
+**ReEvo** — Reflective Evolution *(NeurIPS 2024)*  
+Adds two reflection signals to genetic search: short-term (comparing worse/better
+parent pairs → better crossover) and long-term (accumulated history → better
+elite mutation).
+
+```yaml
+evolution:
+  type: "reevo"
+  max_generations: 50
+  population_size: 8          # individuals in the population
+  mutation_rate: 0.5          # fraction of pop used for elite mutations per gen
+  max_sample_nums: 100        # LLM call budget cap for the run
+  num_samplers: 1             # parallel crossover candidates per step
+  seed_path: null             # optional path to a seed heuristic file
+planner:
+  type: "reevo_evolution"
+```
+
+**MCTS-AHD** — Monte Carlo Tree Search for AHD *(ICML 2025)*  
+Tree search over algorithm space: selects nodes via UCT, expands with
+e1/e2/m1/m2/s1 operators. Not generational; `max_generations` is interpreted
+as MCTS iterations.
+
+```yaml
+evolution:
+  type: "mcts_ahd"
+  max_generations: 1000       # MCTS iterations (not generations)
+  init_size: 4                # initial child nodes expanded under root
+  population_size: 10         # active algorithm pool size
+  selection_num: 2            # parents per e1/e2 operator
+  max_sample_nums: 100        # LLM call budget cap for the search
+  alpha: 0.5                  # UCT progressive-widening parameter
+  lambda_0: 0.1               # UCT exploration constant (decays with budget)
+  max_depth: 10               # maximum tree depth
+  seed_path: null             # optional path to a seed heuristic file
+planner:
+  type: "mcts_ahd_evolution"
+```
+
+### Switching checklist (only when the user actively requests it)
+
+1. **Replace `evolution` section** — remove the old method's specific params,
+   write the new method's complete section from the templates above. Do NOT
+   carry over params that don't exist in the new method's schema (e.g.
+   `num_islands` is IGA-only).
+2. **Update `planner.type`** — must match the new method.
+3. **Keep everything else** — `providers`, `evaluator`, `coder`, `dataset`,
+   `version_control` stay unchanged.
+4. **Warn the user** — switching evolution type means a fresh run; you cannot
+   resume an old checkpoint under a different method.
+5. **Re-verify** — after editing `config.yaml`, re-run `debug_run.py` to
+   confirm the new method loads correctly.
+6. **Ask whether to continue** — after the switch is applied and verified, ask
+   the user if they want to adjust any parameters further or are satisfied.
+
 <!-- PLATFORM-USAGE-DRAFT: 以下"如何在平台上使用"为草稿，待产品同学修订 -->
 ## How the package is used on the LLM4AD platform
 
@@ -146,3 +258,12 @@ the provider `model`, and `evaluator.timeout`.
 The package is done only when `test_evaluator.py` loads the evaluator AND
 `debug_run.py` runs without raising. Then summarize what was built (files + the
 7 decisions) and the verification result.
+
+After a successful build, always close by conveying this message (translate to the
+user's language; do NOT proactively recommend a specific method — just mention
+that the option exists):
+
+> The task package has been built and verified. I can help you choose the
+> evolution method (such as EoH, ReEvo, or MCTS-AHD), and adjust evolution
+> parameters (such as max_generations, population size, etc.), or feel free
+> to let me know if you have other needs!


### PR DESCRIPTION
1. Add language parameter to build system prompts, driven by frontend language toggle via gathering_context — the agent now receives an explicit "Respond in Chinese" or "Respond in English" instruction instead of the ambiguous "Respond in the user's language".

2. Make all agent-generated UI cards language-aware:
   - ask_choice option labels (upload, custom input)
   - _confirm_build_card (plan confirmation heading, table headers, button labels, descriptions)
   - build_config_summary_md (evolution params & token cost estimate)
   - propose_plan tool result text Fix variable shadowing: inner functions (propose_plan, build_task) have their own 'language' param (programming language, default 'python'), so the UI language is saved as _ui_lang to avoid conflicts.

3. Add evolution method reference (Island GA, EoH, ReEvo, MCTS-AHD) to both SKILL.md copies, including complete YAML config templates and a switching checklist. Agent defaults to Island GA and only suggests alternatives when the user actively asks.

4. Ensure GATHER prompt example options (problem categories, code source, data source, confirm cues) match the user's language setting — zh keeps bilingual examples, en gets English-only.